### PR TITLE
chore: add keywords and py.typed marker to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [{name = "XeroIP"}]
+keywords = ["general-conference", "audiobook", "m4b", "epub", "lds", "latter-day-saints"]
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Summary
- `pyproject.toml`: add `keywords` for PyPI discoverability
- `src/gencon_audiobook/py.typed`: PEP 561 marker so type checkers know the package exports type information

## Test plan
- [ ] TOML syntax valid
- [ ] All 181 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)