### PR TITLE
fix: suppress INFO log lines from console in non-verbose mode

### DIFF
--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -41,9 +41,9 @@ def _setup_logging(verbose: bool) -> None:
     """Configure console logging using Rich.
 
     Args:
-        verbose: If True, show DEBUG messages on the console; otherwise INFO.
+        verbose: If True, show DEBUG messages on the console; otherwise WARNING.
     """
-    log_level = logging.DEBUG if verbose else logging.INFO
+    log_level = logging.DEBUG if verbose else logging.WARNING
     console_handler = RichHandler(
         level=log_level,
         console=console,


### PR DESCRIPTION
## Summary
Changes the console log handler level from `INFO` to `WARNING` in `_setup_logging()`. INFO messages (cache saved, download counts, etc.) now only appear in the log file, not on the console. `--verbose` continues to show DEBUG and above.

## Test plan
- [ ] CI passes
- [ ] Run without `--verbose` and confirm no INFO lines appear
- [ ] Run with `--verbose` and confirm INFO/DEBUG lines still appear

Closes #116