### PR TITLE
docs: sync all documentation with v0.1.6 features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,9 @@ See `docs/spec.md` for the full specification. Critical points:
 - m4b chapters: ffmpeg FFMETADATA1 format — mutagen is for verification only, NOT writing
 - Conference scope: scrape ALL available conferences; user selects
 - ffmpeg: check system PATH first, then static-ffmpeg fallback
-- CLI flags: `--audiobook-only` / `--epub-only`
+- CLI flags: `--audiobook-only` / `--epub-only` / `--force-scrape`
+- Conference metadata cached in `conference.json` after first scrape; `cache.py` handles serialize/deserialize
+- Image downloads parallelized via `ThreadPoolExecutor` (8 workers, thread-local sessions); audio sequential
 
 ## Copyright
 Downloaded content is copyright Intellectual Reserve, Inc. Tool code is MIT licensed.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ gencon-audiobook --bitrate 32k --sample-rate 22050
 
 # Show detailed progress in the terminal
 gencon-audiobook --verbose
+
+# Add paragraph numbers to EPUB transcripts (useful for study groups and citations)
+gencon-audiobook --epub-paragraph-numbers
 ```
 
 For the full options reference, file size guide, and platform compatibility notes, see the [User Guide](https://github.com/XeroIP/gencon-audiobook/wiki/User-Guide).

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ gencon-audiobook --output ~/Books
 # Rebuild existing output files
 gencon-audiobook --overwrite
 
+# Re-scrape fresh data from the Church website (bypass local cache)
+gencon-audiobook --force-scrape
+
 # Reduce file size (lower bitrate and sample rate)
 gencon-audiobook --bitrate 32k --sample-rate 22050
 
@@ -70,12 +73,14 @@ For the full options reference, file size guide, and platform compatibility note
     April 2024 General Conference.m4b    # Chaptered audiobook
     April 2024 General Conference.epub   # Transcript companion
     cover.jpg                            # Conference cover image
+    conference.json                      # Cached conference metadata (skip re-scraping)
     audio/                               # Downloaded MP3 files
     speakers/                            # Speaker photos
+    inline/                              # Inline body images embedded in the EPUB
     gencon-audiobook.log                 # Full DEBUG log for troubleshooting
 ```
 
-Running the tool a second time skips files that already exist. Use `--overwrite` to rebuild.
+Running the tool a second time skips files that already exist and loads conference metadata from `conference.json` instead of re-scraping the Church website. Use `--overwrite` to rebuild output files. Use `--force-scrape` to bypass the metadata cache and fetch fresh data from the Church website.
 
 ---
 
@@ -111,11 +116,13 @@ pytest tests/test_integration.py -v -m integration
 src/gencon_audiobook/
   cli.py            Click entry point
   scraper.py        Fetch and parse conference listings and talk pages
-  downloader.py     Download MP3s, cover, and speaker photos
+  downloader.py     Download MP3s, cover, speaker photos, and inline images (parallel)
   audio.py          Convert MP3 to AAC, assemble chaptered m4b
   epub_builder.py   Build EPUB 3 ZIP from transcripts and images
   ffmpeg_manager.py Locate ffmpeg/ffprobe (PATH first, static-ffmpeg fallback)
-  models.py         Conference / Session / Talk dataclasses
+  cache.py          Save/load Conference metadata to conference.json (skip re-scraping)
+  models.py         Conference / Session / Talk / InlineImage dataclasses
+  progress.py       Custom Rich progress column (TimeRemainingWithLabel)
   utils.py          sanitize_filename(), validate_url()
 
 tests/
@@ -124,6 +131,7 @@ tests/
   test_downloader.py      Mocked HTTP tests
   test_audio.py           Audio pipeline with generated silent fixtures
   test_epub.py            EPUB structure and content validation
+  test_cache.py           Cache serialization and version compatibility
   test_cli.py             CLI behavior (all external calls mocked)
   test_utils.py           Filename sanitization and URL validation
   test_ffmpeg_manager.py  ffmpeg/ffprobe discovery and caching

--- a/docs/scraper-pipeline.md
+++ b/docs/scraper-pipeline.md
@@ -12,27 +12,34 @@ flowchart TD
         S3["Fetch conference listing"]
         S4["Parse Session / Talk stubs"]
         S5["Fetch each talk page"]
-        S6["Extract mp3_url, transcript_html,\nspeaker_image_url, speaker name"]
+        S6["Extract mp3_url, transcript_html,\nspeaker_image_url, inline_images, speaker name"]
         S1 --> S2 --> S3 --> S4 --> S5 --> S6
     end
 
