### PR TITLE
chore: add PR template and CLAUDE.md rule for Closes #N

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+
+## Test plan
+
+
+Closes #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,3 +47,7 @@ No emojis anywhere — not in terminal output, log messages, generated files, or
 ## GitHub Issues
 All changes require a GitHub issue before work begins. Cosmetic fixes (typos, whitespace) are
 the only exception. Use `gh issue create` following the project's issue format.
+
+Every PR description body must include `Closes #N` for each issue it resolves. GitHub reads
+the PR body (not the commit message) to auto-close issues on squash merge — omitting it leaves
+issues open after the PR lands.


### PR DESCRIPTION
## Summary
- Adds \`.github/PULL_REQUEST_TEMPLATE.md\` so every new PR starts with a Summary, Test plan, and \`Closes #\` line pre-filled
- Adds a rule to \`CLAUDE.md\` explaining that \`Closes #N\` must appear in the PR body (not just commit messages) for GitHub to auto-close issues on squash merge

## Test plan
- [ ] Open a new PR and confirm the template pre-populates

No issue — this is a process/tooling change with no functional code impact.