### PR TITLE
fix: remove dead skipped counter in download_conference

### DIFF
--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -296,7 +296,6 @@ def download_conference(
         TimeRemainingColumn(),
     )
 
-    skipped = 0
     failed: list[str] = []
     failed_talks: list[Talk] = []
 
@@ -319,8 +318,6 @@ def download_conference(
             finally:
                 overall_progress.advance(overall_task)
 
-    if skipped:
-        logger.info("%d file(s) already up to date, skipped.", skipped)
     if failed:
         logger.warning(
             "%d file(s) failed to download and will be absent from output: %s",


### PR DESCRIPTION
## Summary
- Removes `skipped = 0` and the `if skipped:` log block from `download_conference`
- The counter was initialized but never incremented — the log message could never fire
- Skip detection lives inside `download_file` / `_download_image` and doesn't report back to the caller

## Test plan
- [ ] `pytest tests/test_downloader.py -v` passes
- [ ] No change in observable behavior (the log message was dead code)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)