### PR TITLE
fix: derive __version__ from package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gencon-audiobook"
-version = "0.1.5"
+version = "0.1.7"
 description = "Download General Conference talks as a complete audiobook (m4b) and epub with full transcripts"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gencon_audiobook/__init__.py
+++ b/src/gencon_audiobook/__init__.py
@@ -2,4 +2,9 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.7"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("gencon-audiobook")
+except PackageNotFoundError:
+    __version__ = "unknown"  # running from source without pip install


### PR DESCRIPTION
## Summary
- Replace hardcoded `__version__ = "0.1.7"` in `__init__.py` with `importlib.metadata.version("gencon-audiobook")`
- `pyproject.toml` is now the single source of truth for the package version
- `PackageNotFoundError` fallback returns `"unknown"` when running from source without a `pip install`

## Why
The v0.1.6 and v0.1.7 version bumps only updated `__init__.py` and left `pyproject.toml` at `0.1.5`. Every build produced a `gencon_audiobook-0.1.5-py3-none-any.whl`, which PyPI rejected as a duplicate of the already-published v0.1.5 wheel. Future version bumps now only need to touch `pyproject.toml`.

## Test plan
- [ ] 238 unit tests pass
- [ ] `python -c "from gencon_audiobook import __version__; print(__version__)"` prints `0.1.7`
- [ ] CI passes

Closes #131