### PR TITLE
feat: completion report with audio quality and timing stats

### DIFF
--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -7,6 +7,7 @@ import logging
 import subprocess
 import tempfile
 import unicodedata
+from dataclasses import dataclass
 from pathlib import Path
 
 from mutagen.mp4 import MP4
@@ -27,6 +28,27 @@ logger = logging.getLogger(__name__)
 
 class AudioError(Exception):
     """Raised when an ffmpeg step fails."""
+
+
+@dataclass
+class BuildStats:
+    """Quality and chapter statistics returned by build_m4b.
+
+    Attributes:
+        source_bitrate: Detected bitrate of the source MP3s (e.g., "128k").
+        source_sample_rate: Detected sample rate of the source MP3s in Hz.
+        output_bitrate: AAC encoding bitrate used (e.g., "128k").
+        output_sample_rate: AAC sample rate used in Hz.
+        chapter_count: Number of chapters written to the m4b.
+        duration_seconds: Total audio duration in seconds.
+    """
+
+    source_bitrate: str
+    source_sample_rate: int
+    output_bitrate: str
+    output_sample_rate: int
+    chapter_count: int
+    duration_seconds: float
 
 
 # ---------------------------------------------------------------------------
@@ -438,7 +460,7 @@ def build_m4b(
     ffprobe_path: Path,
     bitrate: str | None = None,
     sample_rate: int | None = None,
-) -> None:
+) -> BuildStats:
     """Build a chaptered m4b audiobook from downloaded MP3 files.
 
     Process:
@@ -462,6 +484,9 @@ def build_m4b(
         bitrate: AAC encoding bitrate (e.g., "64k", "128k"). Defaults to source bitrate.
         sample_rate: Output sample rate in Hz. Defaults to source sample rate.
 
+    Returns:
+        BuildStats with source/output quality and chapter statistics.
+
     Raises:
         AudioError: if any ffmpeg step fails or no valid talks are found.
     """