-    SCRAPER --> MODELS
+    SCRAPER --> CACHE
+
+    subgraph CACHE["cache.py"]
+        C1["Save Conference to conference.json\n(after first scrape)"]
+        C2["Load from conference.json\n(subsequent runs — skip scraping)\n--force-scrape bypasses this"]
+    end
+
+    CACHE --> MODELS
 
     subgraph MODELS["models.py"]
         direction LR
         M1["Conference\ntitle, year, month,\nsessions, cover_image_url"]
         M2["Session\nname, number, talks"]
-        M3["Talk\ntitle, speaker, mp3_url,\ntranscript_html, speaker_image_url,\ntalk_index, session_name"]
-        M1 --- M2 --- M3
+        M3["Talk\ntitle, speaker, mp3_url,\ntranscript_html, speaker_image_url,\ninline_images, talk_index, session_name"]
+        M4["InlineImage\nurl, asset_id"]
+        M1 --- M2 --- M3 --- M4
     end
 
     MODELS --> DOWNLOADER
 
     subgraph DOWNLOADER["downloader.py"]
-        D1["Download MP3s\naudio/{index}-{title}.mp3"]
-        D2["Download cover\ncover.jpg"]
-        D3["Download speaker photos\nspeakers/{index}-{speaker}.jpg"]
-        D4["JPEG conversion applied to all images\nResume: skips files already at correct size"]
+        D1["Images (parallel, up to 8 threads)\nDownload cover → cover.jpg\nDownload photos → speakers/{index}-{speaker}.jpg\nDownload body imgs → inline/{index}-{asset_id}.jpg"]
+        D2["Audio (sequential, 0.5s delay)\nDownload MP3s → audio/{index}-{title}.mp3"]
+        D3["JPEG conversion via Pillow\nIIIF URLs rewritten to 800px\nResume: skips files already at correct size"]
     end
 
     DOWNLOADER --> AUDIO

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -20,6 +20,7 @@ gencon-audiobook --epub-only              # Produce only the epub
 gencon-audiobook --output ~/Books         # Custom output directory
 gencon-audiobook --verbose                # Enable DEBUG-level console output
 gencon-audiobook --overwrite              # Overwrite existing output files
+gencon-audiobook --force-scrape           # Bypass conference.json cache, re-scrape from website
 ```
 
 ## Output Structure
@@ -29,12 +30,16 @@ gencon-audiobook --overwrite              # Overwrite existing output files
   April 2024 General Conference.m4b     # Complete audiobook with chapters
   April 2024 General Conference.epub    # Transcript companion
   cover.jpg                             # Conference cover image
+  conference.json                       # Cached conference metadata (skip re-scraping on rerun)
   audio/                                # Downloaded and converted audio
     001-sanitized-title.mp3             # Zero-padded talk_index, sanitized title
     001-sanitized-title.m4a             # Intermediate AAC (deleted after m4b is built)
     ...
   speakers/                             # Speaker photos (for reference and epub)
     001-speaker-name.jpg                # Zero-padded talk_index, sanitized speaker name
+    ...
+  inline/                               # Inline body images from talk transcripts
+    001-asset-id.jpg                    # Zero-padded talk_index, sanitized asset ID
     ...
   gencon-audiobook.log                  # Full DEBUG log for troubleshooting
 ```
@@ -76,23 +81,33 @@ churchofjesuschrist.org
         |
         v
   scraper.py  -------------------------------->  models.py
-  (html.parser, primary+fallback selectors)       Conference / Session / Talk
+  (html.parser, primary+fallback selectors)       Conference / Session / Talk / InlineImage
   (all conferences, user selects one)
         |
         v
+  cache.py  (conference.json)
+  (save after first scrape; load on subsequent runs to skip scraping)
+  (--force-scrape bypasses cache)
+        |
+        v
   downloader.py  ----------------------------->  output_dir/
