### PR TITLE
fix: replace spaces with hyphens in sanitize_filename()

### DIFF
--- a/src/gencon_audiobook/utils.py
+++ b/src/gencon_audiobook/utils.py
@@ -37,10 +37,14 @@ _ALLOWED_HOSTNAMES = re.compile(
 def sanitize_filename(name: str) -> str:
     """Return a safe filename derived from name.
 
-    Replaces characters outside [a-zA-Z0-9 ._-] with underscores, collapses
-    consecutive underscores, strips leading/trailing underscores and spaces,
-    and truncates to 200 characters. Never returns a string that could be used
-    for path traversal.
+    Replaces spaces with hyphens, replaces characters outside [a-zA-Z0-9 ._-]
+    with underscores, collapses consecutive underscores, strips leading/trailing
+    underscores and spaces, and truncates to 200 characters. Never returns a
+    string that could be used for path traversal.
+
+    Spaces are replaced with hyphens (not underscores) so that filenames used
+    in EPUB IRI path segments are valid without percent-encoding (epubcheck
+    PKG-010).
 
     Args:
         name: Raw string to sanitize.
@@ -48,8 +52,11 @@ def sanitize_filename(name: str) -> str:
     Returns:
         A safe filename string. Returns "unnamed" if the result would be empty.
     """
+    # Replace spaces with hyphens before other transformations so EPUB IRI
+    # path segments contain no spaces (epubcheck PKG-010, RSC-020).
+    result = name.replace(" ", "-")
     # Replace unsafe characters with underscores
-    result = _SAFE_CHARS.sub("_", name)
+    result = _SAFE_CHARS.sub("_", result)
     # Collapse consecutive underscores
     result = _MULTI_UNDERSCORE.sub("_", result)
     # Strip leading/trailing underscores, spaces, and dots. Dots are included to prevent

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -30,7 +30,7 @@ def _make_conference(tmp_path: Path, n_talks: int = 3, duration: float = 2.0) ->
             talk_index=i,
         )
         talks.append(talk)
-        mp3 = tmp_path / "audio" / f"{i:03d}-Talk {i}.mp3"
+        mp3 = tmp_path / "audio" / f"{i:03d}-Talk-{i}.mp3"
         make_silent_mp3(mp3, duration_seconds=duration)
 
     session = Session(name="Morning Session", number=1, talks=talks)
@@ -225,7 +225,7 @@ def test_build_m4b_skips_missing_mp3(tmp_path: Path) -> None:
     output = tmp_path / "output.m4b"
 
     # Remove the second talk's MP3
-    mp3_to_remove = audio_dir / "002-Talk 2.mp3"
+    mp3_to_remove = audio_dir / "002-Talk-2.mp3"
     mp3_to_remove.unlink()
 
     build_m4b(conference, audio_dir, output, None, _FFMPEG, _FFPROBE)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -248,7 +248,7 @@ def test_audio_path_format(tmp_path: Path) -> None:
         talk_index=3,
     )
     path = _audio_path(tmp_path, talk)
-    assert path.name == "003-Welcome to Conference.mp3", f"Unexpected name: {path.name!r}"
+    assert path.name == "003-Welcome-to-Conference.mp3", f"Unexpected name: {path.name!r}"
     assert path.parent == tmp_path / "audio"
 
 
@@ -260,7 +260,7 @@ def test_speaker_path_format(tmp_path: Path) -> None:
         talk_index=1,
     )
     path = _speaker_path(tmp_path, talk)
-    assert path.name == "001-Dallin H. Oaks.jpg", f"Unexpected name: {path.name!r}"
+    assert path.name == "001-Dallin-H.-Oaks.jpg", f"Unexpected name: {path.name!r}"
     assert path.parent == tmp_path / "speakers"
 
 
@@ -310,7 +310,7 @@ def test_download_conference_skip_audio_downloads_images(tmp_path: Path) -> None
 
     assert (tmp_path / "cover.jpg").exists(), \
         "cover.jpg must be downloaded even in epub-only (skip_audio=True) mode"
-    assert (tmp_path / "speakers" / "001-Test Speaker.jpg").exists(), \
+    assert (tmp_path / "speakers" / "001-Test-Speaker.jpg").exists(), \
         "speaker photos must be downloaded even in epub-only (skip_audio=True) mode"
 
     audio_files = list((tmp_path / "audio").glob("*.mp3")) if (tmp_path / "audio").exists() else []
@@ -332,7 +332,7 @@ def test_download_conference_audio_downloaded_by_default(tmp_path: Path) -> None
     conference = _make_single_talk_conference()
     download_conference(conference, tmp_path, delay=0, skip_audio=False)
 
-    mp3 = tmp_path / "audio" / "001-Test Talk.mp3"
+    mp3 = tmp_path / "audio" / "001-Test-Talk.mp3"
     assert mp3.exists(), \
         f"MP3 should be downloaded by default (skip_audio=False); expected {mp3}"
 
@@ -357,5 +357,5 @@ def test_download_conference_continues_on_failed_download(tmp_path: Path) -> Non
     # Must not raise even though cover download fails
     download_conference(conference, tmp_path, delay=0, skip_audio=False)
 
-    mp3 = tmp_path / "audio" / "001-Test Talk.mp3"
+    mp3 = tmp_path / "audio" / "001-Test-Talk.mp3"
     assert mp3.exists(), "MP3 should still be downloaded even when cover image fails"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,9 +12,9 @@ from gencon_audiobook.utils import sanitize_filename, validate_url
 # ---------------------------------------------------------------------------
 
 
-def test_sanitize_filename_clean_input_unchanged():
+def test_sanitize_filename_replaces_spaces_with_hyphens():
     result = sanitize_filename("April 2024 General Conference")
-    assert result == "April 2024 General Conference", f"Expected unchanged, got {result!r}"
+    assert result == "April-2024-General-Conference", f"Expected hyphens, got {result!r}"
 
 
 def test_sanitize_filename_replaces_unsafe_chars():
@@ -85,8 +85,8 @@ def test_sanitize_filename_preserves_dots_dashes_underscores():
 
 
 def test_sanitize_filename_already_clean_name():
-    result = sanitize_filename("Talk Title Here")
-    assert result == "Talk Title Here", f"Expected unchanged, got {result!r}"
+    result = sanitize_filename("Talk-Title-Here")
+    assert result == "Talk-Title-Here", f"Expected unchanged, got {result!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `name.replace(" ", "-")` at the top of `sanitize_filename()` so all generated EPUB filenames and href/src path segments contain no spaces
- Eliminates ~73 PKG-010 warnings and ~700 RSC-020 errors reported by epubcheck
- Updates tests to reflect new hyphenated filenames

## Test plan
- [ ] All 181 unit tests pass
- [ ] `epubcheck` on a rebuilt EPUB reports 0 PKG-010 and 0 RSC-020 errors
- [ ] Filenames in the EPUB ZIP contain hyphens instead of spaces

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)