@@ -471,6 +496,10 @@ def build_m4b(
     aac_paths: list[Path] = []
     successful_talks: list[Talk] = []
     skipped: list[str] = []
+
+    # Tracked separately so BuildStats can report source quality vs. output quality.
+    source_bitrate: str | None = None
+    source_sample_rate: int | None = None
 
     # Step 1: Auto-detect source quality unless the caller explicitly overrode it.
     # Probe the first available MP3 — all talks in a conference come from the same
@@ -485,6 +514,8 @@ def build_m4b(
     )
     if first_mp3 is not None:
         detected_bitrate, detected_sample_rate = _probe_source_quality(first_mp3, ffprobe_path)
+        source_bitrate = detected_bitrate
+        source_sample_rate = detected_sample_rate
         if bitrate is None:
             bitrate = detected_bitrate
         if sample_rate is None:
@@ -493,6 +524,9 @@ def build_m4b(
     # Final fallback if no MP3s exist yet or probe returned nothing
     bitrate = bitrate or _FALLBACK_BITRATE
     sample_rate = sample_rate or _FALLBACK_SAMPLE_RATE
+    # If probe failed entirely, report source quality == output quality
+    source_bitrate = source_bitrate or bitrate
+    source_sample_rate = source_sample_rate or sample_rate
 
     # Step 2: Convert MP3 → AAC, populate duration_seconds
     logger.info("Converting %d talks to AAC...", len(talks))
@@ -598,3 +632,12 @@ def build_m4b(
     # Step 7: Verify
     _verify_m4b(output_path, conference, ffprobe_path)
     logger.info("Built: %s (%.1f MB)", output_path.name, output_path.stat().st_size / 1_048_576)
+
+    return BuildStats(
+        source_bitrate=source_bitrate,
+        source_sample_rate=source_sample_rate,
+        output_bitrate=bitrate,
+        output_sample_rate=sample_rate,
+        chapter_count=len(successful_talks),
+        duration_seconds=sum(t.duration_seconds for t in successful_talks),
+    )

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import shutil
 import sys
+import time
 from pathlib import Path
 
 import click
@@ -12,7 +13,7 @@ from rich.console import Console
 from rich.logging import RichHandler
 
 from . import __version__
-from .audio import AudioError, build_m4b
+from .audio import AudioError, BuildStats, build_m4b
 from .downloader import DownloadError, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
@@ -254,6 +255,76 @@ def main(
         sys.exit(1)
 
 
+def _format_duration(seconds: float) -> str:
+    """Format a duration in seconds as HH:MM:SS.
+
+    Args:
+        seconds: Duration in seconds.
+
+    Returns:
+        Duration string in HH:MM:SS format.
+    """
+    total = int(seconds)
+    h = total // 3600
+    m = (total % 3600) // 60
+    s = total % 60
+    return f"{h}:{m:02d}:{s:02d}"
+
+
+def _print_completion_report(
+    conf_output_dir: Path,
+    m4b_path: Path,
+    epub_path: Path,
+    failed_talks: list[Talk],
+    stats: BuildStats | None,
+    phase_times: dict[str, float],
+) -> None:
+    """Print a structured completion report to the console.
+
+    Args:
+        conf_output_dir: Conference output directory.
+        m4b_path: Path to the built m4b file (may not exist if epub-only).
+        epub_path: Path to the built epub file (may not exist if audiobook-only).
+        failed_talks: Talks that failed to download.
+        stats: BuildStats from build_m4b, or None if audiobook was skipped/cached.
+        phase_times: Elapsed seconds per phase label.
+    """
+    console.print("")
+    console.print("--- Completion Report ---")
+
+    if stats is not None:
+        console.print(f"  Duration:      {_format_duration(stats.duration_seconds)}")
+        console.print(f"  Chapters:      {stats.chapter_count}")
+        if stats.source_bitrate != stats.output_bitrate or stats.source_sample_rate != stats.output_sample_rate:
+            console.print(f"  Source audio:  {stats.source_bitrate} / {stats.source_sample_rate} Hz")
+            console.print(f"  Output audio:  {stats.output_bitrate} / {stats.output_sample_rate} Hz")
+        else:
+            console.print(f"  Audio quality: {stats.output_bitrate} / {stats.output_sample_rate} Hz")
+
+    if m4b_path.exists():
+        size_mb = m4b_path.stat().st_size / 1_048_576
+        console.print(f"  Audiobook:     {m4b_path.name} ({size_mb:.0f} MB)")
+
+    if epub_path.exists():
+        size_mb = epub_path.stat().st_size / 1_048_576
+        console.print(f"  EPUB:          {epub_path.name} ({size_mb:.1f} MB)")
+
+    if phase_times:
+        parts = ", ".join(f"{label} {elapsed:.0f}s" for label, elapsed in phase_times.items())
+        console.print(f"  Timing:        {parts}")
+
+    if len(failed_talks) > 0:
+        console.print(
+            f"\n  Warning: {len(failed_talks)} talk(s) could not be downloaded "
+            "and are not included in the output:"
+        )
+        for talk in failed_talks:
+            console.print(f"    - {talk.title} ({talk.speaker})")
+
+    console.print(f"\n  Output: {conf_output_dir}")
+    console.print(f"  Log:    {conf_output_dir / _LOG_FILENAME}")
+
+
 def _run(
     output: str,
     conference: str | None,
@@ -265,16 +336,19 @@ def _run(
 ) -> None:
     """Inner implementation of main() — separated so KeyboardInterrupt is handled cleanly."""
     output_dir = Path(output).expanduser().resolve()
+    phase_times: dict[str, float] = {}
 
     conf_title, conf_url = _select_conference(conference)
 
     # Scrape conference details
     console.print(f"Scraping conference: {conf_title}")
+    t0 = time.monotonic()
     try:
         conf_obj = scrape_conference(conf_url)
     except ScraperError as exc:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
+    phase_times["scrape"] = time.monotonic() - t0
 
     conf_output_dir = output_dir / conf_obj.title
 
@@ -294,6 +368,7 @@ def _run(
 
     # Download audio (skipped for --epub-only) and images.
     console.print(f"Downloading files for {len(conf_obj.talks)} talks...")
+    t0 = time.monotonic()
     try:
         failed_talks: list[Talk] = download_conference(
             conf_obj, conf_output_dir, skip_audio=epub_only
@@ -301,9 +376,11 @@ def _run(
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
         sys.exit(1)
+    phase_times["download"] = time.monotonic() - t0
 
     m4b_path = conf_output_dir / f"{conf_obj.title}.m4b"
     epub_path = conf_output_dir / f"{conf_obj.title}.epub"
+    build_stats: BuildStats | None = None
 
     # Build m4b audiobook
     if not epub_only:
@@ -323,8 +400,9 @@ def _run(
                 f"Audiobook already exists (use --overwrite to rebuild): {m4b_path.name}"
             )
         else:
+            t0 = time.monotonic()
             try:
-                build_m4b(
+                build_stats = build_m4b(
                     conference=conf_obj,
                     audio_dir=audio_dir,
                     output_path=m4b_path,
@@ -337,6 +415,7 @@ def _run(
             except AudioError as exc:
                 click.echo(f"Error: Audiobook build failed.\n{exc}", err=True)
                 sys.exit(1)
+            phase_times["audiobook"] = time.monotonic() - t0
 
     # Build EPUB companion
     if not audiobook_only:
@@ -346,6 +425,7 @@ def _run(
                 f"EPUB already exists (use --overwrite to rebuild): {epub_path.name}"
             )
         else:
+            t0 = time.monotonic()
             try:
                 build_epub(
                     conference=conf_obj,
@@ -355,24 +435,13 @@ def _run(
             except EpubError as exc:
                 click.echo(f"Error: EPUB build failed.\n{exc}", err=True)
                 sys.exit(1)
+            phase_times["epub"] = time.monotonic() - t0
 
-    # Summary
-    console.print("")
-    console.print(f"Output saved to: {conf_output_dir}")
-    if m4b_path.exists():
-        size_mb = m4b_path.stat().st_size / 1_048_576
-        chapter_count = len(conf_obj.talks)
-        console.print(f"  {m4b_path.name} ({size_mb:.0f} MB, {chapter_count} chapters)")
-    if epub_path.exists():
-        size_mb = epub_path.stat().st_size / 1_048_576
-        talk_count = len(conf_obj.talks)
-        console.print(f"  {epub_path.name} ({size_mb:.1f} MB, {talk_count} talks)")
-
-    if failed_talks:
-        console.print(
-            f"\n[yellow]Warning:[/yellow] {len(failed_talks)} talk(s) could not be "
-            "downloaded and are not included in the output:"
-        )
-        for talk in failed_talks:
-            console.print(f"  - {talk.title} ({talk.speaker})")
-        console.print(f"For details, see: {conf_output_dir / _LOG_FILENAME}")
+    _print_completion_report(
+        conf_output_dir=conf_output_dir,
+        m4b_path=m4b_path,
+        epub_path=epub_path,
+        failed_talks=failed_talks,
+        stats=build_stats,
+        phase_times=phase_times,
+    )

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -15,7 +15,7 @@ import pytest
 from PIL import Image
 
 from conftest import FFMPEG as _FFMPEG, FFPROBE as _FFPROBE, make_silent_mp3, requires_ffmpeg
-from gencon_audiobook.audio import AudioError, _ascii_safe, _probe_source_quality, build_m4b, convert_mp3_to_aac
+from gencon_audiobook.audio import AudioError, BuildStats, _ascii_safe, _probe_source_quality, build_m4b, convert_mp3_to_aac
 from gencon_audiobook.models import Conference, Session, Talk
 
 
@@ -500,7 +500,12 @@ def test_build_m4b_auto_detects_source_quality(tmp_path: Path) -> None:
     output = tmp_path / "output.m4b"
 
     # No bitrate or sample_rate passed — should auto-detect from source
-    build_m4b(conference, audio_dir, output, None, _FFMPEG, _FFPROBE)
+    stats = build_m4b(conference, audio_dir, output, None, _FFMPEG, _FFPROBE)
 
     assert output.exists(), "m4b should be produced with auto-detected quality"
     assert output.stat().st_size > 0
+    assert stats.chapter_count == 2, f"Expected 2 chapters, got {stats.chapter_count}"
+    assert stats.duration_seconds > 0, f"Expected positive duration, got {stats.duration_seconds}"
+    assert stats.source_bitrate, "source_bitrate should be populated"
+    assert stats.output_bitrate, "output_bitrate should be populated"
+    assert stats.source_sample_rate > 0, "source_sample_rate should be positive"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -325,7 +325,8 @@ def test_completion_summary_printed(tmp_path: Path) -> None:
         runner = CliRunner()
         result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
 
-    assert "Output saved to" in result.output, result.output
+    assert "Completion Report" in result.output, result.output
+    assert "Audiobook:" in result.output, result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `BuildStats` dataclass returned by `build_m4b()` containing source/output bitrate, sample rate, chapter count, and total duration
- CLI now wraps each phase (scrape, download, audiobook, epub) with `time.monotonic()` timing
- `_print_completion_report()` prints a structured report on success showing duration, chapter count, audio quality (distinguishes source vs output when `--bitrate` overrides), file sizes, per-phase timing, and any failed talks

## Example output
```
--- Completion Report ---
  Duration:      2:01:37
  Chapters:      31
  Audio quality: 64k / 22050 Hz
  Audiobook:     April 2024 General Conference.m4b (178 MB)
  EPUB:          April 2024 General Conference.epub (12.3 MB)
  Timing:        scrape 4s, download 312s, audiobook 48s, epub 3s

  Output: /home/user/gencon-audiobook/April 2024 General Conference
  Log:    /home/user/gencon-audiobook/April 2024 General Conference/gencon-audiobook.log
```

## Test plan
- [ ] Unit tests pass: `pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py`
- [ ] `test_build_m4b_auto_detects_source_quality` validates `BuildStats` fields
- [ ] `test_completion_summary_printed` checks new report format
- [ ] `--bitrate` override shows separate "Source audio" / "Output audio" lines

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)