### PR TITLE
chore: consolidate shared test helpers into conftest.py (#44)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,86 @@
-"""Shared pytest fixtures."""
+"""Shared pytest fixtures and helpers used across multiple test files."""
 
 from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg / ffprobe discovery
+# ---------------------------------------------------------------------------
+
+
+def _find_ffmpeg() -> Path | None:
+    which = shutil.which("ffmpeg")
+    return Path(which) if which else None
+
+
+def _find_ffprobe(ffmpeg: Path) -> Path | None:
+    suffix = ffmpeg.suffix
+    candidate = ffmpeg.parent / f"ffprobe{suffix}"
+    if candidate.exists():
+        return candidate
+    which = shutil.which("ffprobe")
+    return Path(which) if which else None
+
+
+FFMPEG = _find_ffmpeg()
+FFPROBE = _find_ffprobe(FFMPEG) if FFMPEG else None
+
+requires_ffmpeg = pytest.mark.skipif(
+    FFMPEG is None or FFPROBE is None,
+    reason="ffmpeg/ffprobe not available on PATH",
+)
+
+
+# ---------------------------------------------------------------------------
+# Audio helpers
+# ---------------------------------------------------------------------------
+
+
+def make_silent_mp3(path: Path, duration_seconds: float = 2.0) -> None:
+    """Generate a short silent MP3 test fixture using ffmpeg.
+
+    Args:
+        path: Destination path for the MP3 file.
+        duration_seconds: Duration of the generated audio.
+    """
+    assert FFMPEG is not None
+    path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        [
+            str(FFMPEG),
+            "-f", "lavfi",
+            "-i", "anullsrc=channel_layout=mono:sample_rate=44100",
+            "-t", str(duration_seconds),
+            "-acodec", "libmp3lame",
+            "-ab", "128k",
+            "-y",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Image helpers
+# ---------------------------------------------------------------------------
+
+
+def make_jpeg(path: Path, size: tuple[int, int] = (100, 100), color: str = "gray") -> None:
+    """Write a minimal JPEG test image to path, creating parent directories.
+
+    Args:
+        path: Destination path for the JPEG file.
+        size: Image dimensions as (width, height).
+        color: Fill color string understood by Pillow.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img = Image.new("RGB", size, color=color)
+    img.save(path, format="JPEG")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -14,61 +14,9 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from conftest import FFMPEG as _FFMPEG, FFPROBE as _FFPROBE, make_silent_mp3, requires_ffmpeg
 from gencon_audiobook.audio import AudioError, _ascii_safe, _probe_source_quality, build_m4b, convert_mp3_to_aac
 from gencon_audiobook.models import Conference, Session, Talk
-
-
-# ---------------------------------------------------------------------------
-# Fixtures and helpers
-# ---------------------------------------------------------------------------
-
-
-def _find_ffmpeg() -> Path | None:
-    which = shutil.which("ffmpeg")
-    return Path(which) if which else None
-
-
-def _find_ffprobe(ffmpeg: Path) -> Path | None:
-    suffix = ffmpeg.suffix
-    candidate = ffmpeg.parent / f"ffprobe{suffix}"
-    if candidate.exists():
-        return candidate
-    which = shutil.which("ffprobe")
-    return Path(which) if which else None
-
-
-_FFMPEG = _find_ffmpeg()
-_FFPROBE = _find_ffprobe(_FFMPEG) if _FFMPEG else None
-
-requires_ffmpeg = pytest.mark.skipif(
-    _FFMPEG is None or _FFPROBE is None,
-    reason="ffmpeg/ffprobe not available on PATH",
-)
-
-
-def make_silent_mp3(path: Path, duration_seconds: float = 2.0) -> None:
-    """Generate a short silent MP3 test fixture using ffmpeg.
-
-    Args:
-        path: Destination path for the MP3 file.
-        duration_seconds: Duration of the generated audio.
-    """
-    assert _FFMPEG is not None
-    path.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            str(_FFMPEG),
-            "-f", "lavfi",
-            "-i", "anullsrc=channel_layout=mono:sample_rate=44100",
-            "-t", str(duration_seconds),
-            "-acodec", "libmp3lame",
-            "-ab", "128k",
-            "-y",
-            str(path),
-        ],
-        check=True,
-        capture_output=True,
-    )
 
 
 def _make_conference(tmp_path: Path, n_talks: int = 3, duration: float = 2.0) -> Conference:

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from conftest import make_jpeg as _make_jpeg
 from gencon_audiobook.epub_builder import (
     EpubError,
     _sanitize_transcript,
@@ -22,12 +23,6 @@ from gencon_audiobook.models import Conference, Session, Talk
 # Fixtures and helpers
 # ---------------------------------------------------------------------------
 
-
-def _make_jpeg(path: Path, size: tuple[int, int] = (100, 100), color: str = "gray") -> None:
-    """Write a minimal JPEG test image to path, creating parent directories."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    img = Image.new("RGB", size, color=color)
-    img.save(path, format="JPEG")
 
 
 def _make_conference(n_talks: int = 3, include_transcripts: bool = True) -> Conference:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,76 +14,17 @@ from __future__ import annotations
 
 import io
 import json
-import shutil
-import subprocess
 import zipfile
 from pathlib import Path
 
 import pytest
 from mutagen.mp4 import MP4
-from PIL import Image
 
+from conftest import FFMPEG as _FFMPEG, FFPROBE as _FFPROBE, make_jpeg as _make_jpeg, make_silent_mp3 as _make_silent_mp3, requires_ffmpeg
 from gencon_audiobook.audio import build_m4b
 from gencon_audiobook.epub_builder import build_epub
 from gencon_audiobook.models import Conference, Session, Talk
 from gencon_audiobook.utils import sanitize_filename
-
-
-# ---------------------------------------------------------------------------
-# ffmpeg availability
-# ---------------------------------------------------------------------------
-
-
-def _find_ffmpeg() -> Path | None:
-    w = shutil.which("ffmpeg")
-    return Path(w) if w else None
-
-
-def _find_ffprobe(ffmpeg: Path) -> Path | None:
-    cand = ffmpeg.parent / f"ffprobe{ffmpeg.suffix}"
-    if cand.exists():
-        return cand
-    w = shutil.which("ffprobe")
-    return Path(w) if w else None
-
-
-_FFMPEG = _find_ffmpeg()
-_FFPROBE = _find_ffprobe(_FFMPEG) if _FFMPEG else None
-
-requires_ffmpeg = pytest.mark.skipif(
-    _FFMPEG is None or _FFPROBE is None,
-    reason="ffmpeg/ffprobe not available on PATH",
-)
-
-
-# ---------------------------------------------------------------------------
-# Fixture builders
-# ---------------------------------------------------------------------------
-
-
-def _make_silent_mp3(path: Path, duration: float = 3.0) -> None:
-    """Write a short silent MP3 to path using ffmpeg."""
-    assert _FFMPEG is not None
-    path.parent.mkdir(parents=True, exist_ok=True)
-    subprocess.run(
-        [
-            str(_FFMPEG),
-            "-f", "lavfi",
-            "-i", "anullsrc=channel_layout=mono:sample_rate=44100",
-            "-t", str(duration),
-            "-acodec", "libmp3lame",
-            "-ab", "128k",
-            "-y", str(path),
-        ],
-        check=True,
-        capture_output=True,
-    )
-
-
-def _make_jpeg(path: Path, size: tuple[int, int] = (200, 200)) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    img = Image.new("RGB", size, color="gray")
-    img.save(path, format="JPEG")
 
 
 def _build_conference(tmp_path: Path) -> Conference:
@@ -153,7 +94,7 @@ def _build_conference(tmp_path: Path) -> Conference:
     # MP3 files
     for talk in conference.talks:
         mp3 = tmp_path / "audio" / f"{talk.talk_index:03d}-{sanitize_filename(talk.title)}.mp3"
-        _make_silent_mp3(mp3, duration=3.0)
+        _make_silent_mp3(mp3, duration_seconds=3.0)
 
     # Cover image
     _make_jpeg(tmp_path / "cover.jpg", size=(400, 600))


### PR DESCRIPTION
## Summary
- Moves `_find_ffmpeg`, `_find_ffprobe`, `requires_ffmpeg`, `make_silent_mp3`, and `make_jpeg` into `conftest.py`
- Removes duplicate copies from `test_audio.py`, `test_epub.py`, and `test_integration.py`
- Renames public helpers to `FFMPEG`, `FFPROBE`, `make_silent_mp3`, `make_jpeg` (no leading underscore — these are shared helpers, not internal)

## Test plan
- [ ] All 181 unit tests pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)