### PR TITLE
fix: add nav.xhtml to spine with linear="no" to resolve epubcheck RSC-011

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -623,6 +623,9 @@ def _content_opf(
     lines += [
         '  </manifest>',
         '  <spine>',
+        # nav.xhtml must be in the spine for landmarks href="#toc" to satisfy RSC-011.
+        # linear="no" keeps it out of the normal reading flow.
+        '    <itemref idref="nav" linear="no"/>',
         '    <itemref idref="page-cover"/>',
         '    <itemref idref="page-copyright"/>',
     ]

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -968,3 +968,18 @@ def test_build_epub_spine_includes_session_pages(tmp_path: Path) -> None:
     assert "session-001" in opf, (
         "content.opf spine must include session-001 divider page"
     )
+
+
+def test_build_epub_spine_includes_nav_linear_no(tmp_path: Path) -> None:
+    """nav.xhtml must appear in the spine with linear='no' to satisfy epubcheck RSC-011.
+
+    The landmarks nav links to nav.xhtml via href='#toc'. epubcheck RSC-011 requires
+    that any linked resource is a spine item. linear='no' keeps it out of normal reading flow.
+    """
+    conference = _make_conference(n_talks=1)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    opf = _epub_read(output, "content.opf").decode()
+    assert 'idref="nav"' in opf, "nav must be referenced in the spine"
+    assert 'linear="no"' in opf, "nav spine entry must have linear='no'"


### PR DESCRIPTION
## Summary
- Adds `<itemref idref="nav" linear="no"/>` to the OPF spine in `_content_opf()`
- Adds `test_build_epub_spine_includes_nav_linear_no` to verify the fix

The landmarks nav references nav.xhtml via `href="#toc"`. epubcheck RSC-011 requires that any linked resource be a spine item. `linear="no"` satisfies the constraint without surfacing nav.xhtml as a browsable chapter in reading apps.

## Test plan
- [ ] CI passes
- [ ] Run epubcheck on a freshly built EPUB and confirm 0 errors

Closes #110