### PR TITLE
feat: compose portrait cover image from landscape source

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -26,6 +26,8 @@ _COPYRIGHT = (
 _MAX_PHOTO_WIDTH = 300   # px — speaker photos (per epub-style.md)
 _MAX_INLINE_WIDTH = 600  # px — inline body images (larger, they're content not thumbnails)
 _JPEG_QUALITY = 85       # JPEG quality for all embedded images
+_COVER_WIDTH = 1200      # px — portrait cover canvas width
+_COVER_HEIGHT = 1800     # px — portrait cover canvas height (2:3 ratio)
 
 # Void elements that must be self-closed in XHTML
 _VOID_RE = re.compile(
@@ -285,6 +287,44 @@ def _resize_image(src_path: Path, max_width: int) -> bytes:
 def _resize_photo(src_path: Path) -> bytes:
     """Load a speaker photo and resize to at most _MAX_PHOTO_WIDTH pixels wide."""
     return _resize_image(src_path, _MAX_PHOTO_WIDTH)
+
+
+def _make_portrait_cover(src_path: Path) -> bytes:
+    """Compose a portrait EPUB cover from a landscape source image.
+
+    The Church website provides a landscape banner (16:9) as the conference
+    cover image. EPUB covers should be portrait to display correctly in
+    reader library grids. This function places the landscape image centered
+    on a neutral gray 2:3 portrait canvas.
+
+    Args:
+        src_path: Path to the source landscape JPEG.
+
+    Returns:
+        JPEG bytes of the portrait cover (_COVER_WIDTH x _COVER_HEIGHT).
+    """
+    with Image.open(src_path) as raw:
+        src: Image.Image = raw.convert("RGB") if raw.mode != "RGB" else raw
+
+        # Scale source image to fit within canvas width with 50px margin each side
+        max_src_w = _COVER_WIDTH - 100
+        if src.width > max_src_w:
+            scale = max_src_w / src.width
+            new_w = max_src_w
+            new_h = int(src.height * scale)
+        else:
+            new_w, new_h = src.width, src.height
+        src_scaled: Image.Image = src.resize((new_w, new_h), Image.Resampling.LANCZOS)
+
+        canvas = Image.new("RGB", (_COVER_WIDTH, _COVER_HEIGHT), color=(128, 128, 128))
+        # Center horizontally; position in the upper-middle of the canvas
+        x = (_COVER_WIDTH - new_w) // 2
+        y = (_COVER_HEIGHT - new_h) // 2
+        canvas.paste(src_scaled, (x, y))
+
+        buf = io.BytesIO()
+        canvas.save(buf, format="JPEG", quality=_JPEG_QUALITY, optimize=True)
+    return buf.getvalue()
 
 
 def _xhtml_wrap(
@@ -708,10 +748,12 @@ def build_epub(
                 logger.debug("Added talk page: text/%s", d["filename"])
 
             if has_cover:
-                # JPEGs are already compressed — store them to avoid double-compression
-                # and compatibility issues on older e-ink readers.
-                zf.write(cover_src, "images/cover.jpg", compress_type=zipfile.ZIP_STORED)
-                logger.debug("Added cover image")
+                # Compose a portrait cover from the landscape source image —
+                # e-reader library grids expect portrait (2:3) covers.
+                # JPEGs are already compressed — store to avoid double-compression.
+                cover_bytes = _make_portrait_cover(cover_src)
+                zf.writestr("images/cover.jpg", cover_bytes, compress_type=zipfile.ZIP_STORED)
+                logger.debug("Added cover image (portrait composition)")
 
             for d in talk_file_data:
                 if d["photo_src"] and d["photo_epub_href"]:

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import re
 import zipfile
 from pathlib import Path
@@ -12,6 +13,7 @@ from PIL import Image
 from conftest import make_jpeg as _make_jpeg
 from gencon_audiobook.epub_builder import (
     EpubError,
+    _make_portrait_cover,
     _sanitize_transcript,
     _void_to_xhtml,
     build_epub,
@@ -879,3 +881,48 @@ def test_build_epub_css_has_transcript_img_rule(tmp_path: Path) -> None:
         "style.css must include a .transcript img rule for inline image sizing"
     )
     assert "max-width" in css, "The .transcript img rule must include max-width"
+
+
+# ---------------------------------------------------------------------------
+# _make_portrait_cover (#95)
+# ---------------------------------------------------------------------------
+
+
+def test_make_portrait_cover_produces_portrait_dimensions(tmp_path: Path) -> None:
+    """Portrait cover output must be taller than wide (height > width)."""
+    src = tmp_path / "landscape.jpg"
+    _make_jpeg(src, size=(800, 450))
+    result = _make_portrait_cover(src)
+
+    with Image.open(io.BytesIO(result)) as img:
+        assert img.height > img.width, (
+            f"Portrait cover must be taller than wide, got {img.width}x{img.height}"
+        )
+
+
+def test_make_portrait_cover_output_is_jpeg(tmp_path: Path) -> None:
+    """Portrait cover must be a valid JPEG."""
+    src = tmp_path / "landscape.jpg"
+    _make_jpeg(src, size=(800, 450))
+    result = _make_portrait_cover(src)
+
+    assert result[:2] == b"\xff\xd8", (
+        "Portrait cover bytes must start with JPEG magic bytes"
+    )
+
+
+def test_make_portrait_cover_uses_expected_dimensions(tmp_path: Path) -> None:
+    """Portrait cover must use the defined canvas dimensions (1200x1800)."""
+    from gencon_audiobook.epub_builder import _COVER_HEIGHT, _COVER_WIDTH
+
+    src = tmp_path / "landscape.jpg"
+    _make_jpeg(src, size=(800, 450))
+    result = _make_portrait_cover(src)
+
+    with Image.open(io.BytesIO(result)) as img:
+        assert img.width == _COVER_WIDTH, (
+            f"Cover width must be {_COVER_WIDTH}, got {img.width}"
+        )
+        assert img.height == _COVER_HEIGHT, (
+            f"Cover height must be {_COVER_HEIGHT}, got {img.height}"
+        )


### PR DESCRIPTION
## Summary
The Church website provides a 16:9 landscape banner as the conference cover image. EPUB readers expect portrait covers (~2:3) for correct display in library grids. Adds `_make_portrait_cover()` which centers the landscape image on a neutral gray 1200x1800 canvas and returns JPEG bytes.

## Test plan
- [ ] `pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py` — 201 tests pass
- [ ] `test_make_portrait_cover_produces_portrait_dimensions` — height > width
- [ ] `test_make_portrait_cover_output_is_jpeg` — valid JPEG bytes
- [ ] `test_make_portrait_cover_uses_expected_dimensions` — 1200x1800

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)