### PR TITLE
chore: add [project.urls] to pyproject.toml (#45)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ dev = [
     "pip-audit>=2.0",
 ]
 
+[project.urls]
+Homepage = "https://github.com/XeroIP/gencon-audiobook"
+Repository = "https://github.com/XeroIP/gencon-audiobook"
+"Bug Tracker" = "https://github.com/XeroIP/gencon-audiobook/issues"
+
 [project.scripts]
 gencon-audiobook = "gencon_audiobook.cli:main"
 


### PR DESCRIPTION
## Summary
- Adds `[project.urls]` section with Homepage, Repository, and Bug Tracker links
- These appear prominently on the PyPI project page after publish

## Test plan
- [ ] TOML syntax valid (`python -c "import tomllib; tomllib.loads(open('pyproject.toml').read())"`)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)