### PR TITLE
docs: update phase-2-epub, scraper-pipeline, and release-testing for v0.1.5

### DIFF
--- a/docs/phases/phase-2-epub.md
+++ b/docs/phases/phase-2-epub.md
@@ -47,21 +47,24 @@ Define `EpubError(Exception)`.
 
 ### EPUB File Structure
 
-The final ZIP must contain these files in this order:
+The final ZIP must contain these files:
 
 ```
-mimetype                          # first file, uncompressed, no newline
+mimetype                                        # first file, uncompressed, no newline
 META-INF/container.xml
-OEBPS/content.opf
-OEBPS/nav.xhtml
-OEBPS/stylesheet.css
-OEBPS/cover.xhtml
-OEBPS/copyright.xhtml
-OEBPS/chapter-001-001.xhtml       # session 1, talk 1
-OEBPS/chapter-001-002.xhtml       # session 1, talk 2
+content.opf
+nav.xhtml
+style.css
+text/cover.xhtml
+text/copyright.xhtml
+text/session-001-Saturday-Morning-Session.xhtml # session divider pages
+text/session-002-Saturday-Afternoon-Session.xhtml
 ...
-OEBPS/images/cover.jpg
-OEBPS/images/speaker-001.jpg
+text/talk-001-Opening-Remarks.xhtml             # one per talk
+text/talk-002-Talk-Title.xhtml
+...
+images/cover.jpg                                # ZIP_STORED (already compressed)
+images/spk-001-Speaker-Name.jpg                 # ZIP_STORED
 ...
 ```
 
@@ -74,53 +77,74 @@ application/epub+zip
 Must be the FIRST file in the ZIP. Must be stored uncompressed (`zipfile.ZIP_STORED`).
 Must NOT have a trailing newline.
 
+### Image compression
+
+All JPEG images (cover, speaker photos, inline images) must be stored with
+`compress_type=zipfile.ZIP_STORED`. JPEGs are already compressed — deflating them wastes
+CPU on every page load for negligible savings, and double-compression causes compatibility
+issues on some older e-ink readers.
+
+All other files (XHTML, CSS, OPF, XML) use the default `ZIP_DEFLATED`.
+
 ### `META-INF/container.xml`
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
   <rootfiles>
-    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
   </rootfiles>
 </container>
 ```
 
-### `OEBPS/content.opf`
+### `content.opf`
 
 EPUB 3 package document. Must include:
 - `<metadata>` with dc:title, dc:creator ("General Conference"), dc:date (year), dc:rights
   (Intellectual Reserve copyright notice), dc:identifier (unique ID)
+- `<meta property="dcterms:modified">` set to the actual build timestamp
+  (`datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")`), not a static date
 - `<manifest>` listing every file in the EPUB with correct media types
-- `<spine>` listing reading order: cover, copyright, then chapters in order
+- `<spine>` listing reading order: cover, copyright, then interleaved session divider pages
+  and talks (session page followed by all its talks, for each session)
 
-### `OEBPS/nav.xhtml`
+### `nav.xhtml`
 
-EPUB 3 navigation document. The TOC must be **nested by session**:
+EPUB 3 navigation document. Must contain two `<nav>` elements:
+
+**TOC nav** — nested by session, session headers link to their divider page:
 
 ```html
 <nav epub:type="toc" id="toc">
-  <h1>Table of Contents</h1>
+  <h2>Table of Contents</h2>
   <ol>
+    <li><a href="text/cover.xhtml">Conference Title</a></li>
+    <li><a href="text/copyright.xhtml">Copyright</a></li>
     <li>
-      <span>Saturday Morning Session</span>
+      <a href="text/session-001-Saturday-Morning-Session.xhtml">Saturday Morning Session</a>
       <ol>
-        <li><a href="chapter-001-001.xhtml">Opening Remarks -- President Henry B. Eyring</a></li>
-        <li><a href="chapter-001-002.xhtml">Talk Title -- Speaker Name</a></li>
-      </ol>
-    </li>
-    <li>
-      <span>Saturday Afternoon Session</span>
-      <ol>
-        ...
+        <li><a href="text/talk-001-Opening-Remarks.xhtml">Opening Remarks — President Henry B. Eyring</a></li>
+        <li><a href="text/talk-002-Talk-Title.xhtml">Talk Title — Speaker Name</a></li>
       </ol>
     </li>
   </ol>
 </nav>
 ```
 
