### PR TITLE
feat: nav session headers as links and higher-res cover image

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -337,7 +337,13 @@ def _nav_xhtml(conference: Conference, talk_hrefs: dict[int, str]) -> str:
     ]
     for session in conference.sessions:
         toc.append('    <li>')
-        toc.append(f'      <span>{escape(session.name)}</span>')
+        # Link session headers to the first talk in that session so reading
+        # systems that require <a> (e.g., Kindle) don't drop the label.
+        if session.talks:
+            first_href = talk_hrefs[session.talks[0].talk_index]
+            toc.append(f'      <a href="{first_href}">{escape(session.name)}</a>')
+        else:
+            toc.append(f'      <span>{escape(session.name)}</span>')
         toc.append('      <ol>')
         for talk in session.talks:
             href = talk_hrefs[talk.talk_index]

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -962,13 +962,24 @@ def _month_name(month: int) -> str:
 
 
 def _find_cover_image(soup: BeautifulSoup) -> str | None:
-    """Try to find a conference cover image URL from a parsed page."""
+    """Try to find a conference cover image URL from a parsed page.
+
+    Upgrades IIIF-style size parameters to 800px wide so the cover is
+    suitable for an ebook cover rather than a social-sharing thumbnail.
+    """
+    def _upgrade_iiif(url: str) -> str:
+        """Rewrite IIIF size segment to request 800px-wide image."""
+        # Handles both percent-encoded (%21...%2C) and plain (!N,) forms
+        url = re.sub(r"/full/%21\d+%2C/", "/full/%21800%2C/", url)
+        url = re.sub(r"/full/!\d+,/", "/full/!800,/", url)
+        return url
+
     # Primary: og:image meta tag
     og = soup.find("meta", property="og:image")
     if isinstance(og, Tag):
         content = og.get("content")
         if isinstance(content, str) and validate_url(content):
-            return content
+            return _upgrade_iiif(content)
 
     # Fallback: first /imgs/ image on the page
     for img in soup.find_all("img", src=True):
@@ -976,6 +987,6 @@ def _find_cover_image(soup: BeautifulSoup) -> str | None:
             continue
         src = img.get("src")
         if isinstance(src, str) and "/imgs/" in src and validate_url(src):
-            return src
+            return _upgrade_iiif(src)
 
     return None

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -255,6 +255,19 @@ def test_build_epub_sessions_in_nav(tmp_path: Path) -> None:
         )
 
 
+def test_build_epub_session_headers_are_links(tmp_path: Path) -> None:
+    """Session headers in nav.xhtml must use <a> not <span> for reader compatibility."""
+    conference = _make_conference(n_talks=2)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    nav = _epub_read(output, "nav.xhtml").decode("utf-8")
+    session_name = conference.sessions[0].name
+    assert f"<span>{session_name}</span>" not in nav, \
+        "Session header must not use <span>"
+    assert f">{session_name}</a>" in nav, \
+        "Session header must use <a> linking to first talk"
+
+
 # ---------------------------------------------------------------------------
 # build_epub — images
 # ---------------------------------------------------------------------------

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -15,6 +15,7 @@ import responses as responses_lib
 from gencon_audiobook.scraper import (
     ScraperError,
     _check_robots,
+    _find_cover_image,
     _get_robots,
     _make_http_session as _scraper_make_session,
     _robots_cache,
@@ -337,3 +338,54 @@ def test_fetch_403_raises_immediately_without_retry() -> None:
     assert len(responses_lib.calls) == 1, (
         f"403 must not be retried — expected 1 request, got {len(responses_lib.calls)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _find_cover_image — IIIF URL upgrade
+# ---------------------------------------------------------------------------
+
+
+def test_find_cover_image_upgrades_iiif_percent_encoded_url() -> None:
+    """og:image URLs with percent-encoded IIIF size must be upgraded to 800px."""
+    from bs4 import BeautifulSoup
+    html = (
+        '<html><head>'
+        '<meta property="og:image" content="https://www.churchofjesuschrist.org'
+        '/imgs/abc123/full/%21250%2C/0/default"/>'
+        '</head></html>'
+    )
+    soup = BeautifulSoup(html, "html.parser")
+    result = _find_cover_image(soup)
+    assert result is not None, "Should find cover image URL"
+    assert "%21800%2C" in result, f"IIIF size not upgraded to 800: {result!r}"
+    assert "%21250%2C" not in result, f"Original size still present: {result!r}"
+
+
+def test_find_cover_image_upgrades_iiif_plain_url() -> None:
+    """og:image URLs with plain IIIF size must also be upgraded."""
+    from bs4 import BeautifulSoup
+    html = (
+        '<html><head>'
+        '<meta property="og:image" content="https://www.churchofjesuschrist.org'
+        '/imgs/abc123/full/!500,/0/default"/>'
+        '</head></html>'
+    )
+    soup = BeautifulSoup(html, "html.parser")
+    result = _find_cover_image(soup)
+    assert result is not None
+    assert "!800," in result, f"IIIF size not upgraded to 800: {result!r}"
+    assert "!500," not in result, f"Original size still present: {result!r}"
+
+
+def test_find_cover_image_leaves_non_iiif_url_unchanged() -> None:
+    """URLs that don't match the IIIF pattern are returned as-is."""
+    from bs4 import BeautifulSoup
+    html = (
+        '<html><head>'
+        '<meta property="og:image" content="https://www.churchofjesuschrist.org'
+        '/imgs/cover.jpg"/>'
+        '</head></html>'
+    )
+    soup = BeautifulSoup(html, "html.parser")
+    result = _find_cover_image(soup)
+    assert result == "https://www.churchofjesuschrist.org/imgs/cover.jpg"


### PR DESCRIPTION
## Summary
- **Nav session headers**: `nav.xhtml` session groupings now use `<a href="...">` linking to the first talk in the session instead of `<span>`. Reading systems that require `<a>` (Kindle) no longer drop the session label.
- **Cover image resolution**: IIIF-style size parameters in the cover image URL are rewritten from thumbnail size (e.g., `!250,`) to `!800,` so the cover renders at full quality in reading apps.

## Test plan
- [ ] All 185 unit tests pass
- [ ] `nav.xhtml` in built EPUB has `<a>` session headers (no `<span>`)
- [ ] Cover image in rebuilt EPUB is visibly larger/higher quality

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)