### PR TITLE
fix: ZIP verification, store JPEGs uncompressed, materialize footnote markers

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -225,6 +225,13 @@ def _sanitize_transcript(
     for a_tag in soup.find_all("a"):
         a_tag.unwrap()
 
+    # Materialize data-value into text for elements that rely on CSS
+    # content: attr(data-value) for display (e.g., footnote markers on the
+    # Church site use <sup data-value="1"></sup> with no text content).
+    for tag in soup.find_all(attrs={"data-value": True}):
+        if not tag.get_text(strip=True):
+            tag.string = str(tag["data-value"])
+
     # Strip data-* attributes (React/JS rendering artifacts) and random web IDs
     # (e.g., id="p_fvoG6") — neither has meaning in an EPUB reading system.
     # Preserve id attributes beginning with "note" (footnote anchors).
@@ -656,14 +663,16 @@ def build_epub(
                 logger.debug("Added talk page: text/%s", d["filename"])
 
             if has_cover:
-                zf.write(cover_src, "images/cover.jpg")
+                # JPEGs are already compressed — store them to avoid double-compression
+                # and compatibility issues on older e-ink readers.
+                zf.write(cover_src, "images/cover.jpg", compress_type=zipfile.ZIP_STORED)
                 logger.debug("Added cover image")
 
             for d in talk_file_data:
                 if d["photo_src"] and d["photo_epub_href"]:
                     try:
                         photo_bytes = _resize_photo(d["photo_src"])
-                        zf.writestr(d["photo_epub_href"], photo_bytes)
+                        zf.writestr(d["photo_epub_href"], photo_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added speaker photo: %s", d["photo_epub_href"])
                     except Exception as exc:
                         logger.warning(
@@ -676,7 +685,7 @@ def build_epub(
                 for epub_href, src_path, _manifest_id in d["inline_image_files"]:
                     try:
                         img_bytes = _resize_image(src_path, _MAX_INLINE_WIDTH)
-                        zf.writestr(epub_href, img_bytes)
+                        zf.writestr(epub_href, img_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added inline image: %s", epub_href)
                     except Exception as exc:
                         logger.warning(
@@ -684,6 +693,14 @@ def build_epub(
                             src_path.name,
                             exc,
                         )
+
+        # Verify ZIP integrity after close() — catches truncated writes or corrupt entries.
+        try:
+            bad = zipfile.ZipFile(output_path).testzip()
+            if bad is not None:
+                raise EpubError(f"EPUB ZIP verification failed: corrupt entry {bad!r}")
+        except zipfile.BadZipFile as exc:
+            raise EpubError(f"EPUB ZIP is not a valid ZIP file: {exc}") from exc
 
     except OSError as exc:
         raise EpubError(f"Failed to write EPUB to {output_path}: {exc}") from exc

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -687,3 +687,93 @@ def test_build_epub_raises_epub_error_on_write_failure(tmp_path: Path) -> None:
     with patch("zipfile.ZipFile", side_effect=OSError("disk full")):
         with pytest.raises(EpubError, match="Failed to write EPUB"):
             build_epub(conference, tmp_path, output)
+
+
+# ---------------------------------------------------------------------------
+# build_epub — ZIP integrity (#90)
+# ---------------------------------------------------------------------------
+
+
+def test_build_epub_zip_passes_testzip(tmp_path: Path) -> None:
+    """A freshly built EPUB must pass zipfile.testzip() with no corrupt entries."""
+    conference = _make_conference(n_talks=3)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    with zipfile.ZipFile(output) as zf:
+        result = zf.testzip()
+    assert result is None, (
+        f"zipfile.testzip() should return None for a valid ZIP, got: {result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_epub — image compression (#91)
+# ---------------------------------------------------------------------------
+
+
+def test_build_epub_images_stored_not_deflated(tmp_path: Path) -> None:
+    """JPEG images in the EPUB must be stored (ZIP_STORED), not Deflate-compressed."""
+    conference = _make_conference(n_talks=2)
+    output = tmp_path / "test.epub"
+
+    # Add a cover image and speaker photos so we have something to check
+    images_dir = tmp_path
+    cover_path = images_dir / "cover.jpg"
+    _make_jpeg(cover_path, size=(800, 450))
+
+    speakers_dir = images_dir / "speakers"
+    speakers_dir.mkdir()
+    for talk in conference.talks:
+        photo_path = speakers_dir / f"{talk.talk_index:03d}-{talk.speaker.replace(' ', '-')}.jpg"
+        _make_jpeg(photo_path, size=(300, 300))
+        talk.speaker_image_url = "https://www.churchofjesuschrist.org/imgs/test"
+
+    conference.cover_image_url = "https://www.churchofjesuschrist.org/imgs/cover"
+
+    build_epub(conference, images_dir, output)
+
+    with zipfile.ZipFile(output) as zf:
+        for info in zf.infolist():
+            if info.filename.startswith("images/"):
+                assert info.compress_type == zipfile.ZIP_STORED, (
+                    f"Image {info.filename!r} should be ZIP_STORED, "
+                    f"got compress_type={info.compress_type}"
+                )
+            elif info.filename.endswith((".xhtml", ".css", ".opf", ".xml")):
+                assert info.compress_type == zipfile.ZIP_DEFLATED, (
+                    f"Text file {info.filename!r} should be ZIP_DEFLATED, "
+                    f"got compress_type={info.compress_type}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_transcript — footnote markers (#92)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_transcript_materializes_data_value_for_empty_markers() -> None:
+    """Empty elements with data-value must have their number materialized as text content.
+
+    The Church website uses CSS content: attr(data-value) to render footnote
+    numbers. The <sup> has no text content — only data-value. After stripping
+    data-*, the number must still be visible.
+    """
+    html = '<p>Text.<sup class="marker" data-value="1"></sup></p>'
+    result = _sanitize_transcript(html)
+    assert ">1<" in result, (
+        f"data-value '1' must be materialized as text content, got: {result!r}"
+    )
+    assert "data-value" not in result, (
+        f"data-value attribute must still be stripped after materialization, got: {result!r}"
+    )
+
+
+def test_sanitize_transcript_preserves_existing_text_over_data_value() -> None:
+    """If an element already has text content, data-value must not overwrite it."""
+    html = '<span data-value="X">Already has text</span>'
+    result = _sanitize_transcript(html)
+    assert "Already has text" in result, "Existing text content must be preserved"
+    # data-value should be stripped, but it should NOT replace the existing text
+    assert ">X<" not in result, (
+        f"data-value 'X' must not overwrite existing text content, got: {result!r}"
+    )


### PR DESCRIPTION
## Summary
- Post-write `zipfile.testzip()` verification raises `EpubError` on any corrupt entry or bad ZIP (#90)
- All JPEG images (cover, speaker photos, inline) stored with `ZIP_STORED` to avoid double-compression and e-reader issues (#91)
- `_sanitize_transcript()` materializes `data-value` into text content before stripping `data-*`, fixing 404 invisible footnote markers that relied on the Church website's CSS `content: attr(data-value)` rule (#92)

## Test plan
- [ ] `pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py` — 202 tests pass
- [ ] `test_build_epub_zip_passes_testzip` — ZIP integrity check
- [ ] `test_build_epub_images_stored_not_deflated` — JPEG compression type verified
- [ ] `test_sanitize_transcript_materializes_data_value_for_empty_markers` — footnote number visible
- [ ] `test_sanitize_transcript_preserves_existing_text_over_data_value` — no overwrite of existing text

Closes #90, #91, #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)