### PR TITLE
chore: code-style compliance across all modules

### DIFF
--- a/src/gencon_audiobook/__init__.py
+++ b/src/gencon_audiobook/__init__.py
@@ -1,3 +1,5 @@
 """gencon-audiobook: Download General Conference talks as m4b audiobook and epub."""
 
+from __future__ import annotations
+
 __version__ = "0.1.1"

--- a/src/gencon_audiobook/__main__.py
+++ b/src/gencon_audiobook/__main__.py
@@ -1,5 +1,7 @@
 """Entry point for python -m gencon_audiobook."""
 
-from gencon_audiobook.cli import main
+from __future__ import annotations
+
+from .cli import main
 
 main()

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -85,7 +85,9 @@ def _ffmeta_escape(value: str) -> str:
     return value
 
 
-_SUBPROCESS_TIMEOUT = 600  # 10 minutes — generous for large conference builds
+_SUBPROCESS_TIMEOUT = 600   # 10 minutes — generous for large conference builds
+_FALLBACK_BITRATE = "64k"   # used when ffprobe quality probe fails
+_FALLBACK_SAMPLE_RATE = 44100  # used when ffprobe quality probe fails
 
 
 def _run(cmd: list[str], label: str) -> subprocess.CompletedProcess[str]:
@@ -200,16 +202,16 @@ def _probe_source_quality(mp3_path: Path, ffprobe_path: Path) -> tuple[str, int]
 
         logger.warning(
             "Could not parse quality from %s (bit_rate=%r, sample_rate=%r) "
-            "— falling back to 64k/44100",
-            mp3_path.name, bit_rate, sample_rate,
+            "— falling back to %s/%d",
+            mp3_path.name, bit_rate, sample_rate, _FALLBACK_BITRATE, _FALLBACK_SAMPLE_RATE,
         )
     except (AudioError, OSError) as exc:
         # OSError covers FileNotFoundError when the ffprobe binary itself is missing.
         logger.warning(
-            "ffprobe quality probe failed for %s: %s — falling back to 64k/44100",
-            mp3_path.name, exc,
+            "ffprobe quality probe failed for %s: %s — falling back to %s/%d",
+            mp3_path.name, exc, _FALLBACK_BITRATE, _FALLBACK_SAMPLE_RATE,
         )
-    return "64k", 44100
+    return _FALLBACK_BITRATE, _FALLBACK_SAMPLE_RATE
 
 
 def _derive_ffprobe(ffmpeg_path: Path) -> Path:
