### PR TITLE
fix: retry on HTTP 429, keep 403 as fatal

### DIFF
--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -220,13 +220,29 @@ def _fetch(http: requests.Session, url: str, delay: float = _REQUEST_DELAY) -> s
             logger.debug("Fetching: %s", url)
             response = http.get(url, timeout=(_CONNECT_TIMEOUT, _READ_TIMEOUT))
 
-            if response.status_code in (403, 429):
+            if response.status_code == 403:
+                # 403 is a permanent block — do not retry.
                 raise ScraperError(
-                    f"Access was blocked (HTTP {response.status_code}). "
+                    "Access was blocked (HTTP 403). "
                     "The website may be blocking automated access. "
                     "Try again later or open a GitHub issue if this persists: "
                     "github.com/XeroIP/gencon-audiobook"
                 )
+
+            if response.status_code == 429:
+                # 429 is a transient rate-limit signal — respect Retry-After if present,
+                # otherwise fall through to raise_for_status() which triggers the retry loop.
+                retry_after = response.headers.get("Retry-After")
+                if retry_after is not None:
+                    try:
+                        wait_override = int(retry_after)
+                        logger.warning(
+                            "Rate limited (HTTP 429). Retry-After: %ds — waiting before retry.",
+                            wait_override,
+                        )
+                        time.sleep(wait_override)
+                    except ValueError:
+                        pass  # non-integer Retry-After (date format) — ignore, let backoff handle it
 
             response.raise_for_status()
 

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -16,6 +16,7 @@ from gencon_audiobook.scraper import (
     ScraperError,
     _check_robots,
     _get_robots,
+    _make_http_session as _scraper_make_session,
     _robots_cache,
     parse_conference_archive,
     parse_conference_listing,
@@ -295,3 +296,46 @@ def test_get_robots_caches_result() -> None:
 
     # Cleanup
     _robots_cache.pop(base, None)
+
+
+# ---------------------------------------------------------------------------
+# _fetch — 429 retry behaviour
+# ---------------------------------------------------------------------------
+
+
+@responses_lib.activate
+def test_fetch_retries_on_429_then_succeeds() -> None:
+    """A 429 response should trigger retry; a subsequent 200 should succeed."""
+    from gencon_audiobook.scraper import _fetch
+
+    url = "https://www.churchofjesuschrist.org/study/general-conference"
+    minimal_html = "<html><body>" + "x" * 1200 + "</body></html>"
+
+    responses_lib.add(responses_lib.GET, url, status=429, body="Too Many Requests")
+    responses_lib.add(responses_lib.GET, url, status=200, body=minimal_html)
+
+    session = _scraper_make_session()
+    # Patch time.sleep to avoid real delays in the test
+    with patch("gencon_audiobook.scraper.time.sleep"):
+        result = _fetch(session, url)
+
+    assert len(result) > 100, f"Expected page content after retry, got: {result[:100]!r}"
+
+
+@responses_lib.activate
+def test_fetch_403_raises_immediately_without_retry() -> None:
+    """A 403 response must raise ScraperError immediately, not be retried."""
+    from gencon_audiobook.scraper import _fetch
+
+    url = "https://www.churchofjesuschrist.org/study/general-conference"
+    responses_lib.add(responses_lib.GET, url, status=403, body="Forbidden")
+    # Only one response registered — if retry occurs, responses_lib raises ConnectionError
+
+    session = _scraper_make_session()
+    with patch("gencon_audiobook.scraper.time.sleep"):
+        with pytest.raises(ScraperError, match="403"):
+            _fetch(session, url)
+
+    assert len(responses_lib.calls) == 1, (
+        f"403 must not be retried — expected 1 request, got {len(responses_lib.calls)}"
+    )


### PR DESCRIPTION
## Summary
- Splits 429 and 403 handling: 403 raises immediately (permanent block); 429 falls through to `raise_for_status()` which triggers the retry loop
- Respects `Retry-After` header on 429 when present as an integer
- Adds `test_fetch_retries_on_429_then_succeeds` and `test_fetch_403_raises_immediately_without_retry`

## Test plan
- [ ] `pytest tests/test_scraper.py -v` passes (28 tests)
- [ ] Full unit suite passes

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)