### PR TITLE
feat: add Rich progress bars and spinners to remaining pipeline phases

### DIFF
--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -18,10 +18,10 @@ from rich.progress import (
     SpinnerColumn,
     TaskProgressColumn,
     TextColumn,
-    TimeRemainingColumn,
 )
 
 from .models import Conference, Talk
+from .progress import TimeRemainingWithLabel
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -536,8 +536,8 @@ def build_m4b(
         MofNCompleteColumn(),
         BarColumn(),
         TaskProgressColumn(),
+        TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
-        TimeRemainingColumn(),
     )
     with progress:
         task = progress.add_task("Converting to AAC", total=len(talks))

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -532,6 +532,7 @@ def build_m4b(
     # Step 2: Convert MP3 → AAC, populate duration_seconds
     logger.info("Converting %d talks to AAC...", len(talks))
     progress = Progress(
+        SpinnerColumn(),
         MofNCompleteColumn(),
         BarColumn(),
         TaskProgressColumn(),

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -15,6 +15,7 @@ from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
     Progress,
+    SpinnerColumn,
     TaskProgressColumn,
     TextColumn,
     TimeRemainingColumn,
@@ -630,7 +631,9 @@ def build_m4b(
             logger.warning("Could not delete %s: %s", aac_path, exc)
 
     # Step 7: Verify
-    _verify_m4b(output_path, conference, ffprobe_path)
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
+        sp.add_task(f"Verifying m4b: {output_path.name}")
+        _verify_m4b(output_path, conference, ffprobe_path)
     logger.info("Built: %s (%.1f MB)", output_path.name, output_path.stat().st_size / 1_048_576)
 
     return BuildStats(

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 from rich.logging import RichHandler
+from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
@@ -134,9 +135,10 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     Raises:
         SystemExit: if the filter matches nothing or the list cannot be fetched.
     """
-    console.print("Fetching available conferences...")
     try:
-        refs = fetch_available_conferences()
+        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
+            sp.add_task("Fetching available conferences...")
+            refs = fetch_available_conferences()
     except ScraperError as exc:
         click.echo(f"Error: {exc}", err=True)
         sys.exit(1)
@@ -340,8 +342,7 @@ def _run(
 
     conf_title, conf_url = _select_conference(conference)
 
-    # Scrape conference details
-    console.print(f"Scraping conference: {conf_title}")
+    # Scrape conference details — progress bar printed inside scrape_conference()
     t0 = time.monotonic()
     try:
         conf_obj = scrape_conference(conf_url)
@@ -419,7 +420,6 @@ def _run(
 
     # Build EPUB companion
     if not audiobook_only:
-        console.print("Building epub...")
         if epub_path.exists() and not overwrite:
             console.print(
                 f"EPUB already exists (use --overwrite to rebuild): {epub_path.name}"
@@ -427,11 +427,16 @@ def _run(
         else:
             t0 = time.monotonic()
             try:
-                build_epub(
-                    conference=conf_obj,
-                    images_dir=conf_output_dir,
-                    output_path=epub_path,
-                )
+                with Progress(
+                    SpinnerColumn(),
+                    TextColumn("[progress.description]{task.description}"),
+                ) as sp:
+                    sp.add_task(f"Building EPUB: {conf_obj.title}")
+                    build_epub(
+                        conference=conf_obj,
+                        images_dir=conf_output_dir,
+                        output_path=epub_path,
+                    )
             except EpubError as exc:
                 click.echo(f"Error: EPUB build failed.\n{exc}", err=True)
                 sys.exit(1)

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -274,6 +274,7 @@ def _format_duration(seconds: float) -> str:
 
 
 def _print_completion_report(
+    conf_title: str,
     conf_output_dir: Path,
     m4b_path: Path,
     epub_path: Path,
@@ -284,6 +285,7 @@ def _print_completion_report(
     """Print a structured completion report to the console.
 
     Args:
+        conf_title: Human-readable conference title.
         conf_output_dir: Conference output directory.
         m4b_path: Path to the built m4b file (may not exist if epub-only).
         epub_path: Path to the built epub file (may not exist if audiobook-only).
@@ -293,6 +295,7 @@ def _print_completion_report(
     """
     console.print("")
     console.print("--- Completion Report ---")
+    console.print(f"  Conference:    {conf_title}")
 
     if stats is not None:
         console.print(f"  Duration:      {_format_duration(stats.duration_seconds)}")
@@ -443,6 +446,7 @@ def _run(
             phase_times["epub"] = time.monotonic() - t0
 
     _print_completion_report(
+        conf_title=conf_obj.title,
         conf_output_dir=conf_output_dir,
         m4b_path=m4b_path,
         epub_path=epub_path,

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -13,6 +13,7 @@ from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
     Progress,
+    SpinnerColumn,
     TaskProgressColumn,
     TextColumn,
     TimeRemainingColumn,
@@ -282,6 +283,7 @@ def download_conference(
     )
 
     overall_progress = Progress(
+        SpinnerColumn(),
         MofNCompleteColumn(),
         BarColumn(),
         TaskProgressColumn(),
@@ -289,6 +291,7 @@ def download_conference(
         TimeRemainingColumn(),
     )
     file_progress = Progress(
+        SpinnerColumn(),
         MofNCompleteColumn(),
         BarColumn(),
         TaskProgressColumn(),

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -16,10 +16,10 @@ from rich.progress import (
     SpinnerColumn,
     TaskProgressColumn,
     TextColumn,
-    TimeRemainingColumn,
 )
 
 from .models import Conference, Talk
+from .progress import TimeRemainingWithLabel
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -287,16 +287,16 @@ def download_conference(
         MofNCompleteColumn(),
         BarColumn(),
         TaskProgressColumn(),
+        TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
-        TimeRemainingColumn(),
     )
     file_progress = Progress(
         SpinnerColumn(),
         MofNCompleteColumn(),
         BarColumn(),
         TaskProgressColumn(),
+        TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
-        TimeRemainingColumn(),
     )
 
     failed: list[str] = []

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -1,0 +1,16 @@
+"""Shared Rich progress column customizations."""
+
+from __future__ import annotations
+
+from rich.progress import TimeRemainingColumn
+from rich.text import Text
+
+
+class TimeRemainingWithLabel(TimeRemainingColumn):
+    """TimeRemainingColumn that appends ' remaining' to the rendered time."""
+
+    def render(self, task: "Task") -> Text:  # type: ignore[override]
+        text = super().render(task)
+        if text.plain.strip() and text.plain.strip() not in ("--:--", "-:--:--"):
+            text.append(" remaining")
+        return text

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from rich.progress import TimeRemainingColumn
+from rich.progress import Task, TimeRemainingColumn
 from rich.text import Text
 
 
 class TimeRemainingWithLabel(TimeRemainingColumn):
     """TimeRemainingColumn that appends ' remaining' to the rendered time."""
 
-    def render(self, task: "Task") -> Text:  # type: ignore[override]
+    def render(self, task: Task) -> Text:
         text = super().render(task)
         if text.plain.strip() and text.plain.strip() not in ("--:--", "-:--:--"):
             text.append(" remaining")

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -22,10 +22,10 @@ from rich.progress import (
     SpinnerColumn,
     TaskProgressColumn,
     TextColumn,
-    TimeRemainingColumn,
 )
 
 from .models import Conference, Session, Talk
+from .progress import TimeRemainingWithLabel
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
@@ -887,8 +887,8 @@ def scrape_conference(conference_url: str) -> Conference:
         MofNCompleteColumn(),
         BarColumn(),
         TaskProgressColumn(),
+        TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
-        TimeRemainingColumn(),
     )
     with scrape_progress:
         task = scrape_progress.add_task("Scraping talks", total=len(all_talks))

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -14,11 +14,22 @@ from urllib.robotparser import RobotFileParser
 
 import requests
 from bs4 import BeautifulSoup, Tag
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
 
 from .models import Conference, Session, Talk
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
+console = Console()
 
 _BASE_URL = "https://www.churchofjesuschrist.org"
 _ARCHIVE_PATH = "/study/general-conference"
@@ -870,42 +881,56 @@ def scrape_conference(conference_url: str) -> Conference:
     valid_count = 0
     skipped: list[Talk] = []
 
-    for i, talk in enumerate(all_talks, start=1):
-        logger.info("Scraping talk %d/%d: %s", i, len(all_talks), talk.title)
-        try:
-            talk_html = _fetch(http, talk.talk_url)
-            data = parse_talk_page(talk_html, talk.talk_url)
+    console.print(f"Scraping: {title}")
+    scrape_progress = Progress(
+        SpinnerColumn(),
+        MofNCompleteColumn(),
+        BarColumn(),
+        TaskProgressColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeRemainingColumn(),
+    )
+    with scrape_progress:
+        task = scrape_progress.add_task("Scraping talks", total=len(all_talks))
+        for i, talk in enumerate(all_talks, start=1):
+            scrape_progress.update(task, description=talk.title[:60])
+            logger.debug("Scraping talk %d/%d: %s", i, len(all_talks), talk.title)
+            try:
+                talk_html = _fetch(http, talk.talk_url)
+                data = parse_talk_page(talk_html, talk.talk_url)
 
-            # Use speaker from talk page if listing didn't provide one
-            if not talk.speaker and data["speaker"]:
-                talk.speaker = data["speaker"]
+                # Use speaker from talk page if listing didn't provide one
+                if not talk.speaker and data["speaker"]:
+                    talk.speaker = data["speaker"]
 
-            talk.mp3_url = data["mp3_url"]
-            talk.transcript_html = data["transcript_html"]
-            talk.speaker_image_url = data["speaker_image_url"]
+                talk.mp3_url = data["mp3_url"]
+                talk.transcript_html = data["transcript_html"]
+                talk.speaker_image_url = data["speaker_image_url"]
 
-            # Validate required fields
-            missing = []
-            if not talk.title:
-                missing.append("title")
-            if not talk.speaker:
-                missing.append("speaker")
-            if not talk.mp3_url or not validate_url(talk.mp3_url):
-                missing.append("mp3_url")
+                # Validate required fields
+                missing = []
+                if not talk.title:
+                    missing.append("title")
+                if not talk.speaker:
+                    missing.append("speaker")
+                if not talk.mp3_url or not validate_url(talk.mp3_url):
+                    missing.append("mp3_url")
 
-            if missing:
-                logger.error(
-                    "Talk at %s missing required fields: %s — skipping",
-                    talk.talk_url,
-                    ", ".join(missing),
-                )
+                if missing:
+                    logger.error(
+                        "Talk at %s missing required fields: %s — skipping",
+                        talk.talk_url,
+                        ", ".join(missing),
+                    )
+                    skipped.append(talk)
+                else:
+                    valid_count += 1
+
+            except ScraperError as exc:
+                logger.error("Failed to scrape talk %s: %s", talk.talk_url, exc)
                 skipped.append(talk)
-            else:
-                valid_count += 1
-
-        except ScraperError as exc:
-            logger.error("Failed to scrape talk %s: %s", talk.talk_url, exc)
-            skipped.append(talk)
+            finally:
+                scrape_progress.advance(task)
 
     if skipped:
         logger.warning("%d talk(s) skipped due to missing fields or errors", len(skipped))


### PR DESCRIPTION
## Summary
- Replaces noisy `logger.info` scraping lines with a Rich M/N progress bar; conference title prints above the bar
- Wraps `fetch_available_conferences()` and `build_epub()` in spinners (cli.py)
- Wraps `_verify_m4b()` in a spinner (audio.py)
- Removes now-redundant `console.print` calls that the spinners replace

## Test plan
- [ ] All 181 unit tests pass (`pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py`)
- [ ] Visual check: spinner appears while fetching conferences
- [ ] Visual check: M/N bar with talk title advances during scraping (no INFO lines)
- [ ] Visual check: spinner appears during EPUB build
- [ ] Visual check: spinner appears during m4b verification

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)