### PR TITLE
feat: add ruff + mypy + coverage to CI; fix all type errors (#67, #66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,51 @@ jobs:
           -v
           --tb=short
 
+  lint:
+    name: Lint and type check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: ruff check
+        run: ruff check src/
+
+      - name: mypy
+        run: mypy src/gencon_audiobook/
+
+  coverage:
+    name: Coverage report
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests with coverage
+        run: >
+          pytest tests/
+          --ignore=tests/test_scraper_live.py
+          --ignore=tests/test_integration.py
+          --cov=gencon_audiobook
+          --cov-report=term-missing
+          --tb=short
+
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "requests>=2.28",
     "beautifulsoup4>=4.11",
     "mutagen>=1.47",
-    "Pillow>=9.0",
+    "Pillow>=9.1",
     "rich>=13.0",
     "static-ffmpeg>=2.7",
 ]
@@ -37,6 +37,10 @@ dev = [
     "pytest-cov>=4.0",
     "responses>=0.23",
     "pip-audit>=2.0",
+    "ruff>=0.3",
+    "mypy>=1.9",
+    "types-requests>=2.31",
+    "types-beautifulsoup4>=4.12",
 ]
 
 [project.urls]
@@ -49,6 +53,22 @@ gencon-audiobook = "gencon_audiobook.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gencon_audiobook"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = false
+warn_unused_ignores = true
+warn_return_any = true
+disallow_untyped_defs = true
+check_untyped_defs = true
+no_implicit_optional = true
+
+[tool.ruff]
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP"]
+ignore = ["E501"]  # line length — not enforced
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -114,12 +114,11 @@ def _image_to_jpeg(data: bytes) -> bytes:
     Returns:
         JPEG-encoded bytes.
     """
-    with Image.open(BytesIO(data)) as img:
-        # Convert palette/transparency modes that JPEG can't handle
-        if img.mode in ("RGBA", "P", "LA"):
-            img = img.convert("RGB")
-        elif img.mode != "RGB":
-            img = img.convert("RGB")
+    with Image.open(BytesIO(data)) as raw:
+        # Convert palette/transparency modes that JPEG can't handle.
+        # PIL stubs type .convert() as Image.Image; cast via local var avoids
+        # the ImageFile/Image mismatch that confuses mypy.
+        img: Image.Image = raw.convert("RGB") if raw.mode != "RGB" else raw
         out = BytesIO()
         img.save(out, format="JPEG", quality=_JPEG_QUALITY, optimize=True)
     return out.getvalue()
@@ -303,7 +302,7 @@ def download_conference(
     with overall_progress, file_progress:
         overall_task = overall_progress.add_task("Downloading files", total=len(queue))
 
-        for url, dest, label, is_image, talk in queue:
+        for url, dest, label, is_image, queue_talk in queue:
             overall_progress.update(overall_task, description=label)
             try:
                 if is_image:
@@ -314,8 +313,8 @@ def download_conference(
             except (DownloadError, ValueError) as exc:
                 logger.error("Failed to download %s: %s", label, exc)
                 failed.append(label)
-                if talk is not None:
-                    failed_talks.append(talk)
+                if queue_talk is not None:
+                    failed_talks.append(queue_talk)
             finally:
                 overall_progress.advance(overall_task)
 

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -136,7 +136,7 @@ def _void_to_xhtml(html: str) -> str:
         tag = m.group(1)
         attrs = m.group(2) or ""
         if attrs.rstrip().endswith("/"):
-            return m.group(0)  # already self-closed
+            return str(m.group(0))  # already self-closed
         return f"<{tag}{attrs}/>"
     return _VOID_RE.sub(_close, html)
 
@@ -186,11 +186,14 @@ def _resize_photo(src_path: Path) -> bytes:
     Returns:
         JPEG bytes of the (possibly resized) image.
     """
-    with Image.open(src_path) as img:
+    with Image.open(src_path) as raw:
+        # PIL stubs type resize()/convert() as Image.Image, not ImageFile.
+        # Use a typed local variable to avoid mypy's ImageFile/Image mismatch.
+        img: Image.Image = raw
         if img.width > _MAX_PHOTO_WIDTH:
             ratio = _MAX_PHOTO_WIDTH / img.width
             new_size = (_MAX_PHOTO_WIDTH, int(img.height * ratio))
