### PR TITLE
feat: add --epub-paragraph-numbers for left-margin paragraph numbering

### DIFF
--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -231,6 +231,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     type=int,
     help="Audio sample rate in Hz (e.g., 22050, 44100). Default: match source MP3.",
 )
+@click.option(
+    "--epub-paragraph-numbers",
+    is_flag=True,
+    default=False,
+    help="Add left-margin paragraph numbers to each talk transcript in the EPUB.",
+)
 @click.version_option(version=__version__, prog_name="gencon-audiobook")
 def main(
     output: str,
@@ -242,6 +248,7 @@ def main(
     force_scrape: bool,
     bitrate: str | None,
     sample_rate: int | None,
+    epub_paragraph_numbers: bool,
 ) -> None:
     """Download General Conference talks as a chaptered m4b audiobook and epub companion."""
     _check_python_version()
@@ -257,6 +264,7 @@ def main(
             force_scrape=force_scrape,
             bitrate=bitrate,
             sample_rate=sample_rate,
+            epub_paragraph_numbers=epub_paragraph_numbers,
         )
     except KeyboardInterrupt:
         console.print(
@@ -348,6 +356,7 @@ def _run(
     force_scrape: bool,
     bitrate: str | None,
     sample_rate: int | None,
+    epub_paragraph_numbers: bool = False,
 ) -> None:
     """Inner implementation of main() — separated so KeyboardInterrupt is handled cleanly."""
     output_dir = Path(output).expanduser().resolve()
@@ -466,6 +475,7 @@ def _run(
                         conference=conf_obj,
                         images_dir=conf_output_dir,
                         output_path=epub_path,
+                        paragraph_numbers=epub_paragraph_numbers,
                     )
             except EpubError as exc:
                 click.echo(f"Error: EPUB build failed.\n{exc}", err=True)

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -128,6 +128,19 @@ aside {
   padding-left: 1em;
   font-size: 0.85em;
 }
+
+.transcript.numbered {
+  margin-left: 2.5em;
+}
+
+.para-num {
+  float: left;
+  width: 2em;
+  margin-left: -2.5em;
+  text-align: right;
+  font-size: 0.8em;
+  line-height: inherit;
+}
 """
 
 
@@ -161,6 +174,7 @@ def _void_to_xhtml(html: str) -> str:
 def _sanitize_transcript(
     raw_html: str | None,
     inline_image_map: dict[str, str] | None = None,
+    paragraph_numbers: bool = False,
 ) -> str:
     """Strip unsafe elements and external URLs from transcript HTML for EPUB embedding.
 
@@ -174,11 +188,17 @@ def _sanitize_transcript(
     img attributes (srcset, sizes, loading, class) are stripped to just src and
     alt. Void elements are converted to XHTML self-closing form.
 
+    If paragraph_numbers is True, each top-level transcript paragraph receives
+    id="pN" and a prepended <span class="para-num">N</span> for left-margin
+    numbering. Paragraphs inside <aside> (footnote bodies) are excluded.
+
     Args:
         raw_html: Raw HTML fragment from a scraped talk page, or None.
         inline_image_map: Optional mapping of original image URL -> EPUB-relative
             path (e.g., "../images/inline-001-assetid.jpg"). Images whose URL
             matches a key are kept with the local src; others are removed.
+        paragraph_numbers: If True, prepend paragraph numbers to each <p> in the
+            transcript and add id="pN" attributes.
 
     Returns:
         Sanitized XHTML fragment string, or empty string if input is None/empty.
@@ -284,6 +304,21 @@ def _sanitize_transcript(
             del tag["id"]
         if "class" in tag.attrs:
             del tag["class"]
+
+    if paragraph_numbers:
+        # Number each <p> that is not inside a footnote <aside>.
+        # Prepend <span class="para-num">N</span> and add id="pN" for deep-linking.
+        # Numbers restart at 1 per call (i.e., per talk).
+        num = 0
+        for p_tag in soup.find_all("p"):
+            if p_tag.find_parent("aside"):
+                continue  # footnote content — do not number
+            num += 1
+            p_tag["id"] = f"p{num}"
+            span = soup.new_tag("span")
+            span["class"] = "para-num"
+            span.string = str(num)
+            p_tag.insert(0, span)
 
     return _void_to_xhtml(str(soup))
 
@@ -461,6 +496,7 @@ def _talk_page(
     transcript_html: str | None,
     photo_href: str | None,
     inline_image_map: dict[str, str] | None = None,
+    paragraph_numbers: bool = False,
 ) -> str:
     """Generate a talk XHTML page with speaker photo, byline, title, and transcript.
 
@@ -470,6 +506,7 @@ def _talk_page(
         transcript_html: Raw transcript HTML fragment, or None.
         photo_href: Relative path to speaker photo from this page's location, or None.
         inline_image_map: Optional mapping of original image URL -> EPUB-relative path.
+        paragraph_numbers: If True, add left-margin paragraph numbers to transcript.
 
     Returns:
         Complete XHTML document string.
@@ -488,11 +525,16 @@ def _talk_page(
         f'<h1 class="talk-title">{escape(talk_title)}</h1>'
     )
 
-    sanitized = _sanitize_transcript(transcript_html, inline_image_map=inline_image_map)
+    sanitized = _sanitize_transcript(
+        transcript_html,
+        inline_image_map=inline_image_map,
+        paragraph_numbers=paragraph_numbers,
+    )
+    transcript_class = "transcript numbered" if paragraph_numbers else "transcript"
     if sanitized:
-        parts.append(f'<div class="transcript">\n{sanitized}\n</div>')
+        parts.append(f'<div class="{transcript_class}">\n{sanitized}\n</div>')
     else:
-        parts.append('<div class="transcript"><p>[Transcript not available.]</p></div>')
+        parts.append(f'<div class="{transcript_class}"><p>[Transcript not available.]</p></div>')
 
     body = "\n".join(parts)
     return _xhtml_wrap(
@@ -673,6 +715,7 @@ def build_epub(
     conference: Conference,
     images_dir: Path,
     output_path: Path,
+    paragraph_numbers: bool = False,
 ) -> None:
     """Build an EPUB 3 companion with full transcripts and speaker photos.
 
@@ -697,6 +740,8 @@ def build_epub(
             text; talks with no transcript get a placeholder.
         images_dir: Directory containing cover.jpg and speakers/*.jpg.
         output_path: Destination path for the .epub file. Parent is created if needed.
+        paragraph_numbers: If True, prepend left-margin paragraph numbers to each
+            transcript paragraph and add id="pN" attributes for deep-linking.
 
     Raises:
         EpubError: if the output file cannot be written.
@@ -852,6 +897,7 @@ def build_epub(
                     talk.transcript_html,
                     d["photo_page_href"],
                     inline_image_map=d["inline_image_map"] or None,
+                    paragraph_numbers=paragraph_numbers,
                 )
                 zf.writestr(f"text/{d['filename']}", page)
                 logger.debug("Added talk page: text/%s", d["filename"])

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -1022,3 +1022,118 @@ def test_build_epub_spine_includes_nav_linear_no(tmp_path: Path) -> None:
     opf = _epub_read(output, "content.opf").decode()
     assert 'idref="nav"' in opf, "nav must be referenced in the spine"
     assert 'linear="no"' in opf, "nav spine entry must have linear='no'"
+
+
+# ---------------------------------------------------------------------------
+# Paragraph numbers
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_transcript_paragraph_numbers_adds_spans() -> None:
+    """With paragraph_numbers=True, each <p> gets a <span class='para-num'>."""
+    html = "<p>First.</p><p>Second.</p><p>Third.</p>"
+    result = _sanitize_transcript(html, paragraph_numbers=True)
+    assert '<span class="para-num">1</span>' in result, "First paragraph span missing"
+    assert '<span class="para-num">2</span>' in result, "Second paragraph span missing"
+    assert '<span class="para-num">3</span>' in result, "Third paragraph span missing"
+
+
+def test_sanitize_transcript_paragraph_numbers_adds_ids() -> None:
+    """With paragraph_numbers=True, each <p> gets id='pN'."""
+    html = "<p>Alpha.</p><p>Beta.</p>"
+    result = _sanitize_transcript(html, paragraph_numbers=True)
+    assert 'id="p1"' in result, "First paragraph id missing"
+    assert 'id="p2"' in result, "Second paragraph id missing"
+
+
+def test_sanitize_transcript_paragraph_numbers_off_by_default() -> None:
+    """Without paragraph_numbers, no <span class='para-num'> or id='pN' is added."""
+    html = "<p>Only paragraph.</p>"
+    result = _sanitize_transcript(html)
+    assert "para-num" not in result, "para-num span must be absent by default"
+    assert 'id="p1"' not in result, "paragraph id must be absent by default"
+
+
+def test_sanitize_transcript_paragraph_numbers_skips_footnotes() -> None:
+    """Paragraphs inside <aside epub:type='footnote'> are not numbered."""
+    html = (
+        '<p>Main text.</p>'
+        '<p id="note1">Footnote content.</p>'
+    )
+    result = _sanitize_transcript(html, paragraph_numbers=True)
+    # Main paragraph should be numbered
+    assert '<span class="para-num">1</span>' in result, "Main paragraph must be numbered"
+    # Footnote is inside an aside (wrapping happens in sanitization), so it should not have para-num=2
+    assert '<span class="para-num">2</span>' not in result, "Footnote paragraph must not be numbered"
+
+
+def test_build_epub_paragraph_numbers_transcript_class(tmp_path: Path) -> None:
+    """With paragraph_numbers=True, talk pages use class='transcript numbered'."""
+    conference = _make_conference(n_talks=1)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output, paragraph_numbers=True)
+
+    with zipfile.ZipFile(output) as zf:
+        names = [n for n in zf.namelist() if n.startswith("text/talk-")]
+        assert names, "Expected at least one talk page"
+        page = zf.read(names[0]).decode()
+    assert 'class="transcript numbered"' in page, \
+        "Talk page must use 'transcript numbered' class when paragraph numbers enabled"
+
+
+def test_build_epub_no_paragraph_numbers_transcript_class(tmp_path: Path) -> None:
+    """Without paragraph_numbers, talk pages use class='transcript' only."""
+    conference = _make_conference(n_talks=1)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    with zipfile.ZipFile(output) as zf:
+        names = [n for n in zf.namelist() if n.startswith("text/talk-")]
+        page = zf.read(names[0]).decode()
+    assert 'class="transcript"' in page, "Default class must be 'transcript'"
+    assert "numbered" not in page, "Default output must not contain 'numbered'"
+
+
+def test_build_epub_paragraph_numbers_restart_per_talk(tmp_path: Path) -> None:
+    """Paragraph numbers restart at 1 for each talk."""
+    conference = _make_conference(n_talks=3)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output, paragraph_numbers=True)
+
+    with zipfile.ZipFile(output) as zf:
+        talk_pages = sorted(n for n in zf.namelist() if n.startswith("text/talk-"))
+        for page_name in talk_pages:
+            page = zf.read(page_name).decode()
+            assert 'id="p1"' in page, \
+                f"Paragraph numbering must start at 1 in each talk, missing in {page_name}"
+            assert '<span class="para-num">1</span>' in page, \
+                f"First paragraph span missing in {page_name}"
+
+
+def test_build_epub_css_has_para_num_rule(tmp_path: Path) -> None:
+    """The stylesheet must contain a .para-num rule."""
+    conference = _make_conference(n_talks=1)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    css = _epub_read(output, "style.css").decode("utf-8")
+    assert ".para-num" in css, "Stylesheet must define .para-num rule"
+
+
+def test_build_epub_css_para_num_theme_safe(tmp_path: Path) -> None:
+    """.para-num must not use color, background-color, font-family, or absolute sizes."""
+    conference = _make_conference(n_talks=1)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    css = _epub_read(output, "style.css").decode("utf-8")
+    css_no_comments = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+
+    # Extract just the .para-num rule block
+    match = re.search(r"\.para-num\s*\{([^}]*)\}", css_no_comments, re.DOTALL)
+    assert match, ".para-num rule not found in stylesheet"
+    block = match.group(1)
+
+    assert not re.search(r"\bcolor\s*:", block), ".para-num must not set color"
+    assert not re.search(r"\bbackground(-color)?\s*:", block), ".para-num must not set background"
+    assert not re.search(r"\bfont-family\s*:", block), ".para-num must not set font-family"
+    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", block), \
+        ".para-num must not use absolute font-size units"


### PR DESCRIPTION
## Summary

- Adds `--epub-paragraph-numbers` CLI flag (off by default)
- Prepends `<span class="para-num">N</span>` before each transcript paragraph and sets `id="pN"` for potential deep-linking
- Numbers restart at 1 for each talk (per-chapter scope)
- Paragraphs inside footnote `<aside>` elements are excluded from numbering
- Adds `.para-num` and `.transcript.numbered` CSS rules — theme-safe (em units, no color/font-family/absolute sizes)
- 8 new tests: span injection, id attributes, per-talk restart, footnote exclusion, transcript class name, CSS compliance

## Test plan

- [x] `pytest tests/test_epub.py -k "paragraph"` — 8 new tests pass
- [x] `pytest tests/test_epub.py -k "css"` — all CSS compliance tests pass
- [x] Full unit suite: 238 passed

Closes #112

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>