### PR TITLE
fix: prevent duplicate issues from consecutive live test failures (#69)

### DIFF
--- a/.github/workflows/live-test.yml
+++ b/.github/workflows/live-test.yml
@@ -33,31 +33,59 @@ jobs:
         run: pytest tests/test_scraper_live.py -v -m live --tb=short
         continue-on-error: true
 
-      - name: Open issue on failure
+      - name: Open or update issue on failure
         if: steps.live_tests.outcome == 'failure'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const title = `Live smoke test failed — ${new Date().toISOString().slice(0,10)}`;
-            const body = [
-              "## Live smoke test failure",
-              "",
-              "The weekly live scraper smoke test failed. This usually means the",
-              "Church site changed its HTML structure or URL patterns.",
-              "",
-              `**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              "",
-              "### Next steps",
-              "1. Open the workflow run linked above and read the pytest output.",
-              "2. Check whether the conference listing page or talk page structure changed.",
-              "3. Update the relevant selectors in `scraper.py` and add/update fixtures.",
-              "4. Re-run the live test manually to confirm the fix.",
-            ].join("\n");
+            const LABEL = "live-test-failure";
+            const TITLE = "Live smoke test failing";
 
-            await github.rest.issues.create({
+            // Check for an existing open issue with our sentinel label
+            const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title,
-              body,
-              labels: ["bug"],
+              state: "open",
+              labels: LABEL,
+              per_page: 1,
             });
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const comment = [
+              `**Workflow run:** ${runUrl}`,
+              `**Date:** ${new Date().toISOString().slice(0,10)}`,
+            ].join("\n");
+
+            if (existing.data.length > 0) {
+              // Add a comment to the existing issue instead of opening a duplicate
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body: `Live smoke test failed again.\n\n${comment}`,
+              });
+            } else {
+              const body = [
+                "## Live smoke test failure",
+                "",
+                "The weekly live scraper smoke test failed. This usually means the",
+                "Church site changed its HTML structure or URL patterns.",
+                "",
+                comment,
+                "",
+                "### Next steps",
+                "1. Open the workflow run linked above and read the pytest output.",
+                "2. Check whether the conference listing page or talk page structure changed.",
+                "3. Update the relevant selectors in `scraper.py` and add/update fixtures.",
+                "4. Re-run the live test manually to confirm the fix.",
+                "5. Close this issue once the fix is merged.",
+              ].join("\n");
+
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: TITLE,
+                body,
+                labels: ["bug", LABEL],
+              });
+            }


### PR DESCRIPTION
## Summary
When the live smoke test fails on consecutive weeks, it previously opened a new GitHub issue each time. This PR changes the behavior:

1. Check for an existing open issue with the `live-test-failure` label
2. If found: add a comment with the new failure's workflow run URL
3. If not found: create a new issue with both `bug` and `live-test-failure` labels

The sentinel label `live-test-failure` allows reliable deduplication without title-matching.

## Test plan
- [ ] YAML syntax valid

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)