### PR TITLE
feat: cache scraped conference metadata to skip re-scraping on re-runs

### DIFF
--- a/src/gencon_audiobook/cache.py
+++ b/src/gencon_audiobook/cache.py
@@ -6,6 +6,7 @@ import dataclasses
 import json
 import logging
 from pathlib import Path
+from typing import Any
 
 from .models import Conference, InlineImage, Session, Talk
 
@@ -98,7 +99,7 @@ def load_cache(directory: Path, expected_url: str) -> Conference | None:
 # ---------------------------------------------------------------------------
 
 
-def _conference_from_dict(d: dict) -> Conference:  # type: ignore[type-arg]
+def _conference_from_dict(d: dict[str, Any]) -> Conference:
     """Reconstruct a Conference dataclass from a plain dict."""
     sessions = [_session_from_dict(s) for s in d["sessions"]]
     return Conference(
@@ -111,13 +112,13 @@ def _conference_from_dict(d: dict) -> Conference:  # type: ignore[type-arg]
     )
 
 
-def _session_from_dict(d: dict) -> Session:  # type: ignore[type-arg]
+def _session_from_dict(d: dict[str, Any]) -> Session:
     """Reconstruct a Session dataclass from a plain dict."""
     talks = [_talk_from_dict(t) for t in d["talks"]]
     return Session(name=d["name"], number=d["number"], talks=talks)
 
 