@@ -489,8 +491,8 @@ def build_m4b(
             sample_rate = detected_sample_rate
         logger.info("Source quality: %s / %d Hz", bitrate, sample_rate)
     # Final fallback if no MP3s exist yet or probe returned nothing
-    bitrate = bitrate or "64k"
-    sample_rate = sample_rate or 44100
+    bitrate = bitrate or _FALLBACK_BITRATE
+    sample_rate = sample_rate or _FALLBACK_SAMPLE_RATE
 
     # Step 2: Convert MP3 → AAC, populate duration_seconds
     logger.info("Converting %d talks to AAC...", len(talks))

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -7,10 +7,6 @@ import shutil
 import sys
 from pathlib import Path
 
-_LOG_FILENAME = "gencon-audiobook.log"
-_MIN_PYTHON = (3, 10)
-_DISK_WARN_MB = 500
-
 import click
 from rich.console import Console
 from rich.logging import RichHandler
@@ -24,6 +20,10 @@ from .models import Talk
 from .scraper import ScraperError, fetch_available_conferences, scrape_conference
 
 logger = logging.getLogger(__name__)
+
+_LOG_FILENAME = "gencon-audiobook.log"
+_MIN_PYTHON = (3, 10)
+_DISK_WARN_MB = 500
 
 # Module-level console so helpers can print without threading a Console argument.
 console = Console()

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -23,6 +23,9 @@ from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
 
+_DOWNLOAD_CHUNK_SIZE = 65_536  # 64 KB chunks for streaming downloads
+_JPEG_QUALITY = 85              # JPEG quality for converted images
+
 
 class DownloadError(Exception):
     """Raised when a file download fails after all retries."""
@@ -80,7 +83,7 @@ def download_file(
                 resp.raise_for_status()
                 tmp.parent.mkdir(parents=True, exist_ok=True)
                 with tmp.open("wb") as fh:
-                    for chunk in resp.iter_content(chunk_size=65536):
+                    for chunk in resp.iter_content(chunk_size=_DOWNLOAD_CHUNK_SIZE):
                         if chunk:
                             fh.write(chunk)
 
@@ -111,14 +114,14 @@ def _image_to_jpeg(data: bytes) -> bytes:
     Returns:
         JPEG-encoded bytes.
     """
-    img = Image.open(BytesIO(data))
-    # Convert palette/transparency modes that JPEG can't handle
-    if img.mode in ("RGBA", "P", "LA"):
-        img = img.convert("RGB")
-    elif img.mode != "RGB":
-        img = img.convert("RGB")
-    out = BytesIO()
-    img.save(out, format="JPEG", quality=85, optimize=True)
+    with Image.open(BytesIO(data)) as img:
+        # Convert palette/transparency modes that JPEG can't handle
+        if img.mode in ("RGBA", "P", "LA"):
+            img = img.convert("RGB")
+        elif img.mode != "RGB":
+            img = img.convert("RGB")
+        out = BytesIO()
+        img.save(out, format="JPEG", quality=_JPEG_QUALITY, optimize=True)
     return out.getvalue()
 
 

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -23,6 +23,7 @@ _COPYRIGHT = (
 )
 
 _MAX_PHOTO_WIDTH = 300  # px — per epub-style.md
+_JPEG_QUALITY = 85      # JPEG quality for all embedded images
 
 # Void elements that must be self-closed in XHTML
 _VOID_RE = re.compile(
@@ -185,15 +186,15 @@ def _resize_photo(src_path: Path) -> bytes:
     Returns:
         JPEG bytes of the (possibly resized) image.
     """
-    img = Image.open(src_path)
-    if img.width > _MAX_PHOTO_WIDTH:
-        ratio = _MAX_PHOTO_WIDTH / img.width
-        new_size = (_MAX_PHOTO_WIDTH, int(img.height * ratio))
-        img = img.resize(new_size, Image.LANCZOS)
-    if img.mode != "RGB":
-        img = img.convert("RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="JPEG", quality=85, optimize=True)
+    with Image.open(src_path) as img:
+        if img.width > _MAX_PHOTO_WIDTH:
+            ratio = _MAX_PHOTO_WIDTH / img.width
+            new_size = (_MAX_PHOTO_WIDTH, int(img.height * ratio))
+            img = img.resize(new_size, Image.LANCZOS)
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", quality=_JPEG_QUALITY, optimize=True)
     return buf.getvalue()
 
 

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -8,7 +8,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any  # JSON decode returns Any; no narrower type available
 from urllib.parse import urljoin, urlparse
 from urllib.robotparser import RobotFileParser
 
@@ -27,6 +27,8 @@ _REQUEST_DELAY = 0.5
 _CONNECT_TIMEOUT = 15
 _READ_TIMEOUT = 30
 _MAX_RETRIES = 3
+_MIN_RESPONSE_LENGTH = 1000   # responses shorter than this are suspiciously small
+_CLOUDFLARE_PAGE_LENGTH = 5000  # challenge pages are tiny; real pages are much larger
 
 # Matches /study/general-conference/YYYY/MM (conference listing URL)
 # Allows trailing query strings like ?lang=eng
@@ -251,10 +253,10 @@ def _fetch(http: requests.Session, url: str, delay: float = _REQUEST_DELAY) -> s
             response.raise_for_status()
 
             body = _decode_response(response)
-            if len(body) < 1000:
+            if len(body) < _MIN_RESPONSE_LENGTH:
                 logger.warning("Suspiciously short response for %s (%d chars)", url, len(body))
             if "cloudflare" in body.lower() or (
-                "challenge" in body.lower() and len(body) < 5000
+                "challenge" in body.lower() and len(body) < _CLOUDFLARE_PAGE_LENGTH
             ):
                 raise ScraperError(
                     "Access was blocked by the website. This may be temporary. "

--- a/src/gencon_audiobook/utils.py
+++ b/src/gencon_audiobook/utils.py
@@ -74,7 +74,7 @@ def validate_url(url: str) -> bool:
     Allowed domains:
     - churchofjesuschrist.org
     - *.ldscdn.org
-    - media*.churchofjesuschrist.org
+    - *.churchofjesuschrist.org
 
     Never raises — invalid or malformed URLs return False.
 


### PR DESCRIPTION
## Summary
- `__init__.py`, `__main__.py`: add `from __future__ import annotations`
- `__main__.py`: use relative import (`.cli` instead of absolute)
- `cli.py`: move constants below import groups (per code-style rules)
- `scraper.py`: justify `Any` usage with comment; name `_MIN_RESPONSE_LENGTH` and `_CLOUDFLARE_PAGE_LENGTH`
- `audio.py`: name `_FALLBACK_BITRATE` and `_FALLBACK_SAMPLE_RATE`; use consistently
- `epub_builder.py`: add `_JPEG_QUALITY` constant; wrap `Image.open()` in `with`
- `downloader.py`: add `_JPEG_QUALITY`, `_DOWNLOAD_CHUNK_SIZE`; wrap `Image.open()` in `with`
- `utils.py`: fix `validate_url()` docstring (`media*` → `*.churchofjesuschrist.org`)

## Test plan
- [ ] All 181 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)