### PR TITLE
fix: pass ffprobe_path through convert_mp3_to_aac (#42)

### DIFF
--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -381,6 +381,7 @@ def convert_mp3_to_aac(
     mp3_path: Path,
     aac_path: Path,
     ffmpeg_path: Path,
+    ffprobe_path: Path,
     bitrate: str = "64k",
     sample_rate: int = 44100,
 ) -> float:
@@ -390,6 +391,7 @@ def convert_mp3_to_aac(
         mp3_path: Input MP3 file.
         aac_path: Output AAC file path.
         ffmpeg_path: Path to ffmpeg binary.
+        ffprobe_path: Path to ffprobe binary.
         bitrate: AAC encoding bitrate as an ffmpeg bitrate string (e.g., "64k", "32k").
         sample_rate: Output sample rate in Hz (e.g., 44100, 22050).
 
@@ -419,7 +421,6 @@ def convert_mp3_to_aac(
         label=f"MP3→AAC conversion of {mp3_path.name}",
     )
 
-    ffprobe_path = _derive_ffprobe(ffmpeg_path)
     return _get_duration_ffprobe(aac_path, ffprobe_path)
 
 
@@ -510,7 +511,7 @@ def build_m4b(
 
             aac_path = mp3_path.with_suffix(".m4a")
             try:
-                duration = convert_mp3_to_aac(mp3_path, aac_path, ffmpeg_path, bitrate, sample_rate)
+                duration = convert_mp3_to_aac(mp3_path, aac_path, ffmpeg_path, ffprobe_path, bitrate, sample_rate)
                 talk.duration_seconds = duration
                 aac_paths.append(aac_path)
                 successful_talks.append(talk)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -133,7 +133,7 @@ def test_convert_mp3_to_aac_produces_aac_file(tmp_path: Path) -> None:
     make_silent_mp3(mp3, duration_seconds=2.0)
     aac = tmp_path / "test.m4a"
 
-    convert_mp3_to_aac(mp3, aac, _FFMPEG)
+    convert_mp3_to_aac(mp3, aac, _FFMPEG, _FFPROBE)
 
     assert aac.exists(), "AAC output file should exist"
     assert aac.stat().st_size > 0, "AAC output file should be non-empty"
@@ -146,7 +146,7 @@ def test_convert_mp3_to_aac_returns_duration(tmp_path: Path) -> None:
     make_silent_mp3(mp3, duration_seconds=expected)
     aac = tmp_path / "test.m4a"
 
-    duration = convert_mp3_to_aac(mp3, aac, _FFMPEG)
+    duration = convert_mp3_to_aac(mp3, aac, _FFMPEG, _FFPROBE)
 
     assert abs(duration - expected) < 0.2, \
         f"Expected duration ~{expected}s, got {duration:.3f}s"
@@ -159,14 +159,14 @@ def test_convert_mp3_to_aac_custom_bitrate_and_sample_rate(tmp_path: Path) -> No
     default_out = tmp_path / "default.m4a"
     custom_out = tmp_path / "custom.m4a"
 
-    convert_mp3_to_aac(mp3, default_out, _FFMPEG)
-    convert_mp3_to_aac(mp3, custom_out, _FFMPEG, bitrate="32k", sample_rate=22050)
+    convert_mp3_to_aac(mp3, default_out, _FFMPEG, _FFPROBE)
+    convert_mp3_to_aac(mp3, custom_out, _FFMPEG, _FFPROBE, bitrate="32k", sample_rate=22050)
 
     assert custom_out.stat().st_size < default_out.stat().st_size, (
         "Lower bitrate/sample-rate output should be smaller than default"
     )
     # Duration should still be approximately correct regardless of encoding settings
-    duration = convert_mp3_to_aac(mp3, tmp_path / "check.m4a", _FFMPEG, bitrate="32k", sample_rate=22050)
+    duration = convert_mp3_to_aac(mp3, tmp_path / "check.m4a", _FFMPEG, _FFPROBE, bitrate="32k", sample_rate=22050)
     assert abs(duration - 3.0) < 0.2, f"Expected ~3.0s, got {duration:.3f}s"
 
 
@@ -176,7 +176,7 @@ def test_audio_error_on_invalid_input(tmp_path: Path) -> None:
     aac = tmp_path / "output.m4a"
 
     with pytest.raises(AudioError):
-        convert_mp3_to_aac(mp3, aac, _FFMPEG)
+        convert_mp3_to_aac(mp3, aac, _FFMPEG, _FFPROBE)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `ffprobe_path: Path` parameter to `convert_mp3_to_aac`
- Removes internal `_derive_ffprobe(ffmpeg_path)` call that ignored the caller's validated path
- Updates `build_m4b` call site to pass `ffprobe_path` through
- Updates all test call sites accordingly

## Test plan
- [ ] All 181 unit tests pass (`pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py`)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)