-Session entries use `<span>` (not `<a>`) since they have no content of their own.
+**Landmarks nav** — required for Kindle and accessibility tools:
 
-### `OEBPS/stylesheet.css`
+```html
+<nav epub:type="landmarks" hidden="hidden">
+  <h2>Landmarks</h2>
+  <ol>
+    <li><a epub:type="cover" href="text/cover.xhtml">Cover</a></li>
+    <li><a epub:type="toc" href="#toc">Table of Contents</a></li>
+    <li><a epub:type="bodymatter" href="text/copyright.xhtml">Start of Content</a></li>
+  </ol>
+</nav>
+```
+
+### `style.css`
 
 Theme-safe stylesheet. See `.claude/rules/epub-style.md` for the complete rules.
 
@@ -160,10 +184,11 @@ p {
     margin: 0 auto 1em auto;
 }
 
-.session-divider {
-    margin: 2em 0 1em 0;
-    font-size: 1.1em;
-    font-weight: bold;
+.transcript img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 1em auto;
 }
 ```
 
@@ -173,7 +198,7 @@ p {
 - `font-family`
 - any numeric value followed by `px` or `pt`
 
-### `OEBPS/cover.xhtml`
+### `text/cover.xhtml`
 
 ```xhtml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -181,15 +206,15 @@ p {
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
 <head>
   <title>Cover</title>
-  <link rel="stylesheet" type="text/css" href="stylesheet.css"/>
+  <link rel="stylesheet" type="text/css" href="../style.css"/>
 </head>
 <body epub:type="cover">
-  <img src="images/cover.jpg" alt="Conference cover" style="max-width: 100%; height: auto;"/>
+  <img src="../images/cover.jpg" alt="Conference cover" style="max-width: 100%; height: auto;"/>
 </body>
 </html>
 ```
 
-### `OEBPS/copyright.xhtml`
+### `text/copyright.xhtml`
 
 First page after cover. Must include:
 - Conference title
@@ -198,9 +223,21 @@ First page after cover. Must include:
   of The Church of Jesus Christ of Latter-day Saints."
 - "This is an unofficial tool not affiliated with The Church of Jesus Christ of Latter-day Saints."
 
-### Chapter XHTML files
+### Session divider pages
 
-One file per talk, named `chapter-SSS-TTT.xhtml` (zero-padded session and talk numbers).
+One lightweight XHTML page per session, e.g. `text/session-001-Saturday-Morning-Session.xhtml`.
+Contains only the session name as an `<h1>`. These give TOC session headers a unique
+destination so they don't share a target with the first talk in the session.
+
+```xhtml
+<body>
+  <h1>Saturday Morning Session</h1>
+</body>
+```
+
+### Talk XHTML files
+
+One file per talk, named `text/talk-NNN-{sanitized-title}.xhtml`.
 
 Structure:
 ```xhtml
@@ -208,14 +245,16 @@ Structure:
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
 <head>
-  <title>{talk.title}</title>
-  <link rel="stylesheet" type="text/css" href="stylesheet.css"/>
+  <title>{talk.title} — {talk.speaker}</title>
+  <link rel="stylesheet" type="text/css" href="../style.css"/>
 </head>
-<body>
-  <img class="speaker-photo" src="images/speaker-{talk.talk_index:03d}.jpg" alt="{talk.speaker}"/>
+<body epub:type="chapter">
+  <img class="speaker-photo" src="../images/spk-{talk.talk_index:03d}-{safe_speaker}.jpg" alt="{talk.speaker}"/>
   <p class="byline">{talk.speaker}</p>
   <h1>{talk.title}</h1>
-  {sanitized_transcript_html}
+  <div class="transcript">
+    {sanitized_transcript_html}
+  </div>
 </body>
 </html>
 ```
@@ -226,23 +265,39 @@ If no speaker photo is available, omit the `<img>` element entirely.
 
 Before embedding transcript HTML from the scraper:
 - Strip all `<script>` and `<style>` elements and their content
-- Remove `src` attributes pointing to external URLs (images from the Church site are already
-  downloaded — replace `src` with the local embedded image path, or remove if not available)
-- Remove `href` attributes pointing to external URLs from `<a>` tags (keep the text, remove the link)
-- Remove `onclick`, `onload`, and other event handlers
-- Ensure all tags are properly closed (XHTML requires this)
+- Materialize `data-value` attributes into text content before stripping — the Church site
+  uses `<sup data-value="1"></sup>` (no text content) with CSS `content: attr(data-value)`
+  to render footnote numbers; after stripping `data-*`, the number would vanish without this step
+- Strip all `data-*` attributes (React/JS rendering artifacts)
+- Strip all `class` attributes (Church site CSS classes have no EPUB stylesheet rules)
+- Strip random web IDs (e.g. `id="p_fvoG6"`); preserve IDs beginning with `"note"` (footnote anchors)
+- Unwrap all `<a>` tags — external links (scripture refs, footnote links) don't resolve in EPUB;
+  keep display text and child elements (e.g. `<sup>`), remove the wrapper
+- Remove `src` attributes pointing to external URLs; replace with local embedded image path
+  where available, or remove the element if not
+- Remove `javascript:` and `data:` URI schemes
+- Ensure all tags are properly closed (XHTML requires this — use `_void_to_xhtml()` to
+  self-close void elements like `<br>`, `<img>`, `<hr>`)
 - All HTML entities must be valid XML entities
 
 ### Images
 
-- Copy `cover.jpg` from `images_dir` to `OEBPS/images/cover.jpg`
-- Locate each talk's speaker photo using the same filename formula as `downloader.py`:
-  `images_dir/speakers/{talk.talk_index:03d}-{sanitize_filename(talk.speaker)}.jpg`
-  Copy to `OEBPS/images/speaker-{talk.talk_index:03d}.jpg`
-- If a speaker photo file does not exist for a talk, omit the `<img>` element in that chapter
-- All images must be JPEG — convert if necessary using Pillow
-- Speaker photos: resize to max 300px wide (maintaining aspect ratio) before embedding
-- If cover.jpg does not exist: skip the cover page image, use a text-only cover page
+- **Cover image**: compose a portrait cover using `_make_portrait_cover()` — the Church's
+  `og:image` is a 16:9 landscape banner; compose it onto a 1200x1800 gray canvas (2:3 portrait)
+  so it displays correctly in reader library grids. Write as `images/cover.jpg` with `ZIP_STORED`.
+- **Speaker photos**: locate each talk's photo at
+  `images_dir/speakers/{talk.talk_index:03d}-{sanitize_filename(talk.speaker)}.jpg`.
+  Resize to max 300px wide (maintaining aspect ratio) before embedding. Source photos are
+  fetched at 800px via IIIF URL upgrade in the scraper — resize at embed time, not download time.
+  Write with `ZIP_STORED`.
+- If a speaker photo file does not exist for a talk, omit the `<img>` element in that chapter.
+- All images must be JPEG.
+
+### Post-write ZIP verification
+
+After the `with zipfile.ZipFile(...)` block closes, call `testzip()` on the output file.
+Raise `EpubError` if any entry is corrupt or the file is not a valid ZIP. This catches
+truncated writes or filesystem-level damage early.
 
 ---
 
@@ -273,19 +328,35 @@ In Phase 1 the `--epub-only` flag prints "epub generation coming in Phase 2" —
 
 Required tests:
 - `test_build_epub_produces_valid_zip` — output is a valid ZIP file
+- `test_build_epub_zip_passes_testzip` — `testzip()` returns None (no corrupt entries)
 - `test_build_epub_mimetype_is_first_and_uncompressed` — mimetype is first entry, stored uncompressed
-- `test_build_epub_contains_required_files` — container.xml, content.opf, nav.xhtml, stylesheet.css
-- `test_build_epub_chapter_count` — chapter files match total talk count
+- `test_build_epub_contains_required_files` — container.xml, content.opf, nav.xhtml, style.css
+- `test_build_epub_chapter_count` — talk files match total talk count
+- `test_build_epub_has_session_divider_pages` — one session page per session
 - `test_build_epub_toc_nested_by_session` — nav.xhtml contains session groupings with nested talk entries
+- `test_nav_session_headers_link_to_divider_pages` — session TOC links point to session pages, not talks
+- `test_nav_has_landmarks` — nav.xhtml has `epub:type="landmarks"` with cover, toc, bodymatter entries
+- `test_cover_page_has_epub_type_cover` — cover.xhtml body has `epub:type="cover"`
+- `test_talk_page_has_epub_type_chapter` — talk XHTML bodies have `epub:type="chapter"`
+- `test_build_epub_spine_includes_session_pages` — OPF spine includes session divider pages
 - `test_build_epub_all_talks_present` — every talk's title appears in a chapter XHTML file
 - `test_build_epub_images_embedded` — images/cover.jpg and speaker images exist in ZIP
 - `test_build_epub_images_are_jpeg` — all embedded images are JPEG (check magic bytes)
+- `test_build_epub_images_stored_not_deflated` — all `images/*` entries use `ZIP_STORED`
 - `test_build_epub_no_external_urls` — no `src` or `href` pointing to http(s):// URLs in content files
-- `test_build_epub_css_no_color_declarations` — stylesheet.css contains no `color:` or `background`
-- `test_build_epub_css_no_font_family` — stylesheet.css contains no `font-family`
-- `test_build_epub_css_no_absolute_sizes` — stylesheet.css contains no `px` or `pt` text sizes
+- `test_build_epub_css_no_color_declarations` — style.css contains no `color:` or `background`
+- `test_build_epub_css_no_font_family` — style.css contains no `font-family`
+- `test_build_epub_css_no_absolute_sizes` — style.css contains no `px` or `pt` text sizes
+- `test_build_epub_css_has_transcript_img_rule` — style.css has `.transcript img` rule with `max-width`
 - `test_build_epub_copyright_page_present` — copyright.xhtml exists and mentions Intellectual Reserve
 - `test_build_epub_missing_speaker_photo_skips_img` — talk with no photo produces chapter without `<img>`
+- `test_build_epub_opf_modified_is_recent` — `dcterms:modified` reflects actual build time (within 60s)
+- `test_sanitize_transcript_materializes_data_value_for_empty_markers` — `<sup data-value="1"></sup>` becomes `<sup>1</sup>`
+- `test_sanitize_transcript_preserves_existing_text_over_data_value` — existing text not overwritten by data-value
+- `test_sanitize_transcript_strips_class_attributes` — all `class=` attributes removed
+- `test_make_portrait_cover_produces_portrait_dimensions` — output height > width
+- `test_make_portrait_cover_output_is_jpeg` — output starts with JPEG magic bytes
+- `test_make_portrait_cover_uses_expected_dimensions` — output is 1200x1800
 
 ---
 
@@ -336,10 +407,12 @@ java -jar epubcheck.jar "test_output/<conference name>/<conference name>.epub"
 # Expected: 0 errors (warnings acceptable)
 
 # 6. Open epub on multiple platforms and verify:
-#    a. Apple Books (macOS/iOS): cover, TOC shows sessions with nested talks, chapters
-#       open to correct talk, speaker photo visible, transcript readable
+#    a. Apple Books (macOS/iOS): cover displays as portrait, TOC shows sessions with nested talks,
+#       session TOC entries link to session divider pages (not directly to first talk),
+#       chapters open to correct talk, speaker photo visible, transcript readable,
+#       footnote numbers visible inline
 #    b. Google Play Books (Android): same checks
-#    c. Calibre (desktop): same checks
+#    c. Calibre (desktop): landmarks nav visible in TOC panel, same content checks
 #    d. Send to Kindle: verify clean conversion and TOC works
 
 # 7. Theme compatibility — test on at least 2 reader apps:

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -24,7 +24,7 @@ test-release\Scripts\activate
 # Mac/Linux:
 source test-release/bin/activate
 
-pip install gencon-audiobook==0.1.2   # replace with the version being tested
+pip install gencon-audiobook==0.1.5   # replace with the version being tested
 ```
 
 Verify the entry point and version:
@@ -50,11 +50,15 @@ gencon-audiobook --epub-only --conference "April 2024" --output ~/gc-test
 - Command exits 0 with a completion report printed
 - `~/gc-test/April 2024 General Conference/April 2024 General Conference.epub` exists and is 10–20 MB
 - Open the epub in Calibre, Apple Books, or your reader and verify:
-  - Cover page with conference image
+  - Cover page displays as portrait (taller than wide) in the library grid
   - Copyright page (Intellectual Reserve, Inc.)
   - Navigable TOC with session headings and talk entries
+  - Session headings in the TOC link to session divider pages (not directly to the first talk)
+  - Landmarks nav visible in Calibre's TOC panel (cover, TOC, Start of Content entries)
   - Per-talk chapters with speaker photo, name byline, and full transcript
+  - Footnote numbers visible inline (not blank superscripts)
   - No garbled text (mojibake) in speaker names or talk titles
+  - No web CSS class names visible as raw text in transcripts
 
 ---
 

--- a/docs/scraper-pipeline.md
+++ b/docs/scraper-pipeline.md
@@ -50,20 +50,22 @@ flowchart TD
     end
 
     subgraph EPUB["epub_builder.py"]
-        E1["Sanitize transcripts"]
-        E2["Resize speaker photos"]
-        E3["Assemble EPUB 3 ZIP"]
-        E1 --> E3
-        E2 --> E3
+        E1["Sanitize transcripts\n(strip classes, data-*, materialize\nfootnote markers, unwrap links)"]
+        E2["Resize speaker photos\n(800px IIIF source → 300px embed)"]
+        E3["Compose portrait cover\n(landscape source → 1200x1800 canvas)"]
+        E4["Assemble EPUB 3 ZIP\n(verify with testzip after write)"]
+        E1 --> E4
+        E2 --> E4
+        E3 --> E4
         subgraph ZIP["EPUB 3 ZIP contents"]
             direction LR
-            Z1["mimetype\n(uncompressed)"]
+            Z1["mimetype\n(ZIP_STORED)"]
             Z2["META-INF/\ncontainer.xml"]
-            Z3["content.opf\nnav.xhtml\nstyle.css"]
-            Z4["text/\ncover.xhtml\ncopyright.xhtml\ntalk-NNN-*.xhtml"]
-            Z5["images/\ncover.jpg\nspk-NNN-*.jpg"]
+            Z3["content.opf\nnav.xhtml (toc + landmarks)\nstyle.css"]
+            Z4["text/\ncover.xhtml\ncopyright.xhtml\nsession-NNN-*.xhtml\ntalk-NNN-*.xhtml"]
+            Z5["images/\ncover.jpg\nspk-NNN-*.jpg\n(all ZIP_STORED)"]
         end
-        E3 --> ZIP
+        E4 --> ZIP
     end
 
     AUDIO --> M4B["output.m4b"]


### PR DESCRIPTION
## Summary
- \`docs/phases/phase-2-epub.md\`: major update — file structure, nav.xhtml examples, session divider pages, portrait cover, ZIP_STORED for JPEGs, landmarks nav, epub:type attributes, transcript sanitization rules (class stripping, data-value materialization), post-write ZIP verification, updated test list
- \`docs/scraper-pipeline.md\`: EPUB subgraph updated to show portrait cover composition, IIIF 800px photo fetch, sanitization detail, session divider pages, ZIP_STORED annotation
- \`docs/release-testing.md\`: EPUB smoke test checklist updated with v0.1.5-specific checks (portrait cover, session dividers, landmarks nav, footnote visibility)

No code changes — docs only.