### PR TITLE
fix: add permissions blocks and Python 3.13 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Unit tests (Python ${{ matrix.python-version }}, ${{ matrix.os }})
@@ -14,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -8,6 +8,10 @@ on:
     - cron: "0 8 * * 1"   # Every Monday at 08:00 UTC
   workflow_dispatch:        # Allow manual trigger from the Actions UI
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   live:
     name: Live scraper smoke test


### PR DESCRIPTION
## Summary
- **#38** — Added `"3.13"` to CI matrix; was in pyproject.toml classifiers but untested
- **#39** — Added `permissions: { contents: read }` to `ci.yml` and `permissions: { contents: read, issues: write }` to `live-test.yml`

## Test plan
- [ ] CI passes on all 4 Python versions × 3 OS = 12 matrix combinations
- [ ] Verify `live-test.yml` can still create issues on failure (has `issues: write`)

Closes #38
Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)