### PR TITLE
fix: strip web CSS classes, dynamic dcterms:modified, .transcript img CSS

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -6,6 +6,7 @@ import io
 import logging
 import re
 import zipfile
+from datetime import datetime, timezone
 from html import escape
 from pathlib import Path
 
@@ -102,6 +103,13 @@ h1, h2, h3 {
 .transcript p {
   margin: 0.5em 0;
   text-align: justify;
+}
+
+.transcript img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 1em auto;
 }
 
 nav ol {
@@ -232,9 +240,10 @@ def _sanitize_transcript(
         if not tag.get_text(strip=True):
             tag.string = str(tag["data-value"])
 
-    # Strip data-* attributes (React/JS rendering artifacts) and random web IDs
-    # (e.g., id="p_fvoG6") — neither has meaning in an EPUB reading system.
-    # Preserve id attributes beginning with "note" (footnote anchors).
+    # Strip data-* attributes (React/JS rendering artifacts), random web IDs
+    # (e.g., id="p_fvoG6"), and web CSS class names that have no corresponding
+    # rules in the EPUB stylesheet. Preserve id attributes beginning with "note"
+    # (footnote anchors). <img> class attrs are already cleared above.
     for tag in soup.find_all(True):
         data_attrs = [attr for attr in tag.attrs if attr.startswith("data-")]
         for attr in data_attrs:
@@ -242,6 +251,8 @@ def _sanitize_transcript(
         tag_id = tag.get("id")
         if isinstance(tag_id, str) and not tag_id.startswith("note"):
             del tag["id"]
+        if "class" in tag.attrs:
+            del tag["class"]
 
     return _void_to_xhtml(str(soup))
 
@@ -501,7 +512,7 @@ def _content_opf(
     """
     uid = f"gencon-audiobook-{conference.year}-{conference.month:02d}"
     rights = escape(_COPYRIGHT.format(year=conference.year))
-    modified = f"{conference.year}-{conference.month:02d}-01T00:00:00Z"
+    modified = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     lines: list[str] = [
         '<?xml version="1.0" encoding="utf-8"?>',

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -825,3 +825,57 @@ def test_talk_page_has_epub_type_chapter(tmp_path: Path) -> None:
     assert 'epub:type="chapter"' in talk_content, (
         f"Talk page body must have epub:type='chapter', got: {talk_content[:300]!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# build_epub — cleanup (#96, #97, #98)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_transcript_strips_class_attributes() -> None:
+    """Web CSS class names must be stripped — they have no EPUB stylesheet rules."""
+    html = (
+        '<p class="body-block">Text</p>'
+        '<div class="imageWrapper-wTPPD"><ul class="bullet"><li>item</li></ul></div>'
+    )
+    result = _sanitize_transcript(html)
+    assert "class=" not in result, (
+        f"All class attributes must be stripped, got: {result!r}"
+    )
+    assert "Text" in result, "Paragraph text content must be preserved"
+    assert "item" in result, "List item content must be preserved"
+
+
+def test_build_epub_opf_modified_is_recent(tmp_path: Path) -> None:
+    """dcterms:modified in content.opf must reflect the actual build time."""
+    from datetime import datetime, timezone
+
+    # Capture window; strip microseconds since the OPF timestamp has second precision
+    before = datetime.now(timezone.utc).replace(microsecond=0)
+    conference = _make_conference(n_talks=1)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    after = datetime.now(timezone.utc).replace(microsecond=0)
+
+    opf = _epub_read(output, "content.opf").decode()
+    import re
+    match = re.search(r"<meta property=\"dcterms:modified\">([^<]+)</meta>", opf)
+    assert match, f"dcterms:modified not found in OPF: {opf[:500]!r}"
+    modified = datetime.fromisoformat(match.group(1).replace("Z", "+00:00"))
+    assert before <= modified <= after, (
+        f"dcterms:modified {modified.isoformat()} must be between "
+        f"{before.isoformat()} and {after.isoformat()}"
+    )
+
+
+def test_build_epub_css_has_transcript_img_rule(tmp_path: Path) -> None:
+    """The EPUB stylesheet must have a .transcript img rule to constrain inline images."""
+    conference = _make_conference(n_talks=1)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    css = _epub_read(output, "style.css").decode()
+    assert ".transcript img" in css, (
+        "style.css must include a .transcript img rule for inline image sizing"
+    )
+    assert "max-width" in css, "The .transcript img rule must include max-width"


### PR DESCRIPTION
## Summary
- Strip all `class` attributes from transcript elements — React CSS class names like `imageWrapper-wTPPD`, `bullet`, `body-block` have no rules in the EPUB stylesheet (#96)
- Replace static conference-date `dcterms:modified` with `datetime.now(timezone.utc)` so Calibre can detect updated EPUBs (#97)
- Add `.transcript img` CSS rule (`max-width: 100%; height: auto; display: block; margin: 1em auto`) to prevent inline images overflowing small screens (#98)

## Test plan
- [ ] `pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py` — 201 tests pass
- [ ] `test_sanitize_transcript_strips_class_attributes` — no class= in output
- [ ] `test_build_epub_opf_modified_is_recent` — timestamp within build window
- [ ] `test_build_epub_css_has_transcript_img_rule` — CSS rule present

Closes #96, #97, #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)