-            img = img.resize(new_size, Image.LANCZOS)
+            img = img.resize(new_size, Image.Resampling.LANCZOS)
         if img.mode != "RGB":
             img = img.convert("RGB")
         buf = io.BytesIO()

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -8,7 +8,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import Any  # JSON decode returns Any; no narrower type available
+from typing import Any, cast  # JSON decode returns Any; no narrower type available
 from urllib.parse import urljoin, urlparse
 from urllib.robotparser import RobotFileParser
 
@@ -303,7 +303,7 @@ def _parse_initial_state(html: str) -> dict[str, Any]:
         # Base64-encoded JSON string
         try:
             json_bytes = base64.b64decode(match.group(1))
-            return json.loads(json_bytes)
+            return cast(dict[str, Any], json.loads(json_bytes))
         except Exception as exc:
             logger.debug("Failed to base64-decode __INITIAL_STATE__: %s", exc)
 
@@ -315,7 +315,7 @@ def _parse_initial_state(html: str) -> dict[str, Any]:
         if end > 0:
             json_str = json_str[:end].rstrip("; \n\r\t")
         try:
-            return json.loads(json_str)
+            return cast(dict[str, Any], json.loads(json_str))
         except json.JSONDecodeError as exc:
             logger.debug("Failed to parse __INITIAL_STATE__ as raw JSON: %s", exc)
 
@@ -553,18 +553,18 @@ def _extract_talk_title(a: Tag) -> str:
     Fallbacks: <p class="title"> inside <h4>, then <h4> text.
     """
     div = a.find("div")
-    if div:
+    if isinstance(div, Tag):
         ps = div.find_all("p", recursive=False)
         if ps:
-            return ps[0].get_text(strip=True)
+            return str(ps[0].get_text(strip=True))
     h4 = a.find("h4")
-    if h4:
+    if isinstance(h4, Tag):
         p = h4.find("p", class_="title")
-        if p:
+        if isinstance(p, Tag):
             return p.get_text(strip=True)
         return h4.get_text(strip=True)
     p = a.find("p", class_="title")
-    if p:
+    if isinstance(p, Tag):
         return p.get_text(strip=True)
     return ""
 
@@ -579,15 +579,15 @@ def _extract_talk_speaker(a: Tag) -> str:
     Fallbacks: <p class="primaryMeta">, <h6> text.
     """
     div = a.find("div")
-    if div:
+    if isinstance(div, Tag):
         ps = div.find_all("p", recursive=False)
         if len(ps) >= 2:
-            return ps[1].get_text(strip=True)
+            return str(ps[1].get_text(strip=True))
     el = a.find("p", class_="primaryMeta")
-    if el:
+    if isinstance(el, Tag):
         return el.get_text(strip=True)
     h6 = a.find("h6")
-    if h6:
+    if isinstance(h6, Tag):
         return h6.get_text(strip=True)
     return ""
 
@@ -720,15 +720,20 @@ def parse_talk_page(html: str, talk_url: str) -> dict[str, str | None]:
     if not result["mp3_url"]:
         # Fallback A: <source type="audio/mpeg"> inside a <video>
         source = soup.find("source", {"type": "audio/mpeg"})
-        if source and source.get("src") and validate_url(source["src"]):
-            result["mp3_url"] = source["src"]
-            logger.debug("mp3_url (video source): %s", result["mp3_url"])
+        if isinstance(source, Tag):
+            src_val = source.get("src")
+            if isinstance(src_val, str) and validate_url(src_val):
+                result["mp3_url"] = src_val
+                logger.debug("mp3_url (video source): %s", result["mp3_url"])
 
     if not result["mp3_url"]:
         logger.warning("MP3 selectors failed for %s, trying href/src scan", talk_url)
         # Fallback B: any <a> or <source> with an .mp3 URL on an allowed domain
         for tag in soup.find_all(["a", "source"]):