-def _talk_from_dict(d: dict) -> Talk:  # type: ignore[type-arg]
+def _talk_from_dict(d: dict[str, Any]) -> Talk:
     """Reconstruct a Talk dataclass from a plain dict.
 
     ``duration_seconds`` is always set to 0.0 — it was stripped during

--- a/src/gencon_audiobook/cache.py
+++ b/src/gencon_audiobook/cache.py
@@ -1,0 +1,143 @@
+"""Persist and restore scraped Conference objects to avoid redundant HTTP requests."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+from pathlib import Path
+
+from .models import Conference, InlineImage, Session, Talk
+
+logger = logging.getLogger(__name__)
+
+CACHE_VERSION = 1
+CACHE_FILENAME = "conference.json"
+
+
+def save_cache(conference: Conference, directory: Path) -> Path:
+    """Serialise a Conference to JSON in the given directory.
+
+    Strips ``duration_seconds`` from each Talk before writing — that field is
+    computed by ``audio.py`` at conversion time, not by the scraper, so it must
+    not be treated as stable cached data.
+
+    Args:
+        conference: Fully-populated Conference returned by the scraper.
+        directory: Output directory for this conference (must already exist or
+            be created by the caller before this function is invoked).
+
+    Returns:
+        Path of the written cache file.
+    """
+    conf_dict = dataclasses.asdict(conference)
+    for session in conf_dict["sessions"]:
+        for talk in session["talks"]:
+            talk.pop("duration_seconds", None)
+
+    envelope = {"cache_version": CACHE_VERSION, "conference": conf_dict}
+    cache_path = directory / CACHE_FILENAME
+    cache_path.write_text(
+        json.dumps(envelope, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    logger.debug("Wrote conference cache: %s", cache_path)
+    return cache_path
+
+
+def load_cache(directory: Path, expected_url: str) -> Conference | None:
+    """Load a cached Conference from disk if the cache is valid.
+
+    Returns ``None`` (and logs a warning) if the file is missing, contains
+    corrupt JSON, has a version mismatch, or records a different conference URL
+    than ``expected_url``.  Never raises — callers should fall back to scraping.
+
+    Args:
+        directory: Directory that may contain ``conference.json``.
+        expected_url: The URL of the conference the caller intends to use.
+            Must match the URL stored in the cache for the cache to be accepted.
+
+    Returns:
+        A reconstructed ``Conference``, or ``None`` if the cache cannot be used.
+    """
+    cache_path = directory / CACHE_FILENAME
+    if not cache_path.exists():
+        return None
+
+    try:
+        envelope = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Conference cache is unreadable, will re-scrape: %s", exc)
+        return None
+
+    if envelope.get("cache_version") != CACHE_VERSION:
+        logger.warning(
+            "Conference cache version mismatch (got %r, expected %d), will re-scrape",
+            envelope.get("cache_version"),
+            CACHE_VERSION,
+        )
+        return None
+
+    conf_dict = envelope.get("conference", {})
+    if conf_dict.get("conference_url") != expected_url:
+        logger.warning(
+            "Conference cache URL mismatch (cached %r, expected %r), will re-scrape",
+            conf_dict.get("conference_url"),
+            expected_url,
+        )
+        return None
+
+    try:
+        return _conference_from_dict(conf_dict)
+    except (KeyError, TypeError, ValueError) as exc:
+        logger.warning("Conference cache is malformed, will re-scrape: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Internal reconstruction helpers
+# ---------------------------------------------------------------------------
+
+
+def _conference_from_dict(d: dict) -> Conference:  # type: ignore[type-arg]
+    """Reconstruct a Conference dataclass from a plain dict."""
+    sessions = [_session_from_dict(s) for s in d["sessions"]]
+    return Conference(
+        title=d["title"],
+        year=d["year"],
+        month=d["month"],
+        cover_image_url=d["cover_image_url"],
+        sessions=sessions,
+        conference_url=d["conference_url"],
+    )
+
+
+def _session_from_dict(d: dict) -> Session:  # type: ignore[type-arg]
+    """Reconstruct a Session dataclass from a plain dict."""
+    talks = [_talk_from_dict(t) for t in d["talks"]]
+    return Session(name=d["name"], number=d["number"], talks=talks)
+
+
+def _talk_from_dict(d: dict) -> Talk:  # type: ignore[type-arg]
+    """Reconstruct a Talk dataclass from a plain dict.
+
+    ``duration_seconds`` is always set to 0.0 — it was stripped during
+    ``save_cache()`` and will be recomputed by ``audio.py``.
+    """
+    inline_images = [
+        InlineImage(url=img["url"], alt=img["alt"], asset_id=img["asset_id"])
+        for img in d.get("inline_images", [])
+    ]
+    return Talk(
+        title=d["title"],
+        speaker=d["speaker"],
+        talk_url=d["talk_url"],
+        mp3_url=d.get("mp3_url"),
+        transcript_html=d.get("transcript_html"),
+        speaker_image_url=d.get("speaker_image_url"),
+        inline_images=inline_images,
+        session_name=d.get("session_name", ""),
+        session_number=d.get("session_number", 0),
+        talk_number=d.get("talk_number", 0),
+        talk_index=d.get("talk_index", 0),
+        duration_seconds=0.0,
+    )

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -15,10 +15,10 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
+from .cache import CACHE_FILENAME, load_cache, save_cache
 from .downloader import DownloadError, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
-from .cache import CACHE_FILENAME, load_cache, save_cache
 from .models import Talk
 from .scraper import ScraperError, fetch_available_conferences, scrape_conference
 

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -18,6 +18,7 @@ from .audio import AudioError, BuildStats, build_m4b
 from .downloader import DownloadError, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
+from .cache import CACHE_FILENAME, load_cache, save_cache
 from .models import Talk
 from .scraper import ScraperError, fetch_available_conferences, scrape_conference
 
@@ -214,6 +215,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     help="Overwrite existing output files instead of skipping.",
 )
 @click.option(
+    "--force-scrape",
+    is_flag=True,
+    default=False,
+    help="Re-scrape conference data from the website even if a local cache exists.",
+)
+@click.option(
     "--bitrate",
     default=None,
     help="AAC encoding bitrate (e.g., 32k, 64k, 128k). Default: match source MP3.",
@@ -232,6 +239,7 @@ def main(
     epub_only: bool,
     verbose: bool,
     overwrite: bool,
+    force_scrape: bool,
     bitrate: str | None,
     sample_rate: int | None,
 ) -> None:
@@ -246,6 +254,7 @@ def main(
             audiobook_only=audiobook_only,
             epub_only=epub_only,
             overwrite=overwrite,
+            force_scrape=force_scrape,
             bitrate=bitrate,
             sample_rate=sample_rate,
         )
@@ -336,6 +345,7 @@ def _run(
     audiobook_only: bool,
     epub_only: bool,
     overwrite: bool,
+    force_scrape: bool,
     bitrate: str | None,
     sample_rate: int | None,
 ) -> None:
@@ -345,16 +355,33 @@ def _run(
 
     conf_title, conf_url = _select_conference(conference)
 
-    # Scrape conference details — progress bar printed inside scrape_conference()
-    t0 = time.monotonic()
-    try:
-        conf_obj = scrape_conference(conf_url)
-    except ScraperError as exc:
-        click.echo(f"Error: {exc}", err=True)
-        sys.exit(1)
-    phase_times["scrape"] = time.monotonic() - t0
+    # Resolve the output directory early — conf_title matches conf_obj.title, so we
+    # can check the cache before scraping rather than after.
+    conf_output_dir = output_dir / conf_title
 
-    conf_output_dir = output_dir / conf_obj.title
+    # Load from cache if available and --force-scrape not set.
+    conf_obj = None
+    if not force_scrape:
+        conf_obj = load_cache(conf_output_dir, expected_url=conf_url)
+        if conf_obj is not None:
+            console.print(
+                f"Loaded {len(conf_obj.talks)} talks from cache "
+                f"({conf_output_dir / CACHE_FILENAME}). "
+                "Use --force-scrape to refresh."
+            )
+
+    if conf_obj is None:
+        # Scrape conference details — progress bar printed inside scrape_conference()
+        t0 = time.monotonic()
+        try:
+            conf_obj = scrape_conference(conf_url)
+        except ScraperError as exc:
+            click.echo(f"Error: {exc}", err=True)
+            sys.exit(1)
+        phase_times["scrape"] = time.monotonic() - t0
+        conf_output_dir.mkdir(parents=True, exist_ok=True)
+        save_cache(conf_obj, conf_output_dir)
+        logger.info("Saved conference cache: %s", conf_output_dir / CACHE_FILENAME)
 
     # Wire up the log file now that we know where output goes.
     try:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,186 @@
+"""Tests for conference metadata caching (cache.py)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gencon_audiobook.cache import (
+    CACHE_FILENAME,
+    CACHE_VERSION,
+    load_cache,
+    save_cache,
+)
+from gencon_audiobook.models import Conference, InlineImage, Session, Talk
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_conference() -> Conference:
+    """Return a representative Conference for cache tests."""
+    inline = InlineImage(
+        url="https://assets.churchofjesuschrist.org/img.jpg",
+        alt="A map",
+        asset_id="abc123",
+    )
+    talk1 = Talk(
+        title="Opening Remarks",
+        speaker="President Henry B. Eyring",
+        talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/talk1",
+        mp3_url="https://assets.churchofjesuschrist.org/audio/talk1.mp3",
+        transcript_html="<p>Welcome.</p>",
+        speaker_image_url="https://assets.churchofjesuschrist.org/photo1.jpg",
+        inline_images=[inline],
+        session_name="Saturday Morning Session",
+        session_number=1,
+        talk_number=1,
+        talk_index=1,
+        duration_seconds=124.5,
+    )
+    talk2 = Talk(
+        title="Another Talk",
+        speaker="Elder Test Speaker",
+        talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/talk2",
+        mp3_url=None,
+        transcript_html=None,
+        speaker_image_url=None,
+        inline_images=[],
+        session_name="Saturday Morning Session",
+        session_number=1,
+        talk_number=2,
+        talk_index=2,
+        duration_seconds=0.0,
+    )
+    session = Session(name="Saturday Morning Session", number=1, talks=[talk1, talk2])
+    return Conference(
+        title="April 2024 General Conference",
+        year=2024,
+        month=4,
+        cover_image_url="https://assets.churchofjesuschrist.org/cover.jpg",
+        sessions=[session],
+        conference_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_round_trip(tmp_path: "pytest.TempPathFactory") -> None:
+    """save_cache → load_cache must reconstruct a Conference equal to the original.
+
+    duration_seconds is the only field that should differ (set to 0.0 on load).
+    """
+    conf = _make_conference()
+    save_cache(conf, tmp_path)
+
+    loaded = load_cache(tmp_path, expected_url=conf.conference_url)
+    assert loaded is not None, "load_cache should return a Conference, not None"
+
+    assert loaded.title == conf.title
+    assert loaded.year == conf.year
+    assert loaded.month == conf.month
+    assert loaded.cover_image_url == conf.cover_image_url
+    assert loaded.conference_url == conf.conference_url
+    assert len(loaded.sessions) == len(conf.sessions)
+
+    orig_talk = conf.talks[0]
+    loaded_talk = loaded.talks[0]
+    assert loaded_talk.title == orig_talk.title
+    assert loaded_talk.speaker == orig_talk.speaker
+    assert loaded_talk.talk_url == orig_talk.talk_url
+    assert loaded_talk.mp3_url == orig_talk.mp3_url
+    assert loaded_talk.transcript_html == orig_talk.transcript_html
+    assert loaded_talk.speaker_image_url == orig_talk.speaker_image_url
+    assert loaded_talk.session_name == orig_talk.session_name
+    assert loaded_talk.session_number == orig_talk.session_number
+    assert loaded_talk.talk_number == orig_talk.talk_number
+    assert loaded_talk.talk_index == orig_talk.talk_index
+
+    assert len(loaded_talk.inline_images) == 1
+    orig_img = orig_talk.inline_images[0]
+    loaded_img = loaded_talk.inline_images[0]
+    assert loaded_img.url == orig_img.url
+    assert loaded_img.alt == orig_img.alt
+    assert loaded_img.asset_id == orig_img.asset_id
+
+
+def test_save_cache_strips_duration_seconds(tmp_path: "pytest.TempPathFactory") -> None:
+    """duration_seconds must be stripped during save and reset to 0.0 on load."""
+    conf = _make_conference()
+    assert conf.talks[0].duration_seconds == 124.5, "pre-condition: non-zero duration"
+
+    save_cache(conf, tmp_path)
+    loaded = load_cache(tmp_path, expected_url=conf.conference_url)
+
+    assert loaded is not None
+    for talk in loaded.talks:
+        assert talk.duration_seconds == 0.0, (
+            f"duration_seconds must be 0.0 after load, got {talk.duration_seconds}"
+        )
+
+
+def test_load_cache_missing_file(tmp_path: "pytest.TempPathFactory") -> None:
+    """load_cache returns None when no cache file exists."""
+    result = load_cache(tmp_path, expected_url="https://example.com/conf")
+    assert result is None, "Expected None for missing cache file"
+
+
+def test_load_cache_corrupt_json(tmp_path: "pytest.TempPathFactory") -> None:
+    """load_cache returns None (not an exception) for corrupt JSON."""
+    (tmp_path / CACHE_FILENAME).write_text("this is not valid json{{{", encoding="utf-8")
+    result = load_cache(tmp_path, expected_url="https://example.com/conf")
+    assert result is None, "Expected None for corrupt JSON"
+
+
+def test_load_cache_version_mismatch(tmp_path: "pytest.TempPathFactory") -> None:
+    """load_cache returns None when cache_version does not match CACHE_VERSION."""
+    conf = _make_conference()
+    save_cache(conf, tmp_path)
+
+    cache_path = tmp_path / CACHE_FILENAME
+    data = json.loads(cache_path.read_text(encoding="utf-8"))
+    data["cache_version"] = CACHE_VERSION + 99
+    cache_path.write_text(json.dumps(data), encoding="utf-8")
+
+    result = load_cache(tmp_path, expected_url=conf.conference_url)
+    assert result is None, "Expected None for version mismatch"
+
+
+def test_load_cache_url_mismatch(tmp_path: "pytest.TempPathFactory") -> None:
+    """load_cache returns None when the cached URL differs from expected_url."""
+    conf = _make_conference()
+    save_cache(conf, tmp_path)
+
+    result = load_cache(
+        tmp_path,
+        expected_url="https://www.churchofjesuschrist.org/study/general-conference/2025/04",
+    )
+    assert result is None, "Expected None when expected_url does not match cached URL"
+
+
+def test_save_cache_writes_expected_filename(tmp_path: "pytest.TempPathFactory") -> None:
+    """save_cache must write to CACHE_FILENAME in the given directory."""
+    conf = _make_conference()
+    path = save_cache(conf, tmp_path)
+
+    assert path == tmp_path / CACHE_FILENAME, (
+        f"Expected cache at {tmp_path / CACHE_FILENAME}, got {path}"
+    )
+    assert path.exists(), "Cache file must exist after save_cache"
+
+
+def test_save_cache_is_valid_json(tmp_path: "pytest.TempPathFactory") -> None:
+    """The cache file must contain valid JSON with the expected envelope structure."""
+    conf = _make_conference()
+    path = save_cache(conf, tmp_path)
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["cache_version"] == CACHE_VERSION
+    assert "conference" in data
+    assert data["conference"]["title"] == conf.title


### PR DESCRIPTION
## Summary
- Adds `src/gencon_audiobook/cache.py` with `save_cache()` and `load_cache()` — serialises the `Conference` object to `conference.json` in the output directory after each scrape
- Subsequent runs load from cache instead of making ~38 HTTP requests to the Church site
- Cache is invalidated automatically on schema version bump or conference URL mismatch
- Adds `--force-scrape` CLI flag to bypass the cache when fresh data is needed
- `duration_seconds` is stripped on save and reset to `0.0` on load (it is recomputed by `audio.py`, not the scraper)
- 8 new tests in `tests/test_cache.py` covering round-trip, version mismatch, URL mismatch, missing file, corrupt JSON, and duration stripping

## Test plan
- [ ] CI passes
- [ ] First run writes `conference.json` to the output directory
- [ ] Second run prints "Loaded N talks from cache." with no scraping progress bar
- [ ] `--force-scrape` shows the scraping progress bar and rewrites the cache

Closes #19