### PR TITLE
fix: centralise User-Agent in utils.py, remove stale hardcoded 0.1.0

### DIFF
--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -19,11 +19,9 @@ from rich.progress import (
 )
 
 from .models import Conference, Talk
-from .utils import sanitize_filename, validate_url
+from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
-
-_USER_AGENT = "gencon-audiobook/0.1.0 (open source; github.com/XeroIP/gencon-audiobook)"
 
 
 class DownloadError(Exception):
@@ -207,7 +205,7 @@ def cleanup_tmp_files(directory: Path) -> None:
 def _make_session() -> requests.Session:
     """Create a requests.Session with the project User-Agent."""
     session = requests.Session()
-    session.headers.update({"User-Agent": _USER_AGENT})
+    session.headers.update({"User-Agent": USER_AGENT})
     return session
 
 

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -16,7 +16,7 @@ import requests
 from bs4 import BeautifulSoup, Tag
 
 from .models import Conference, Session, Talk
-from .utils import validate_url
+from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +27,6 @@ _REQUEST_DELAY = 0.5
 _CONNECT_TIMEOUT = 15
 _READ_TIMEOUT = 30
 _MAX_RETRIES = 3
-
-_USER_AGENT = "gencon-audiobook/0.1.0 (open source; github.com/XeroIP/gencon-audiobook)"
 
 # Matches /study/general-conference/YYYY/MM (conference listing URL)
 # Allows trailing query strings like ?lang=eng
@@ -93,7 +91,7 @@ def _check_robots(http: requests.Session, url: str) -> None:
     parsed = urlparse(url)
     base = f"{parsed.scheme}://{parsed.netloc}"
     parser = _get_robots(http, base)
-    if parser is not None and not parser.can_fetch(_USER_AGENT, url):
+    if parser is not None and not parser.can_fetch(USER_AGENT, url):
         raise ScraperError(
             f"URL disallowed by robots.txt: {url}. "
             "If you believe this is an error, open a GitHub issue: "
@@ -130,7 +128,7 @@ class ScraperError(Exception):
 def _make_http_session() -> requests.Session:
     """Create a requests.Session with the project User-Agent header."""
     session = requests.Session()
-    session.headers.update({"User-Agent": _USER_AGENT})
+    session.headers.update({"User-Agent": USER_AGENT})
     return session
 
 

--- a/src/gencon_audiobook/utils.py
+++ b/src/gencon_audiobook/utils.py
@@ -1,4 +1,4 @@
-"""Filename sanitization and URL validation utilities."""
+"""Filename sanitization, URL validation, and shared HTTP session utilities."""
 
 from __future__ import annotations
 
@@ -6,7 +6,17 @@ import logging
 import re
 from urllib.parse import urlparse
 
+from . import __version__
+
 logger = logging.getLogger(__name__)
+
+# Single source of truth for the User-Agent string sent with every HTTP request.
+# Both scraper.py and downloader.py import this constant so version updates
+# only need to happen in one place (__version__ in __init__.py).
+USER_AGENT = (
+    f"gencon-audiobook/{__version__}"
+    " (open source; github.com/XeroIP/gencon-audiobook)"
+)
 
 _SAFE_CHARS = re.compile(r"[^a-zA-Z0-9 ._-]")
 _MULTI_UNDERSCORE = re.compile(r"_+")


### PR DESCRIPTION
## Summary
- Defines `USER_AGENT` once in `utils.py` using `__version__`, eliminating the duplicate hardcoded `0.1.0` strings in `scraper.py` and `downloader.py`
- Updates `_make_http_session()` and `_make_session()` to use the shared constant
- Updates robots.txt check to use `USER_AGENT`
- Updates `Technical-Decisions.md` wiki example to show `<version>` placeholder

## Test plan
- [ ] `pytest tests/ -q --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py` passes
- [ ] Check DEBUG log during a run to confirm User-Agent shows current version

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)