### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gencon-audiobook"
-version = "0.1.1"
+version = "0.1.2"
 description = "Download General Conference talks as a complete audiobook (m4b) and epub with full transcripts"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gencon_audiobook/__init__.py
+++ b/src/gencon_audiobook/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
## Summary
Patch version bump covering all Phase 1 and Phase 2 review fixes:

**Phase 1 (critical/high):** ghost chapter fix, subprocess timeout, concat path quoting, centralized User-Agent, CI test gate before publish, per-job permissions, Python 3.13 matrix, robots cache API, 429 retry, data: URI strip, ffprobe path passthrough, _TALK_URL_RE documentation, shared conftest fixtures, [project.urls]

**Phase 2 (medium):** audio edge cases (ascii fallback, \r escape), stale spec/wiki fixes, .gitignore gaps, README updates, robots cache reset, test assertion quality, code style compliance, keywords + py.typed

## Test plan
- [ ] All 181 unit tests pass
- [ ] `gencon-audiobook --version` shows `0.1.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)