### PR TITLE
feat: EPUB 3 popup footnotes via epub:type noteref/footnote

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -122,6 +122,12 @@ nav ol {
 nav li {
   margin: 0.25em 0;
 }
+
+aside {
+  margin: 1.5em 0 0.5em;
+  padding-left: 1em;
+  font-size: 0.85em;
+}
 """
 
 
@@ -229,11 +235,34 @@ def _sanitize_transcript(
             ):
                 del tag.attrs[attr]
 
-    # Unwrap all <a> tags — scripture refs, footnote links, and cross-refs all
-    # point outside the EPUB container (RSC-033, RSC-026, RSC-007). Keeps display
-    # text and child elements (e.g., <sup> superscripts) inline.
+    # Preserve internal footnote links as EPUB 3 noterefs; unwrap everything else.
+    # Links whose href starts with "#note" connect superscript markers to footnote
+    # bodies on the same page. Adding epub:type="noteref" lets modern e-readers
+    # (Apple Books, Kobo, Thorium) display the footnote as a dismissible popup.
+    # All other <a> tags (scripture refs, cross-refs) point outside the EPUB
+    # container (RSC-033, RSC-026) and must be unwrapped.
     for a_tag in soup.find_all("a"):
-        a_tag.unwrap()
+        href = str(a_tag.get("href") or "")
+        if href.startswith("#note"):
+            # Strip all attrs except href; add EPUB 3 noteref semantics.
+            a_tag.attrs = {"href": href, "epub:type": "noteref"}
+        else:
+            a_tag.unwrap()
+
+    # Wrap footnote body elements in <aside epub:type="footnote">.
+    # The Church site uses id="note1", id="note2", etc. on <p> or <div> elements
+    # for the footnote content. Moving the id to the wrapping <aside> satisfies
+    # EPUB 3 structure: the noteref href="#note1" links to the aside, which the
+    # reader renders as a popup.
+    for tag in soup.find_all(
+        lambda t: isinstance(t.get("id"), str) and t["id"].startswith("note")
+    ):
+        note_id = str(tag["id"])
+        del tag["id"]
+        aside = soup.new_tag("aside")
+        aside["epub:type"] = "footnote"
+        aside["id"] = note_id
+        tag.wrap(aside)
 
     # Materialize data-value into text for elements that rely on CSS
     # content: attr(data-value) for display (e.g., footnote markers on the

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -173,12 +173,51 @@ def test_sanitize_transcript_unwraps_scripture_ref_links() -> None:
     assert "Alma 5:12" in result, "Link text must be preserved"
 
 
-def test_sanitize_transcript_unwraps_note_ref_links() -> None:
-    """Footnote note-ref links must be unwrapped — superscript preserved, <a> removed."""
+def test_sanitize_transcript_noteref_link_preserved_with_epub_type() -> None:
+    """Internal footnote links (href=#note*) must be preserved as EPUB 3 noterefs.
+
+    The old behavior unwrapped all <a> tags. Now href='#note*' links survive
+    sanitization so e-readers can render the footnote as a popup.
+    """
     html = '<p>See this.<a class="note-ref" href="#note1"><sup class="marker">1</sup></a></p>'
     result = _sanitize_transcript(html)
-    assert "<a" not in result, f"<a> tag must be removed, got: {result!r}"
-    assert "<sup" in result, "Superscript must be preserved after unwrapping"
+    assert 'href="#note1"' in result, f"Footnote href must be preserved, got: {result!r}"
+    assert 'epub:type="noteref"' in result, f"epub:type noteref must be added, got: {result!r}"
+    assert "<sup" in result, "Superscript inside noteref must be preserved"
+
+
+def test_sanitize_transcript_non_note_links_still_unwrapped() -> None:
+    """Non-footnote <a> tags (scripture refs, cross-refs) must still be unwrapped."""
+    html = '<p>See <a href="https://www.churchofjesuschrist.org/scripture/1ne/1.1">1 Ne. 1:1</a>.</p>'
+    result = _sanitize_transcript(html)
+    assert "<a" not in result, f"External <a> must be unwrapped, got: {result!r}"
+    assert "1 Ne. 1:1" in result, "Link text must be preserved after unwrapping"
+
+
+def test_sanitize_transcript_footnote_body_wrapped_in_aside() -> None:
+    """Footnote body elements (id='note*') must be wrapped in <aside epub:type='footnote'>."""
+    html = '<p id="note1">This is the footnote text.</p>'
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote" id="note1">' in result, (
+        f"Footnote body must be wrapped in <aside epub:type='footnote'>, got: {result!r}"
+    )
+    assert "This is the footnote text." in result, "Footnote text must be preserved"
+
+
+def test_sanitize_transcript_footnote_id_moves_to_aside() -> None:
+    """The id='note*' must be on the <aside>, not the inner element."""
+    html = '<p id="note1">Footnote.</p>'
+    result = _sanitize_transcript(html)
+    # The <p> must not carry the id (it moved to the aside)
+    assert "<p id=" not in result, f"id must move to <aside>, not stay on <p>, got: {result!r}"
+    assert '<aside epub:type="footnote" id="note1">' in result
+
+
+def test_sanitize_transcript_preserves_note_ids() -> None:
+    """id='note*' must be preserved (on the wrapping aside) for noteref links to resolve."""
+    html = '<p id="note1">Footnote text.</p>'
+    result = _sanitize_transcript(html)
+    assert 'id="note1"' in result, f"note id must be preserved on aside, got: {result!r}"
 
 
 def test_sanitize_transcript_strips_data_attributes() -> None:


### PR DESCRIPTION
## Summary

- Footnote links (`href="#note*"`) are now preserved through sanitization and annotated with `epub:type="noteref"` — previously they were unwrapped along with all other `<a>` tags
- Footnote body elements (`id="note*"`) are wrapped in `<aside epub:type="footnote" id="...">` with the `id` moved from the inner element to the aside
- Modern e-readers (Apple Books, Kobo, Thorium, Google Play Books) detect this markup and show footnotes as dismissible popovers; older readers degrade to an in-page jump
- Added minimal `aside` CSS (margin/padding/font-size in `em` only — no color, background-color, or font-family per epub-style.md)
- Updated one existing test that expected footnote links to be unwrapped; added 4 new targeted tests

## Test plan

- [ ] All 229 unit tests pass (CI)
- [ ] Open a built EPUB in Apple Books and tap a footnote superscript — should pop up as an overlay
- [ ] Open same EPUB in a reader without popup footnote support — should jump to footnote anchor at bottom of chapter

Closes #113

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>