### PR TITLE
feat: session divider pages and speaker photo IIIF resolution upgrade

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -409,6 +409,23 @@ def _copyright_page(conference_title: str, year: int) -> str:
     return _xhtml_wrap("Copyright", body, css_href="../style.css")
 
 
+def _session_page(session_name: str) -> str:
+    """Generate a lightweight session divider XHTML page.
+
+    Session dividers give TOC session headers a dedicated destination page,
+    avoiding duplicate TOC targets where both the session header and the first
+    talk entry would otherwise link to the same XHTML file.
+
+    Args:
+        session_name: Display name for the session (e.g., "Saturday Morning Session").
+
+    Returns:
+        Complete XHTML document string.
+    """
+    body = f'<h1>{escape(session_name)}</h1>'
+    return _xhtml_wrap(session_name, body, css_href="../style.css")
+
+
 def _talk_page(
     talk_title: str,
     speaker: str,
@@ -457,7 +474,11 @@ def _talk_page(
     )
 
 
-def _nav_xhtml(conference: Conference, talk_hrefs: dict[int, str]) -> str:
+def _nav_xhtml(
+    conference: Conference,
+    talk_hrefs: dict[int, str],
+    session_hrefs: dict[int, str] | None = None,
+) -> str:
     """Generate the EPUB 3 navigation document with a nested session/talk TOC.
 
     nav.xhtml lives at the EPUB root, so talk hrefs use text/filename.xhtml.
@@ -465,6 +486,9 @@ def _nav_xhtml(conference: Conference, talk_hrefs: dict[int, str]) -> str:
     Args:
         conference: Conference with sessions and talks populated.
         talk_hrefs: Mapping from talk_index to href relative to nav.xhtml.
+        session_hrefs: Optional mapping from session.number to href for session
+            divider pages. When provided, session headers link to their divider
+            page instead of the first talk, avoiding duplicate TOC targets.
 
     Returns:
         Complete nav.xhtml XHTML document string.
@@ -478,9 +502,11 @@ def _nav_xhtml(conference: Conference, talk_hrefs: dict[int, str]) -> str:
     ]
     for session in conference.sessions:
         toc.append('    <li>')
-        # Link session headers to the first talk in that session so reading
-        # systems that require <a> (e.g., Kindle) don't drop the label.
-        if session.talks:
+        if session_hrefs and session.number in session_hrefs:
+            # Link to dedicated session divider page
+            toc.append(f'      <a href="{session_hrefs[session.number]}">{escape(session.name)}</a>')
+        elif session.talks:
+            # Fallback: link to first talk in session
             first_href = talk_hrefs[session.talks[0].talk_index]
             toc.append(f'      <a href="{first_href}">{escape(session.name)}</a>')
         else:
@@ -538,14 +564,18 @@ def _content_opf(
     talk_items: list[tuple[str, str]],
     image_items: list[tuple[str, str]],
     has_cover: bool,
+    spine_items: list[tuple[str, str]] | None = None,
 ) -> str:
     """Generate the OPF package document.
 
     Args:
         conference: Conference metadata for title, date, and rights fields.
-        talk_items: List of (manifest-id, href) for talk XHTML files, in spine order.
-        image_items: List of (manifest-id, href) for speaker photo images.
+        talk_items: List of (manifest-id, href) for all content XHTML files (manifest).
+        image_items: List of (manifest-id, href) for image files.
         has_cover: Whether cover.jpg is present.
+        spine_items: Optional ordered list of (manifest-id, href) for the spine. When
+            provided, this controls reading order (e.g., session dividers before talks).
+            When None, talk_items is used for the spine.
 
     Returns:
         OPF XML document as a string.
@@ -596,7 +626,7 @@ def _content_opf(
         '    <itemref idref="page-cover"/>',
         '    <itemref idref="page-copyright"/>',
     ]
-    for item_id, _ in talk_items:
+    for item_id, _ in (spine_items if spine_items is not None else talk_items):
         lines.append(f'    <itemref idref="{item_id}"/>')
     lines += ['  </spine>', '</package>']
     return "\n".join(lines) + "\n"
@@ -702,6 +732,43 @@ def build_epub(
         d["talk"].talk_index: f"text/{d['filename']}" for d in talk_file_data
     }
 
+    # Session divider pages: each session gets a lightweight page so TOC session
+    # headers can link to a unique destination rather than the first talk.
+    session_file_data: list[dict[str, str]] = []
+    session_hrefs: dict[int, str] = {}
+    for session in conference.sessions:
+        safe_name = sanitize_filename(session.name)
+        filename = f"session-{session.number:03d}-{safe_name}.xhtml"
+        item_id = f"session-{session.number:03d}"
+        href = f"text/{filename}"
+        session_file_data.append({
+            "session_name": session.name,
+            "filename": filename,
+            "item_id": item_id,
+        })
+        session_hrefs[session.number] = href
+
+    # Build interleaved spine: session divider page followed by its talks,
+    # for each session. This is the order content pages appear in the EPUB spine.
+    spine_items: list[tuple[str, str]] = []
+    talk_item_lookup: dict[int, tuple[str, str]] = {
+        d["talk"].talk_index: (d["item_id"], f"text/{d['filename']}") for d in talk_file_data
+    }
+    session_item_lookup: dict[int, tuple[str, str]] = {
+        session.number: (
+            f"session-{session.number:03d}",
+            f"text/session-{session.number:03d}-{sanitize_filename(session.name)}.xhtml",
+        )
+        for session in conference.sessions
+    }
+    for session in conference.sessions:
+        spine_items.append(session_item_lookup[session.number])
+        for talk in session.talks:
+            spine_items.append(talk_item_lookup[talk.talk_index])
+
+    # All XHTML content items for the manifest (order doesn't matter for manifest)
+    all_xhtml_items = list(session_item_lookup.values()) + talk_items
+
     logger.info("Building EPUB: %s (%d talks)", output_path.name, len(talks))
 
     try:
@@ -726,14 +793,24 @@ def build_epub(
             zf.writestr("style.css", _STYLESHEET)
             zf.writestr(
                 "content.opf",
-                _content_opf(conference, talk_items, image_items, has_cover),
+                _content_opf(
+                    conference,
+                    all_xhtml_items,
+                    image_items,
+                    has_cover,
+                    spine_items=spine_items,
+                ),
             )
-            zf.writestr("nav.xhtml", _nav_xhtml(conference, talk_hrefs))
+            zf.writestr("nav.xhtml", _nav_xhtml(conference, talk_hrefs, session_hrefs))
             zf.writestr("text/cover.xhtml", _cover_page(conference.title, has_cover))
             zf.writestr(
                 "text/copyright.xhtml",
                 _copyright_page(conference.title, conference.year),
             )
+
+            for d in session_file_data:
+                zf.writestr(f"text/{d['filename']}", _session_page(d["session_name"]))
+                logger.debug("Added session page: text/%s", d["filename"])
 
             for d in talk_file_data:
                 talk = d["talk"]

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -48,6 +48,26 @@ _CONFERENCE_URL_RE = re.compile(r"/study/general-conference/(\d{4})/(\d{2})(?:\?
 # Matches /study/general-conference/YYYYYYYY (decade-range index, e.g. 20202024)
 _DECADE_RANGE_RE = re.compile(r"/study/general-conference/(\d{4})(\d{4})$")
 
+
+def _upgrade_iiif(url: str) -> str:
+    """Rewrite IIIF size segment to request 800px-wide image.
+
+    The Church website serves images via an IIIF Image API endpoint. The
+    og:image and img src tags use small thumbnail sizes (e.g., 250px). This
+    function upgrades those to 800px for better quality in the EPUB output.
+    Both percent-encoded (%21...%2C) and plain (!N,) forms are handled.
+    Non-IIIF URLs pass through unchanged.
+
+    Args:
+        url: Original image URL.
+
+    Returns:
+        URL with IIIF size parameter upgraded to 800px, or original URL unchanged.
+    """
+    url = re.sub(r"/full/%21\d+%2C/", "/full/%21800%2C/", url)
+    url = re.sub(r"/full/!\d+,/", "/full/!800,/", url)
+    return url
+
 # Matches /study/general-conference/YYYY/MM/talk-id (individual talk URL).
 # Modern talk slugs use a numeric-prefix + speaker-name format with no hyphens
 # (e.g., "11oaks", "12christofferson"). Session-level links DO contain hyphens
@@ -843,8 +863,8 @@ def parse_talk_page(html: str, talk_url: str) -> dict:
             continue
         src = img.get("src")
         if isinstance(src, str) and "/imgs/" in src and validate_url(src):
-            result["speaker_image_url"] = src
-            logger.debug("speaker_image_url (primary /imgs/): %s", src)
+            result["speaker_image_url"] = _upgrade_iiif(src)
+            logger.debug("speaker_image_url (primary /imgs/): %s", result["speaker_image_url"])
             break
 
     if not result["speaker_image_url"]:
@@ -853,7 +873,7 @@ def parse_talk_page(html: str, talk_url: str) -> dict:
         if isinstance(og, Tag):
             content = og.get("content")
             if isinstance(content, str) and validate_url(content):
-                result["speaker_image_url"] = content
+                result["speaker_image_url"] = _upgrade_iiif(content)
 
     return result
 
@@ -1019,13 +1039,6 @@ def _find_cover_image(soup: BeautifulSoup) -> str | None:
     Upgrades IIIF-style size parameters to 800px wide so the cover is
     suitable for an ebook cover rather than a social-sharing thumbnail.
     """
-    def _upgrade_iiif(url: str) -> str:
-        """Rewrite IIIF size segment to request 800px-wide image."""
-        # Handles both percent-encoded (%21...%2C) and plain (!N,) forms
-        url = re.sub(r"/full/%21\d+%2C/", "/full/%21800%2C/", url)
-        url = re.sub(r"/full/!\d+,/", "/full/!800,/", url)
-        return url
-
     # Primary: og:image meta tag
     og = soup.find("meta", property="og:image")
     if isinstance(og, Tag):

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -926,3 +926,45 @@ def test_make_portrait_cover_uses_expected_dimensions(tmp_path: Path) -> None:
         assert img.height == _COVER_HEIGHT, (
             f"Cover height must be {_COVER_HEIGHT}, got {img.height}"
         )
+
+
+# ---------------------------------------------------------------------------
+# build_epub — session divider pages (#99)
+# ---------------------------------------------------------------------------
+
+
+def test_build_epub_has_session_divider_pages(tmp_path: Path) -> None:
+    """Each session must have a dedicated divider page in the EPUB."""
+    conference = _make_conference(n_talks=4)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    names = _epub_names(output)
+    session_pages = [n for n in names if n.startswith("text/session-")]
+    assert len(session_pages) == len(conference.sessions), (
+        f"Expected {len(conference.sessions)} session pages, got {session_pages}"
+    )
+
+
+def test_nav_session_headers_link_to_divider_pages(tmp_path: Path) -> None:
+    """Session header links in nav.xhtml must point to session divider pages, not talks."""
+    conference = _make_conference(n_talks=4)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    nav = _epub_read(output, "nav.xhtml").decode()
+    assert "text/session-" in nav, (
+        "nav.xhtml session headers must link to session divider pages"
+    )
+
+
+def test_build_epub_spine_includes_session_pages(tmp_path: Path) -> None:
+    """The OPF spine must include session divider pages before their talks."""
+    conference = _make_conference(n_talks=4)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    opf = _epub_read(output, "content.opf").decode()
+    assert "session-001" in opf, (
+        "content.opf spine must include session-001 divider page"
+    )

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -442,3 +442,46 @@ def test_find_cover_image_leaves_non_iiif_url_unchanged() -> None:
     soup = BeautifulSoup(html, "html.parser")
     result = _find_cover_image(soup)
     assert result == "https://www.churchofjesuschrist.org/imgs/cover.jpg"
+
+
+# ---------------------------------------------------------------------------
+# _upgrade_iiif — module-level function (#100)
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_iiif_rewrites_percent_encoded_form() -> None:
+    """_upgrade_iiif must rewrite percent-encoded IIIF size to 800px."""
+    from gencon_audiobook.scraper import _upgrade_iiif
+
+    url = "https://www.churchofjesuschrist.org/imgs/abc/full/%21250%2C/0/default"
+    result = _upgrade_iiif(url)
+    assert "%21800%2C" in result, (
+        f"Expected %21800%2C in result, got: {result!r}"
+    )
+    assert "%21250%2C" not in result, (
+        f"Original size should be replaced, got: {result!r}"
+    )
+
+
+def test_upgrade_iiif_rewrites_plain_form() -> None:
+    """_upgrade_iiif must rewrite plain !N, IIIF size to 800px."""
+    from gencon_audiobook.scraper import _upgrade_iiif
+
+    url = "https://www.churchofjesuschrist.org/imgs/abc/full/!250,/0/default"
+    result = _upgrade_iiif(url)
+    assert "!800," in result, (
+        f"Expected !800, in result, got: {result!r}"
+    )
+    assert "!250," not in result, (
+        f"Original size should be replaced, got: {result!r}"
+    )
+
+
+def test_upgrade_iiif_leaves_non_iiif_url_unchanged() -> None:
+    """_upgrade_iiif must return non-IIIF URLs unchanged."""
+    from gencon_audiobook.scraper import _upgrade_iiif
+
+    url = "https://www.churchofjesuschrist.org/imgs/abc/photo.jpg"
+    assert _upgrade_iiif(url) == url, (
+        f"Non-IIIF URL must pass through unchanged, got: {_upgrade_iiif(url)!r}"
+    )


### PR DESCRIPTION
## Summary
- Add `_session_page()` and generate `text/session-NNN-name.xhtml` per session. TOC session headers link to divider pages instead of the first talk, eliminating duplicate TOC targets that cause position indicator bugs on Kindle/Kobo (#99)
- Hoist `_upgrade_iiif()` to module level in `scraper.py` and apply it to speaker photo URLs — photos now download at 800px source instead of ~250px thumbnails, producing sharper results after resize to 300px (#100)

## Test plan
- [ ] `pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py` — 204 tests pass
- [ ] `test_build_epub_has_session_divider_pages` — one page per session in ZIP
- [ ] `test_nav_session_headers_link_to_divider_pages` — nav links to session pages
- [ ] `test_build_epub_spine_includes_session_pages` — session pages in OPF spine
- [ ] `test_upgrade_iiif_rewrites_percent_encoded_form` / `plain_form` / `non_iiif`

Closes #99, #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)