-  (.tmp + rename, resume, retry/backoff)          |-- *.mp3
-  (JPEG conversion via Pillow)                    |-- cover.jpg
-                                                  +-- speakers/*.jpg
+  (images: parallel via ThreadPoolExecutor)       |-- audio/*.mp3
+  (audio: sequential, 0.5s delay)                 |-- cover.jpg
+  (.tmp + rename, resume, retry/backoff)          |-- speakers/*.jpg
+  (JPEG conversion via Pillow)                    +-- inline/*.jpg
+  (IIIF URLs rewritten to 800px resolution)
         |
         |---------------------------------------->  audio.py
-        |                                           (ffmpeg: MP3->AAC-LC 64k/44.1kHz/mono,
-        |                                            concat, FFMETADATA1 chapters, cover art)
+        |                                           (ffmpeg: MP3->AAC-LC, source-matched
+        |                                            bitrate/sample-rate, mono,
+        |                                            FFMETADATA1 chapters, cover art)
         |                                           -> Conference.m4b
         |
         +---------------------------------------->  epub_builder.py
                                                     (manual EPUB 3 ZIP of XHTML,
-                                                     theme-safe CSS, nested TOC by session)
+                                                     portrait cover, theme-safe CSS,
+                                                     session dividers, popup footnotes,
+                                                     inline body images, nested TOC)
                                                     -> Conference.epub
 ```
 
@@ -110,6 +125,12 @@ class ConferenceRef:
     month: int   # 4 for April, 10 for October
 
 @dataclass
+class InlineImage:
+    """A single inline body image referenced in a talk's transcript."""
+    url: str       # Full URL (IIIF, rewritten to 800px before download)
+    asset_id: str  # Unique identifier used as the filename component
+
+@dataclass
 class Talk:
     title: str
     speaker: str
@@ -117,6 +138,7 @@ class Talk:
     mp3_url: str | None = None
     transcript_html: str | None = None
     speaker_image_url: str | None = None
+    inline_images: list[InlineImage] = field(default_factory=list)  # body images from transcript
     session_name: str = ""
     session_number: int = 0   # 1-indexed
     talk_number: int = 0      # 1-indexed within the session
@@ -181,14 +203,16 @@ Dependencies intentionally NOT used:
 
 | Module | Responsibility |
 |---|---|
-| `models.py` | Dataclasses: Conference, Session, Talk |
+| `models.py` | Dataclasses: Conference, Session, Talk, InlineImage |
 | `utils.py` | `sanitize_filename()`, `validate_url()` (allowlist enforcement) |
 | `scraper.py` | Fetch all conference URLs, parse conference listing, parse talk pages, return Conference objects |
-| `downloader.py` | Download MP3s, cover, speaker photos with retry/backoff, .tmp+rename, resume |
+| `downloader.py` | Download MP3s, cover, speaker photos, and inline images; parallel image downloads via ThreadPoolExecutor |
+| `cache.py` | Serialize/deserialize Conference to/from conference.json; skip re-scraping on subsequent runs |
 | `ffmpeg_manager.py` | Locate ffmpeg and ffprobe (system PATH first, static-ffmpeg fallback) |
 | `audio.py` | Convert MP3->AAC, assemble m4b with FFMETADATA1 chapters and cover art |
-| `epub_builder.py` | Generate EPUB 3 manually as ZIP of XHTML with theme-safe CSS |
-| `cli.py` | Click CLI entry point, conference selection, disk space warning, error handling |
+| `epub_builder.py` | Generate EPUB 3 manually as ZIP of XHTML; portrait cover, session dividers, popup footnotes, inline images, theme-safe CSS |
+| `progress.py` | Custom Rich progress column: `TimeRemainingWithLabel` with "remaining" label and compact mode |
+| `cli.py` | Click CLI entry point, conference selection, cache load/save, disk space warning, error handling |
 | `__init__.py` | Package version string |
 | `__main__.py` | `python -m gencon_audiobook` support |
 


### PR DESCRIPTION
## Summary

- Fixes factual error in Technical-Decisions.md §13: console log level is WARNING (not INFO) by default
- Adds 6 new Technical-Decisions sections: conference caching, parallel image downloads, EPUB popup footnotes, portrait cover, ZIP_STORED for JPEG, IIIF URL upgrade
- Updates Architecture.md data flow, module descriptions, and models to reflect cache.py, progress.py, InlineImage, inline images, session dividers, popup footnotes, and ZIP_STORED
- Adds `--force-scrape` to README usage examples and output structure docs
- Adds `cache.py`, `progress.py`, `test_cache.py`, `InlineImage`, and `inline/` directory to README project layout
- Updates `conference.json` and `inline/` in output structure (README, spec)
- Updates data flow in spec.md to show cache layer and parallel download split
- Updates scraper-pipeline.md with cache.py node, InlineImage in models, parallel image download grouping
- Updates CLAUDE.md with `--force-scrape`, cache.py, and parallel download notes
- Wiki updated directly to master (Architecture, Technical-Decisions, User-Guide)

Closes #125

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>