-            href = tag.get("href") or tag.get("src") or ""
+            if not isinstance(tag, Tag):
+                continue
+            href_val = tag.get("href") or tag.get("src") or ""
+            href = str(href_val)
             if href.endswith(".mp3") and validate_url(href):
                 result["mp3_url"] = href
                 logger.debug("mp3_url (href/src scan): %s", href)
@@ -738,7 +743,7 @@ def parse_talk_page(html: str, talk_url: str) -> dict[str, str | None]:
     body = soup.find("div", class_="body-block")
     if body:
         result["transcript_html"] = str(body)
-        logger.debug("transcript (primary div.body-block): %d chars", len(result["transcript_html"]))
+        logger.debug("transcript (primary div.body-block): %d chars", len(result["transcript_html"] or ""))
 
     if not result["transcript_html"]:
         logger.warning("Primary transcript selector failed for %s, trying fallback", talk_url)
@@ -772,8 +777,10 @@ def parse_talk_page(html: str, talk_url: str) -> dict[str, str | None]:
 
     # Speaker photo — primary: img whose src contains /imgs/ and is on an allowed domain
     for img in soup.find_all("img", src=True):
-        src = img["src"]
-        if "/imgs/" in src and validate_url(src):
+        if not isinstance(img, Tag):
+            continue
+        src = img.get("src")
+        if isinstance(src, str) and "/imgs/" in src and validate_url(src):
             result["speaker_image_url"] = src
             logger.debug("speaker_image_url (primary /imgs/): %s", src)
             break
@@ -781,8 +788,10 @@ def parse_talk_page(html: str, talk_url: str) -> dict[str, str | None]:
     if not result["speaker_image_url"]:
         # Fallback: og:image meta tag
         og = soup.find("meta", property="og:image")
-        if og and og.get("content") and validate_url(og["content"]):
-            result["speaker_image_url"] = og["content"]
+        if isinstance(og, Tag):
+            content = og.get("content")
+            if isinstance(content, str) and validate_url(content):
+                result["speaker_image_url"] = content
 
     return result
 
@@ -931,13 +940,17 @@ def _find_cover_image(soup: BeautifulSoup) -> str | None:
     """Try to find a conference cover image URL from a parsed page."""
     # Primary: og:image meta tag
     og = soup.find("meta", property="og:image")
-    if og and og.get("content") and validate_url(og["content"]):
-        return og["content"]
+    if isinstance(og, Tag):
+        content = og.get("content")
+        if isinstance(content, str) and validate_url(content):
+            return content
 
     # Fallback: first /imgs/ image on the page
     for img in soup.find_all("img", src=True):
-        src = img["src"]
-        if "/imgs/" in src and validate_url(src):
+        if not isinstance(img, Tag):
+            continue
+        src = img.get("src")
+        if isinstance(src, str) and "/imgs/" in src and validate_url(src):
             return src
 
     return None


### PR DESCRIPTION
## Summary
- Fixes all 26 mypy errors across `scraper.py`, `downloader.py`, `epub_builder.py`
- Adds `ruff` and `mypy` CI jobs to run on every push/PR
- Adds coverage reporting CI job
- Adds `types-requests`, `types-beautifulsoup4`, `ruff`, `mypy` to dev deps
- Bumps Pillow minimum to `>=9.1` (`Image.Resampling` was introduced in 9.1)
- Adds `[tool.mypy]` and `[tool.ruff]` config to `pyproject.toml`

## Type fixes
- BeautifulSoup: `isinstance(x, Tag)` guards before calling `.find_all()` / `.get()`
- BeautifulSoup: explicit `str()` / `isinstance(x, str)` for `str | list[str]` attributes
- PIL: typed local `img: Image.Image` variable avoids `ImageFile`/`Image` mismatch
- PIL: `Image.Resampling.LANCZOS` replaces deprecated `Image.LANCZOS`
- downloader: renamed queue loop variable to avoid `Talk` / `Talk | None` conflict
- scraper: `cast(dict[str, Any], json.loads(...))` for `Any` return narrowing

## Test plan
- [ ] All 181 unit tests pass
- [ ] `mypy src/gencon_audiobook/` — no errors
- [ ] `ruff check src/` — no errors

Closes #67
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)