### PR TITLE
feat: switch PyPI publishing to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   release:
     name: Create GitHub release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gencon-audiobook"
-version = "0.1.5"
+version = "0.1.7"
 description = "Download General Conference talks as a complete audiobook (m4b) and epub with full transcripts"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Remove `password: ${{ secrets.PYPI_API_TOKEN }}` from the publish step
- PyPI Trusted Publisher is already registered for this repo/workflow/environment
- Authentication now happens via OIDC token exchange — no stored secrets required

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, verify next tag push publishes successfully via OIDC

Closes #130