### PR TITLE
fix: downgrade HTML traversal fallback log from WARNING to DEBUG

### DIFF
--- a/.claude/rules/epub-style.md
+++ b/.claude/rules/epub-style.md
@@ -12,7 +12,7 @@ high contrast, accessibility modes). This is achieved by deferring ALL visual st
 - `color` (including `currentColor` in color properties)
 - `background-color`
 - `font-family`
-- Absolute font sizes: `px`, `pt`, `cm`, `mm`, `in`, `pc`
+- `font-size` (any unit — `px`, `pt`, `em`, `%`, `rem`, `vw`, etc. — defer text sizing to the reader)
 
 **Only allowed:**
 - Structural layout: `margin`, `padding`, `text-align`, `line-height` in `em` or `%`

--- a/.claude/rules/github-issues.md
+++ b/.claude/rules/github-issues.md
@@ -1,0 +1,161 @@
+# GitHub Issue Format
+
+When asked to create a GitHub issue, use `gh issue create` with the format below.
+Choose the template that matches the issue type. Fill every section — never leave
+a section empty or with placeholder text.
+
+---
+
+## Issue types and title prefixes
+
+| Type | Title prefix | Label |
+|---|---|---|
+| Bug (user-visible breakage) | `bug: ` | `bug` |
+| Fix (code correctness, not user-visible) | `fix: ` | `bug` |
+| Feature / enhancement | `feat: ` | `enhancement` |
+| Test coverage gap | `test: ` | `test` |
+| Documentation drift | `docs: ` | `documentation` |
+| Maintenance / chore | `chore: ` | `chore` |
+| Security | `security: ` | `security` |
+
+---
+
+## Bug / fix template
+
+```
+gh issue create \
+  --title "bug: <short description>" \
+  --label "bug" \
+  --body "## Problem
+
+<What is broken. One paragraph. State the symptom and when it occurs.>
+
+## Where
+
+- \`src/gencon_audiobook/<file>.py\` line N: <what the bad code does>
+
+## Expected behavior
+
+<What should happen instead.>
+
+## Steps to reproduce
+
+1. <step>
+2. <step>
+
+## Fix
+
+<Proposed fix, or 'Unknown — needs investigation' if not yet known.>"
+```
+
+---
+
+## Feature / enhancement template
+
+```
+gh issue create \
+  --title "feat: <short description>" \
+  --label "enhancement" \
+  --body "## Problem / motivation
+
+<Why this feature is needed. What user problem does it solve?>
+
+## Proposed solution
+
+<What the feature should do. Be specific about behavior, not implementation.>
+
+## Scope
+
+**In scope:**
+- <item>
+
+**Out of scope:**
+- <item>
+
+## Open questions
+
+- <Any design decisions that need discussion before implementation.>"
+```
+
+---
+
+## Test coverage gap template
+
+```
+gh issue create \
+  --title "test: <short description>" \
+  --label "test" \
+  --body "## Gap
+
+<What scenario, path, or behavior is not tested.>
+
+## Where
+
+- \`tests/<file>.py\`: <what is missing>
+
+## Why it matters
+
+<What kind of bug would slip through without this test.>
+
+## Suggested test
+
+\`\`\`python
+def test_<function>_<scenario>():
+    # <sketch of what the test should do>
+\`\`\`"
+```
+
+---
+
+## Documentation template
+
+```
+gh issue create \
+  --title "docs: <short description>" \
+  --label "documentation" \
+  --body "## Problem
+
+<What is wrong or missing in the documentation.>
+
+## Where
+
+- \`<file>\` line N: <what it says vs. what it should say>
+
+## Fix
+
+<What the correct content should be.>"
+```
+
+---
+
+## Chore / maintenance template
+
+```
+gh issue create \
+  --title "chore: <short description>" \
+  --label "chore" \
+  --body "## What
+
+<What needs to be done. Be specific about the change.>
+
+## Why
+
+<Why this maintenance work matters now.>
+
+## Acceptance criteria
+
+- [ ] <measurable outcome>
+- [ ] <measurable outcome>"
+```
+
+---
+
+## Rules
+
+- **One issue per logical change.** Do not bundle unrelated work into one issue.
+- **Always include `Closes #N` in the PR description body** (not the commit message)
+  when a PR resolves an issue. GitHub reads the PR body to auto-close issues on merge.
+- **Cosmetic fixes** (typos, whitespace) are the only exception to the "issue first" rule.
+- **Do not create duplicate issues.** Search open issues before creating a new one.
+- **Labels must match the title prefix.** If the label does not exist, create it with
+  `gh label create`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -83,6 +83,24 @@ jobs:
           --cov-report=term-missing
           --tb=short
 
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Build package
+        run: python -m build
+
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest
@@ -98,5 +116,8 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      # pip-audit currently flags pip itself (CVE-2026-3219) with no published fix version.
       - name: Run pip-audit
-        run: pip-audit
+        run: >
+          pip-audit
+          --ignore-vuln CVE-2026-3219

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
 
       # pip-audit currently flags pip itself (CVE-2026-3219) with no published fix version.
       - name: Run pip-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,8 @@ Initial release.
 - Filename sanitization preventing path traversal and special characters in output paths.
 - Fixture-based unit tests for scraper, downloader, audio pipeline, EPUB builder, and utilities; weekly live smoke test workflow with automatic GitHub issue creation on failure.
 
-[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.7...HEAD
+[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.4...v0.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Progress indicators now show elapsed time on long-running progress bars and spinner phases.
+- Download status messages now show audio/image count breakdowns.
+
+### Fixed
+- `--prefer-video-audio` extraction now writes `.m4a.tmp` files with an explicit ffmpeg muxer, fixing Windows extraction failures where ffmpeg could not infer the output format.
+- `--prefer-video-audio` now falls back to the MP3 URL for an individual talk if video-audio extraction fails.
+- Fully cached `--prefer-video-audio` reruns skip the heavy download confirmation and avoid misleading no-op timing output.
+- `--audiobook-only` and `--epub-only` are now rejected as mutually exclusive flags before scraping or downloading.
+- Missing `--output` values now produce a direct option-value error instead of an unrelated extra-argument error.
+- Missing direct conference URLs now report the requested conference as unavailable instead of retrying and blaming internet connectivity.
+- If every talk audio download fails, the CLI now stops before audiobook build with a clear error and log path.
+
+### Changed
+- Video-audio decision banners are styled so important warning/active states stand out without coloring the full prompt body.
+
 ## [0.2.0rc1] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-29
+
+### Added
+- `--prefer-video-audio` flag: when a conference's 360p video audio is better than the MP3 source, the tool can extract the 96 kbps AAC track from video instead of downloading lower-quality MP3 audio. The default run warns before downloading, the opt-in path shows estimated download/audio-cache sizes, and newer conferences with better MP3 audio are protected from downgrade.
+- EPUB table-of-contents entries now include speaker names.
+- Completion reports now include session count and session names.
+
+### Fixed
+- Scraper fetches now enforce robots.txt through the shared `_fetch()` path, matching the documented behavior.
+
 ## [0.1.7] - 2026-04-16
 
 ### Added
@@ -124,7 +134,8 @@ Initial release.
 - Filename sanitization preventing path traversal and special characters in output paths.
 - Fixture-based unit tests for scraper, downloader, audio pipeline, EPUB builder, and utilities; weekly live smoke test workflow with automatic GitHub issue creation on failure.
 
-[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.8...v0.2.0
 [0.1.8]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.5...v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0] - 2026-04-29
+## [0.2.0rc1] - 2026-04-29
 
 ### Added
 - `--prefer-video-audio` flag: when a conference's 360p video audio is better than the MP3 source, the tool can extract the 96 kbps AAC track from video instead of downloading lower-quality MP3 audio. The default run warns before downloading, the opt-in path shows estimated download/audio-cache sizes, and newer conferences with better MP3 audio are protected from downgrade.
@@ -134,8 +134,8 @@ Initial release.
 - Filename sanitization preventing path traversal and special characters in output paths.
 - Fixture-based unit tests for scraper, downloader, audio pipeline, EPUB builder, and utilities; weekly live smoke test workflow with automatic GitHub issue creation on failure.
 
-[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.8...v0.2.0
+[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.2.0rc1...HEAD
+[0.2.0rc1]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.8...v0.2.0rc1
 [0.1.8]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.5...v0.1.6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ No emojis anywhere — not in terminal output, log messages, generated files, or
 
 ## GitHub Issues
 All changes require a GitHub issue before work begins. Cosmetic fixes (typos, whitespace) are
-the only exception. Use `gh issue create` following the project's issue format.
+the only exception. Use `gh issue create` following the format in `.claude/rules/github-issues.md`.
+That file defines the exact title prefix, label, and body template for every issue type.
 
 Every PR description body must include `Closes #N` for each issue it resolves. GitHub reads
 the PR body (not the commit message) to auto-close issues on squash merge — omitting it leaves

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,9 @@ pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integratio
 pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py \
     --cov=gencon_audiobook --cov-report=term-missing
 
+# Build source and wheel distributions
+python -m build
+
 # Live smoke tests (hits the real website — use sparingly)
 pytest tests/test_scraper_live.py -v -m live
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ New to the terminal or Python? See the [User Guide](https://github.com/XeroIP/ge
 gencon-audiobook
 
 # Select a specific conference
-gencon-audiobook --conference "April 2024"
+gencon-audiobook --conference 2024-04
 
 # Audiobook only (skip epub)
 gencon-audiobook --audiobook-only

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ gencon-audiobook --force-scrape
 # Reduce file size (lower bitrate and sample rate)
 gencon-audiobook --bitrate 32k --sample-rate 22050
 
+# Use higher-quality video audio when older MP3 audio is worse
+gencon-audiobook --conference 2024-04 --prefer-video-audio
+
 # Show detailed progress in the terminal
 gencon-audiobook --verbose
 
@@ -84,6 +87,8 @@ For the full options reference, file size guide, and platform compatibility note
 ```
 
 Running the tool a second time skips files that already exist and loads conference metadata from `conference.json` instead of re-scraping the Church website. Use `--overwrite` to rebuild output files. Use `--force-scrape` to bypass the metadata cache and fetch fresh data from the Church website.
+
+For older conferences, the tool checks whether the 360p video has better audio than the MP3 source. If it does, the default run warns you before downloading. Re-run with `--prefer-video-audio` to extract the higher-quality AAC track from video files. This takes significantly longer and requires much more disk space, so the tool shows estimated download and audio-cache sizes before starting.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ pip install -e ".[dev]"
 # Run unit tests (no network required)
 pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py
 
+# Build source and wheel distributions
+python -m build
+
 # Run live smoke tests (hits the real website)
 pytest tests/test_scraper_live.py -v -m live
 

--- a/docs/phases/phase-1-scraper-audiobook.md
+++ b/docs/phases/phase-1-scraper-audiobook.md
@@ -599,7 +599,7 @@ Implement a minimal but functional CLI. Full error handling and polish comes in 
 @click.option("--output", default="~/gencon-audiobook", show_default=True,
               help="Directory to save output files.")
 @click.option("--conference", default=None,
-              help="Conference to download (e.g., 'April 2024'). Defaults to most recent.")
+              help="Conference date as YYYY-MM (e.g., '2024-04'). Defaults to most recent.")
 @click.option("--audiobook-only", is_flag=True, default=False,
               help="Produce only the m4b audiobook, skip epub.")
 @click.option("--epub-only", is_flag=True, default=False,
@@ -682,7 +682,7 @@ gencon-audiobook --audiobook-only --output ./test_output
 
 # 7. Resume behavior
 # Delete one MP3 from test_output, re-run:
-gencon-audiobook --audiobook-only --output ./test_output --conference "April 2024"
+gencon-audiobook --audiobook-only --output ./test_output --conference 2024-04
 # Expected: only the deleted file re-downloads; all others skipped
 
 # 8. ffmpeg fallback (on clean venv without system ffmpeg)

--- a/docs/phases/phase-3-cli-polish.md
+++ b/docs/phases/phase-3-cli-polish.md
@@ -189,8 +189,8 @@ Handle gracefully (no traceback):
 - **Conference already downloaded**: If output files already exist and `--overwrite` is not set,
   print a message and exit with code 0. Never prompt interactively — the tool must be
   scriptable. `--overwrite` was declared in Phase 1 and is wired up here.
-- **Conference selection**: If `--conference` value doesn't match any available conference,
-  print the list of available conferences and exit with a helpful message
+- **Conference selection**: If `--conference` value is not in YYYY-MM format,
+  print a clear error and exit with a helpful message
 
 ---
 
@@ -220,9 +220,9 @@ ls -la ./test_output/<conference>/gencon-audiobook.log
 gencon-audiobook --output ./test_output  # second run
 # Expected: "Output files already exist. Use --overwrite to replace them."
 
-# 6. Invalid conference name
-gencon-audiobook --conference "Fake Conference 9999"
-# Expected: lists available conferences, clean error message
+# 6. Invalid conference format
+gencon-audiobook --conference "April 2024"
+# Expected: "Invalid conference format" error message, exit non-zero
 
 # 7. Disk space warning
 # (Hard to test without filling disk — verify the logic in code review)

--- a/docs/phases/phase-5-documentation.md
+++ b/docs/phases/phase-5-documentation.md
@@ -50,7 +50,7 @@ contribute.
 6. **Usage**
    ```bash
    gencon-audiobook                               # Most recent conference
-   gencon-audiobook --conference "April 2024"     # Specific conference
+   gencon-audiobook --conference 2024-04          # Specific conference
    gencon-audiobook --audiobook-only              # m4b only
    gencon-audiobook --epub-only                   # epub only
    gencon-audiobook --output ~/Books              # Custom output directory

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -24,7 +24,7 @@ test-release\Scripts\activate
 # Mac/Linux:
 source test-release/bin/activate
 
-pip install gencon-audiobook==0.1.8   # replace with the version being tested
+pip install gencon-audiobook==0.2.0   # replace with the version being tested
 ```
 
 Verify the entry point and version:

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -42,7 +42,7 @@ The epub-only pass covers scraping, image downloading, HTML sanitization, and EP
 without needing ffmpeg or a 200 MB MP3 download. Run this first.
 
 ```bash
-gencon-audiobook --epub-only --conference "April 2024" --output ~/gc-test
+gencon-audiobook --epub-only --conference 2024-04 --output ~/gc-test
 ```
 
 **What to check:**
@@ -65,7 +65,7 @@ gencon-audiobook --epub-only --conference "April 2024" --output ~/gc-test
 ## Step 3: Full run — audiobook + epub (~30–60 min)
 
 ```bash
-gencon-audiobook --conference "April 2024" --output ~/gc-test --overwrite
+gencon-audiobook --conference 2024-04 --output ~/gc-test --overwrite
 ```
 
 **What to check in the completion report:**

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -24,7 +24,7 @@ test-release\Scripts\activate
 # Mac/Linux:
 source test-release/bin/activate
 
-pip install gencon-audiobook==0.1.5   # replace with the version being tested
+pip install gencon-audiobook==0.1.8   # replace with the version being tested
 ```
 
 Verify the entry point and version:

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -24,7 +24,7 @@ test-release\Scripts\activate
 # Mac/Linux:
 source test-release/bin/activate
 
-pip install gencon-audiobook==0.2.0   # replace with the version being tested
+pip install gencon-audiobook==0.2.0rc1   # replace with the version being tested
 ```
 
 Verify the entry point and version:

--- a/docs/scraper-pipeline.md
+++ b/docs/scraper-pipeline.md
@@ -12,7 +12,7 @@ flowchart TD
         S3["Fetch conference listing"]
         S4["Parse Session / Talk stubs"]
         S5["Fetch each talk page"]
-        S6["Extract mp3_url, transcript_html,\nspeaker_image_url, inline_images, speaker name"]
+        S6["Extract mp3_url, transcript_html,\nspeaker_image_url, inline_images,\nfooter.notes footnote bodies, speaker name"]
         S1 --> S2 --> S3 --> S4 --> S5 --> S6
     end
 
@@ -57,7 +57,7 @@ flowchart TD
     end
 
     subgraph EPUB["epub_builder.py"]
-        E1["Sanitize transcripts\n(strip classes, data-*, materialize\nfootnote markers, unwrap links)"]
+        E1["Sanitize transcripts\n(strip classes, data-*, materialize footnote markers,\nunwrap links; preserve noteref via data-scroll-id;\nwrap ^note\\d+$ elements as epub:type=footnote)"]
         E2["Resize speaker photos\n(800px IIIF source → 300px embed)"]
         E3["Compose portrait cover\n(landscape source → 1200x1800 canvas)"]
         E4["Assemble EPUB 3 ZIP\n(verify with testzip after write)"]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -23,6 +23,7 @@ gencon-audiobook --overwrite              # Overwrite existing output files
 gencon-audiobook --force-scrape           # Bypass conference.json cache, re-scrape from website
 gencon-audiobook --bitrate 32k --sample-rate 22050
 gencon-audiobook --epub-paragraph-numbers # Add paragraph numbers to EPUB transcripts
+gencon-audiobook --prefer-video-audio     # Extract better AAC audio from video when MP3 is worse
 ```
 
 ## Output Structure
@@ -35,7 +36,7 @@ gencon-audiobook --epub-paragraph-numbers # Add paragraph numbers to EPUB transc
   conference.json                       # Cached conference metadata (skip re-scraping on rerun)
   audio/                                # Downloaded and converted audio
     001-sanitized-title.mp3             # Zero-padded talk_index, sanitized title
-    001-sanitized-title.m4a             # Intermediate AAC (deleted after m4b is built)
+    001-sanitized-title.m4a             # Extracted video AAC cache, or temporary converted AAC
     ...
   speakers/                             # Speaker photos (for reference and epub)
     001-speaker-name.jpg                # Zero-padded talk_index, sanitized speaker name
@@ -62,6 +63,7 @@ that both `downloader.py` and `audio.py` can compute independently from the Talk
 | ffmpeg sourcing | System PATH first, then `static-ffmpeg` fallback | Users with ffmpeg already installed (most Linux/macOS users) get zero overhead. New users get automatic download. |
 | m4b chapters | ffmpeg FFMETADATA1 format | Only reliable method for writing MP4 chapter atoms. Mutagen used for post-creation verification only — mutagen cannot write chapters. |
 | m4b audio | AAC-LC, source-matched bitrate/sample-rate, mono | Maximum compatibility across iOS and Android. HE-AAC has spotty Android support. Mono is correct for speech. Source quality is preserved by default; `--bitrate` and `--sample-rate` flags override. |
+| Video audio upgrade | Opt-in `--prefer-video-audio` after measured ffprobe comparison | Older MP3s can be 32-64 kbps while 360p video carries 96 kbps AAC. The default run warns and exits before slow downloads; the opt-in path shows size estimates and refuses to downgrade 128 kbps MP3 conferences. |
 | m4b cover | Book-level JPEG only | Per-chapter images not reliably rendered by any player. |
 | m4b chapters | `"Talk Title -- Speaker Name"` | MP4 chapter spec has no author field; speaker name embedded in title with em-dash separator. |
 | EPUB generation | Manual ZIP of XHTML | `ebooklib` is unmaintained (last release 2022), has 100+ open bugs, and produces non-compliant EPUB 3 output. Manual generation gives full control and reliable epubcheck compliance. |
@@ -95,6 +97,7 @@ churchofjesuschrist.org
   downloader.py  ----------------------------->  output_dir/
   (images: parallel via ThreadPoolExecutor)       |-- audio/*.mp3
   (audio: sequential, 0.5s delay)                 |-- cover.jpg
+  (optional video audio extraction)               |-- audio/*.m4a
   (.tmp + rename, resume, retry/backoff)          |-- speakers/*.jpg
   (JPEG conversion via Pillow)                    +-- inline/*.jpg
   (IIIF URLs rewritten to 800px resolution)
@@ -139,6 +142,7 @@ class Talk:
     speaker: str
     talk_url: str
     mp3_url: str | None = None
+    video_url: str | None = None
     transcript_html: str | None = None
     speaker_image_url: str | None = None
     inline_images: list[InlineImage] = field(default_factory=list)  # body images from transcript
@@ -180,9 +184,9 @@ requires-python = ">=3.10"
 dependencies = [
     "click>=8.0",              # CLI framework
     "requests>=2.28",          # HTTP client
-    "beautifulsoup4>=4.11",    # HTML parsing (uses html.parser — NOT lxml)
+    "beautifulsoup4>=4.12",    # HTML parsing (uses html.parser — NOT lxml)
     "mutagen>=1.47",           # Audio metadata verification only (NOT for chapter writing)
-    "Pillow>=9.1",             # Image processing (resize/convert speaker photos to JPEG)
+    "Pillow>=10.0",            # Image processing (resize/convert speaker photos to JPEG)
     "rich>=13.0",              # Progress bars and terminal output
     "static-ffmpeg>=2.7",      # Fallback ffmpeg download if not on system PATH
 ]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -14,7 +14,7 @@ and speaker photos.
 pip install gencon-audiobook
 
 gencon-audiobook                          # List available conferences, default to most recent
-gencon-audiobook --conference "April 2024"  # Select a specific conference
+gencon-audiobook --conference 2024-04       # Select a specific conference
 gencon-audiobook --audiobook-only         # Produce only the m4b
 gencon-audiobook --epub-only              # Produce only the epub
 gencon-audiobook --output ~/Books         # Custom output directory

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -182,7 +182,7 @@ dependencies = [
     "requests>=2.28",          # HTTP client
     "beautifulsoup4>=4.11",    # HTML parsing (uses html.parser — NOT lxml)
     "mutagen>=1.47",           # Audio metadata verification only (NOT for chapter writing)
-    "Pillow>=9.0",             # Image processing (resize/convert speaker photos to JPEG)
+    "Pillow>=9.1",             # Image processing (resize/convert speaker photos to JPEG)
     "rich>=13.0",              # Progress bars and terminal output
     "static-ffmpeg>=2.7",      # Fallback ffmpeg download if not on system PATH
 ]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -21,6 +21,8 @@ gencon-audiobook --output ~/Books         # Custom output directory
 gencon-audiobook --verbose                # Enable DEBUG-level console output
 gencon-audiobook --overwrite              # Overwrite existing output files
 gencon-audiobook --force-scrape           # Bypass conference.json cache, re-scrape from website
+gencon-audiobook --bitrate 32k --sample-rate 22050
+gencon-audiobook --epub-paragraph-numbers # Add paragraph numbers to EPUB transcripts
 ```
 
 ## Output Structure
@@ -128,6 +130,7 @@ class ConferenceRef:
 class InlineImage:
     """A single inline body image referenced in a talk's transcript."""
     url: str       # Full URL (IIIF, rewritten to 800px before download)
+    alt: str       # Alt text from the source <img> element
     asset_id: str  # Unique identifier used as the filename component
 
 @dataclass
@@ -189,7 +192,12 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "responses>=0.23",         # Mock HTTP requests in unit tests
+    "build>=1.2",              # Build sdist/wheel from the documented dev environment
     "pip-audit>=2.0",          # Dependency vulnerability scanning
+    "ruff>=0.3",               # Linting
+    "mypy>=1.9",               # Type checking
+    "types-requests>=2.31",    # requests type stubs
+    "types-beautifulsoup4>=4.12",  # BeautifulSoup type stubs
 ]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "responses>=0.23",
+    "build>=1.2",
     "pip-audit>=2.0",
     "ruff>=0.3",
     "mypy>=1.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gencon-audiobook"
-version = "0.1.7"
+version = "0.2.0"
 description = "Download General Conference talks as a complete audiobook (m4b) and epub with full transcripts"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -24,9 +24,9 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "requests>=2.28",
-    "beautifulsoup4>=4.11",
+    "beautifulsoup4>=4.12",
     "mutagen>=1.47",
-    "Pillow>=9.1",
+    "Pillow>=10.0",
     "rich>=13.0",
     "static-ffmpeg>=2.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gencon-audiobook"
-version = "0.2.0"
+version = "0.2.0rc1"
 description = "Download General Conference talks as a complete audiobook (m4b) and epub with full transcripts"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -13,10 +13,10 @@ from pathlib import Path
 
 from mutagen import MutagenError
 from mutagen.mp4 import MP4
-from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
+from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
 
 from .models import Conference, Talk
-from .progress import standard_progress
+from .progress import shared_console, standard_progress
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -745,6 +745,8 @@ def build_m4b(
         _spinner_progress = Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            console=shared_console,
         )
         with _spinner_progress:
             _spinner_progress.add_task(f"Concatenating {len(aac_paths)} AAC files...")
@@ -788,6 +790,8 @@ def build_m4b(
         _spinner_progress = Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            console=shared_console,
         )
         with _spinner_progress:
             _spinner_progress.add_task(f"Muxing m4b: {output_path.name}")
@@ -803,7 +807,12 @@ def build_m4b(
             logger.warning("Could not delete %s: %s", aac_path, exc)
 
     # Step 7: Verify
-    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=shared_console,
+    ) as sp:
         sp.add_task(f"Verifying m4b: {output_path.name}")
         _verify_m4b(output_path, conference, ffprobe_path)
     logger.info("Built: %s (%.1f MB)", output_path.name, output_path.stat().st_size / 1_048_576)

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -12,18 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from mutagen.mp4 import MP4
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TaskID,
-    TaskProgressColumn,
-    TextColumn,
-)
+from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 
 from .models import Conference, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import standard_progress
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -645,14 +637,7 @@ def build_m4b(
 
     # Step 2: Convert MP3 → AAC, populate duration_seconds
     logger.info("Converting %d talks to AAC...", len(talks))
-    conv_progress = Progress(
-        SpinnerColumn(),
-        MofNCompleteColumn(),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeRemainingWithLabel(compact=True),
-        TextColumn("[progress.description]{task.description}"),
-    )
+    conv_progress = standard_progress()
     with conv_progress:
         outer_task = conv_progress.add_task("Converting to AAC", total=len(talks))
         inner_task = conv_progress.add_task("", total=1.0, visible=False)

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -626,18 +626,22 @@ def build_m4b(
     source_sample_rate: int | None = None
 
     # Step 1: Auto-detect source quality unless the caller explicitly overrode it.
-    # Probe the first available MP3 — all talks in a conference come from the same
+    # Probe the first available audio file — all talks in a conference come from the same
     # source pipeline and share the same bitrate/sample_rate.
-    first_mp3 = next(
+    first_audio = next(
         (
-            audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.mp3"
+            path
             for t in talks
-            if (audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.mp3").exists()
+            for path in (
+                audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.m4a",
+                audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.mp3",
+            )
+            if path.exists()
         ),
         None,
     )
-    if first_mp3 is not None:
-        detected_bitrate, detected_sample_rate = _probe_source_quality(first_mp3, ffprobe_path)
+    if first_audio is not None:
+        detected_bitrate, detected_sample_rate = _probe_source_quality(first_audio, ffprobe_path)
         source_bitrate = detected_bitrate
         source_sample_rate = detected_sample_rate
         if bitrate is None:
@@ -652,8 +656,9 @@ def build_m4b(
     source_bitrate = source_bitrate or bitrate
     source_sample_rate = source_sample_rate or sample_rate
 
-    # Step 2: Convert MP3 → AAC, populate duration_seconds
+    # Step 2: Convert MP3 -> AAC or reuse extracted AAC, populate duration_seconds
     logger.info("Converting %d talks to AAC...", len(talks))
+    delete_after_build: list[Path] = []
     conv_progress = standard_progress()
     with conv_progress:
         outer_task = conv_progress.add_task("Converting to AAC", total=len(talks))
@@ -661,8 +666,23 @@ def build_m4b(
         for talk in talks:
             conv_progress.update(outer_task, description=talk.title[:60])
             mp3_path = audio_dir / f"{talk.talk_index:03d}-{sanitize_filename(talk.title)}.mp3"
+            m4a_path = mp3_path.with_suffix(".m4a")
+            if m4a_path.exists():
+                try:
+                    duration = _get_duration_ffprobe(m4a_path, ffprobe_path)
+                    talk.duration_seconds = duration
+                    aac_paths.append(m4a_path)
+                    successful_talks.append(talk)
+                    logger.debug("Using existing AAC %s (%.1fs)", m4a_path.name, duration)
+                except AudioError as exc:
+                    logger.error("AAC probe failed for %r: %s — skipping", talk.title, exc)
+                    skipped.append(talk.title)
+                finally:
+                    conv_progress.advance(outer_task)
+                continue
+
             if not mp3_path.exists():
-                logger.warning("MP3 not found for talk %r (%s) — skipping", talk.title, mp3_path)
+                logger.warning("Audio not found for talk %r (%s) — skipping", talk.title, mp3_path)
                 skipped.append(talk.title)
                 conv_progress.advance(outer_task)
                 continue
@@ -691,6 +711,7 @@ def build_m4b(
                 )
                 talk.duration_seconds = duration
                 aac_paths.append(aac_path)
+                delete_after_build.append(aac_path)
                 successful_talks.append(talk)
                 logger.debug("Converted %s (%.1fs)", mp3_path.name, duration)
             except AudioError as exc:
@@ -772,8 +793,9 @@ def build_m4b(
             _spinner_progress.add_task(f"Muxing m4b: {output_path.name}")
             _run(mux_cmd, label="m4b mux")
 
-    # Step 6: Delete individual AAC files (intermediate cleaned by TemporaryDirectory)
-    for aac_path in aac_paths:
+    # Step 6: Delete only AAC files created from MP3 conversion. Extracted video
+    # audio is a reusable source cache and must remain for resume/rebuild.
+    for aac_path in delete_after_build:
         try:
             aac_path.unlink()
             logger.debug("Deleted intermediate AAC: %s", aac_path.name)

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from mutagen.mp4 import MP4
 from rich.progress import (
     BarColumn,
-    MofNCompleteColumn,
     Progress,
     SpinnerColumn,
     TaskID,
@@ -23,7 +22,7 @@ from rich.progress import (
 )
 
 from .models import Conference, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import ConditionalMofNColumn, TimeRemainingWithLabel
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -647,7 +646,7 @@ def build_m4b(
     logger.info("Converting %d talks to AAC...", len(talks))
     conv_progress = Progress(
         SpinnerColumn(),
-        MofNCompleteColumn(),
+        ConditionalMofNColumn(),
         BarColumn(),
         TaskProgressColumn(),
         TimeRemainingWithLabel(compact=True),
@@ -655,7 +654,7 @@ def build_m4b(
     )
     with conv_progress:
         outer_task = conv_progress.add_task("Converting to AAC", total=len(talks))
-        inner_task = conv_progress.add_task("", total=1.0, visible=False)
+        inner_task = conv_progress.add_task("", total=1.0, visible=False, show_count=False)
         for talk in talks:
             conv_progress.update(outer_task, description=talk.title[:60])
             mp3_path = audio_dir / f"{talk.talk_index:03d}-{sanitize_filename(talk.title)}.mp3"

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -11,6 +11,7 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 
+from mutagen import MutagenError
 from mutagen.mp4 import MP4
 from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 
@@ -438,7 +439,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
         has_cover = mp4.tags is not None and "covr" in mp4.tags
         if not has_cover:
             logger.warning("Verification: no cover art found in %s", output_path.name)
-    except Exception as exc:
+    except (MutagenError, OSError) as exc:
         logger.warning("Verification: mutagen could not read %s: %s", output_path.name, exc)
 
     # Chapter count and titles — ffprobe
@@ -452,6 +453,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
                 str(output_path),
             ],
             capture_output=True,
+            check=True,
             text=True,
             encoding="utf-8",
             timeout=30,
@@ -483,7 +485,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
             "Verified m4b: %d chapters, %.0fs total", chapter_count, total_s
         )
 
-    except Exception as exc:
+    except (json.JSONDecodeError, OSError, subprocess.SubprocessError, ValueError) as exc:
         logger.warning("Verification: ffprobe chapter check failed: %s", exc)
 
 

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -110,7 +110,8 @@ def _ffmeta_escape(value: str) -> str:
     return value
 
 
-_SUBPROCESS_TIMEOUT = 600   # 10 minutes — generous for large conference builds
+_SUBPROCESS_TIMEOUT = 600   # 10 minutes — for concat/mux of full conference
+_CONVERT_TIMEOUT = 120      # 2 minutes — per-file AAC conversion
 _FALLBACK_BITRATE = "64k"   # used when ffprobe quality probe fails
 _FALLBACK_SAMPLE_RATE = 44100  # used when ffprobe quality probe fails
 
@@ -163,7 +164,11 @@ def _run_ffmpeg_with_progress(
 
     The command must already include `-progress pipe:1 -nostats` so ffmpeg writes
     key=value progress lines to stdout. A watchdog timer kills the process if it
-    exceeds _SUBPROCESS_TIMEOUT seconds without finishing.
+    exceeds _CONVERT_TIMEOUT seconds without finishing.
+
+    stderr is drained in a background thread to prevent pipe deadlock: if ffmpeg
+    writes more than the OS pipe buffer (4KB on Windows) to stderr while Python
+    is blocked reading stdout, both processes stall indefinitely.
 
     Args:
         cmd: Complete ffmpeg command including -progress pipe:1 -nostats flags.
@@ -185,6 +190,17 @@ def _run_ffmpeg_with_progress(
         errors="replace",
     )
 
+    # Drain stderr in a background thread to prevent pipe buffer deadlock.
+    stderr_lines: list[str] = []
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_lines.append(line)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
     killed_by_watchdog = False
 
     def _watchdog() -> None:
@@ -193,7 +209,7 @@ def _run_ffmpeg_with_progress(
             killed_by_watchdog = True
             proc.kill()
 
-    timer = threading.Timer(_SUBPROCESS_TIMEOUT, _watchdog)
+    timer = threading.Timer(_CONVERT_TIMEOUT, _watchdog)
     timer.start()
     try:
         assert proc.stdout is not None  # guaranteed by stdout=PIPE
@@ -212,17 +228,16 @@ def _run_ffmpeg_with_progress(
         timer.cancel()
 
     proc.wait()
+    stderr_thread.join(timeout=5)
 
     if killed_by_watchdog:
         raise AudioError(
-            f"{label} timed out after {_SUBPROCESS_TIMEOUT}s. "
-            "The ffmpeg process was killed. Try with fewer talks or check for corrupt MP3 files."
+            f"{label} timed out after {_CONVERT_TIMEOUT}s. "
+            "The ffmpeg process was killed. Check for corrupt or unsupported MP3 files."
         )
 
     if proc.returncode != 0:
-        stderr = ""
-        if proc.stderr:
-            stderr = proc.stderr.read()
+        stderr = "".join(stderr_lines)
         raise AudioError(
             f"{label} failed (exit {proc.returncode}).\n"
             f"Command: {' '.join(cmd)}\n"

--- a/src/gencon_audiobook/cache.py
+++ b/src/gencon_audiobook/cache.py
@@ -133,6 +133,7 @@ def _talk_from_dict(d: dict[str, Any]) -> Talk:
         speaker=d["speaker"],
         talk_url=d["talk_url"],
         mp3_url=d.get("mp3_url"),
+        video_url=d.get("video_url"),
         transcript_html=d.get("transcript_html"),
         speaker_image_url=d.get("speaker_image_url"),
         inline_images=inline_images,

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import calendar
 import logging
+import re
 import shutil
 import sys
 import time
@@ -30,6 +32,9 @@ _DISK_WARN_MB = 500
 
 # Module-level console so helpers can print without threading a Console argument.
 console = Console()
+
+_CONF_BASE = "https://www.churchofjesuschrist.org/study/general-conference"
+_CONFERENCE_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
 
 
 # ---------------------------------------------------------------------------
@@ -124,18 +129,34 @@ def _check_disk_space(path: Path) -> None:
 def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     """Resolve the conference to download.
 
-    If conference_filter is given, find the first match (case-insensitive).
-    Otherwise print a numbered menu and default to the most recent.
+    If conference_filter is given as YYYY-MM, construct the URL directly — no
+    listing fetch needed. Otherwise fetch the listing and default to the most recent.
 
     Args:
-        conference_filter: Partial conference name to match, or None.
+        conference_filter: Conference date as YYYY-MM (e.g., '2024-04'), or None.
 
     Returns:
         (title, url) of the selected conference.
 
     Raises:
-        SystemExit: if the filter matches nothing or the list cannot be fetched.
+        SystemExit: if the format is invalid or the listing cannot be fetched.
     """
+    if conference_filter:
+        m = _CONFERENCE_RE.match(conference_filter)
+        if not m:
+            click.echo(
+                f"Error: Invalid conference format {conference_filter!r}.\n"
+                "Expected YYYY-MM (e.g., '2024-04' or '1999-10').",
+                err=True,
+            )
+            sys.exit(1)
+        year, month = int(m.group(1)), int(m.group(2))
+        title = f"{calendar.month_name[month]} {year} General Conference"
+        url = f"{_CONF_BASE}/{year}/{month:02d}"
+        console.print(f"Selected: {title}")
+        return title, url
+
+    # No filter — fetch listing, default to most recent.
     try:
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
             sp.add_task("Fetching available conferences...")
@@ -152,23 +173,6 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
         )
         sys.exit(1)
 
-    if conference_filter:
-        needle = conference_filter.lower()
-        matches = [r for r in refs if needle in r.title.lower()]
-        if not matches:
-            click.echo(
-                f"Error: No conference matching {conference_filter!r}.\n\n"
-                "Available conferences:",
-                err=True,
-            )
-            for i, r in enumerate(refs[:10], 1):
-                click.echo(f"  {i}. {r.title}", err=True)
-            sys.exit(1)
-        selected = matches[0]
-        console.print(f"Selected: {selected.title}")
-        return selected.title, selected.url
-
-    # Default: most recent (first in list)
     console.print(f"Found {len(refs)} conferences. Using: {refs[0].title}")
     return refs[0].title, refs[0].url
 
@@ -188,7 +192,7 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 @click.option(
     "--conference",
     default=None,
-    help="Conference to download (e.g., 'April 2024'). Defaults to most recent.",
+    help="Conference date as YYYY-MM (e.g., '2024-04'). Defaults to most recent.",
 )
 @click.option(
     "--audiobook-only",

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import calendar
 import logging
+import os
 import re
 import shutil
 import sys
 import time
 from pathlib import Path
+from typing import cast
 
 import click
 from rich.logging import RichHandler
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
@@ -22,6 +24,7 @@ from .downloader import (
     DownloadError,
     DownloadResult,
     _probe_audio_info,
+    conference_downloads_complete,
     download_conference,
 )
 from .epub_builder import EpubError, build_epub
@@ -43,6 +46,33 @@ console = shared_console
 
 _CONF_BASE = "https://www.churchofjesuschrist.org/study/general-conference"
 _CONFERENCE_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
+
+
+class _OutputPathType(click.Path):
+    """Click path type that catches another option being used as --output's value."""
+
+    def convert(
+        self,
+        value: str | os.PathLike[str],
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> str:
+        if isinstance(value, str) and value.startswith("-"):
+            self.fail("requires a value and cannot use another option as its value", param, ctx)
+        return cast(str, super().convert(value, param, ctx))
+
+
+class _CliCommand(click.Command):
+    """Command subclass for clearer parse errors before Click consumes flags as values."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if "--output" in args:
+            index = args.index("--output")
+            if index == len(args) - 1 or args[index + 1].startswith("-"):
+                raise click.UsageError(
+                    "Option '--output' requires a value and cannot use another option as its value."
+                )
+        return super().parse_args(ctx, args)
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +196,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 
     # No filter — fetch listing, default to most recent.
     try:
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console) as sp:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            console=console,
+        ) as sp:
             sp.add_task("Fetching available conferences...")
             refs = fetch_available_conferences()
     except ScraperError as exc:
@@ -190,11 +225,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 
 
-@click.command()
+@click.command(cls=_CliCommand)
 @click.option(
     "--output",
     default="~/gencon-audiobook",
     show_default=True,
+    type=_OutputPathType(path_type=str),
     help="Directory to save output files.",
 )
 @click.option(
@@ -272,6 +308,13 @@ def main(
     """Download General Conference talks as a chaptered m4b audiobook and epub companion."""
     _check_python_version()
     _setup_logging(verbose)
+    if audiobook_only and epub_only:
+        click.echo(
+            "Error: --audiobook-only and --epub-only are mutually exclusive. "
+            "Choose one output type or omit both to build both.",
+            err=True,
+        )
+        sys.exit(1)
 
     try:
         _run(
@@ -354,8 +397,13 @@ def _print_completion_report(
         size_mb = epub_path.stat().st_size / 1_048_576
         console.print(f"  EPUB:          {epub_path.name} ({size_mb:.1f} MB)")
 
-    if phase_times:
-        parts = ", ".join(f"{label} {elapsed:.0f}s" for label, elapsed in phase_times.items())
+    visible_phase_times = {
+        label: elapsed for label, elapsed in phase_times.items() if elapsed > 0.5
+    }
+    if visible_phase_times:
+        parts = ", ".join(
+            f"{label} {elapsed:.0f}s" for label, elapsed in visible_phase_times.items()
+        )
         console.print(f"  Timing:        {parts}")
 
     if len(failed_talks) > 0:
@@ -424,6 +472,7 @@ def _confirm_audio_choice(
     mp3_probe: AudioProbe,
     video_probe: AudioProbe,
     prefer_video_audio: bool,
+    skip_confirmation: bool = False,
 ) -> bool:
     """Return True when download_conference should extract video audio."""
     mp3_bitrate = mp3_probe.audio_bitrate_bps
@@ -434,8 +483,8 @@ def _confirm_audio_choice(
     if video_bitrate <= mp3_bitrate:
         if prefer_video_audio:
             console.print(
-                "\n--prefer-video-audio was requested, but the MP3 source is already "
-                "equal or better for this conference."
+                "\n[yellow]--prefer-video-audio was requested, but the MP3 source is already "
+                "equal or better for this conference.[/yellow]"
             )
             console.print(f"\n  Source MP3:  {_kbps(mp3_bitrate)} kbps")
             console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
@@ -444,7 +493,7 @@ def _confirm_audio_choice(
         return False
 
     if not prefer_video_audio:
-        console.print("\nHigher quality audio is available for this conference.\n")
+        console.print("\n[yellow]Higher quality audio is available for this conference.[/yellow]\n")
         console.print(f"  Source MP3:  {_kbps(mp3_bitrate)} kbps")
         console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
         console.print(
@@ -456,10 +505,14 @@ def _confirm_audio_choice(
             sys.exit(0)
         return False
 
+    console.print("\n[cyan]--prefer-video-audio is active.[/cyan]\n")
+    if skip_confirmation:
+        console.print("All downloads and the audiobook already exist; skipping download confirmation.")
+        return True
+
     download_size, audio_cache_size, mp3_size, video_count, fallback_count = _video_estimates(
         conf_obj, mp3_probe, video_probe
     )
-    console.print("\n--prefer-video-audio is active.\n")
     console.print(
         f"  Talks to process:      {len(conf_obj.talks)}  "
         f"({video_count} via video, {fallback_count} fallback to MP3)"
@@ -493,6 +546,8 @@ def _run(
     # Resolve the output directory early — conf_title matches conf_obj.title, so we
     # can check the cache before scraping rather than after.
     conf_output_dir = output_dir / conf_title
+    m4b_path = conf_output_dir / f"{conf_title}.m4b"
+    epub_path = conf_output_dir / f"{conf_title}.epub"
 
     # Load from cache if available and --force-scrape not set.
     conf_obj = None
@@ -511,6 +566,14 @@ def _run(
         try:
             conf_obj = scrape_conference(conf_url)
         except ScraperError as exc:
+            if conference and "not found" in str(exc).lower():
+                click.echo(
+                    f"Error: Conference {conference} was not found at churchofjesuschrist.org.\n"
+                    "Check the conference code or run without --conference to choose from "
+                    "available conferences.",
+                    err=True,
+                )
+                sys.exit(1)
             click.echo(f"Error: {exc}", err=True)
             sys.exit(1)
         phase_times["scrape"] = time.monotonic() - t0
@@ -542,8 +605,24 @@ def _run(
         quality = _probe_conference_quality(conf_obj, ffprobe)
         if quality is not None:
             mp3_probe, video_probe = quality
+            skip_video_confirmation = (
+                prefer_video_audio
+                and audiobook_only
+                and not overwrite
+                and m4b_path.exists()
+                and conference_downloads_complete(
+                    conf_obj,
+                    conf_output_dir,
+                    skip_audio=False,
+                    prefer_video_audio=True,
+                )
+            )
             use_video_audio = _confirm_audio_choice(
-                conf_obj, mp3_probe, video_probe, prefer_video_audio
+                conf_obj,
+                mp3_probe,
+                video_probe,
+                prefer_video_audio,
+                skip_confirmation=skip_video_confirmation,
             )
 
     # Warn if disk space is low before starting downloads.
@@ -564,8 +643,10 @@ def _run(
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
         sys.exit(1)
-    phase_times["download"] = time.monotonic() - t0
-    failed_talks = dl_result.failed_talks
+    downloaded_count = dl_result.downloaded if isinstance(dl_result.downloaded, int) else 0
+    failed_talks = dl_result.failed_talks if isinstance(dl_result.failed_talks, list) else []
+    if downloaded_count > 0 or failed_talks:
+        phase_times["download"] = time.monotonic() - t0
 
     m4b_path = conf_output_dir / f"{conf_obj.title}.m4b"
     epub_path = conf_output_dir / f"{conf_obj.title}.epub"
@@ -573,6 +654,15 @@ def _run(
 
     # Build m4b audiobook
     if not epub_only:
+        if failed_talks and len(failed_talks) == len(conf_obj.talks):
+            click.echo(
+                "Error: No talk audio files were downloaded, so the audiobook cannot be built.\n"
+                f"All {len(failed_talks)} talk(s) failed. Check the log for details:\n"
+                f"{conf_output_dir / _LOG_FILENAME}\n"
+                "Run again to retry; already-downloaded files will be reused.",
+                err=True,
+            )
+            sys.exit(1)
         console.print("Building audiobook...")
         assert ffmpeg is not None
         assert ffprobe is not None
@@ -614,6 +704,7 @@ def _run(
                 with Progress(
                     SpinnerColumn(),
                     TextColumn("[progress.description]{task.description}"),
+                    TimeElapsedColumn(),
                     console=console,
                 ) as sp:
                     sp.add_task(f"Building EPUB: {conf_obj.title}")

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -11,7 +11,6 @@ import time
 from pathlib import Path
 
 import click
-from rich.console import Console
 from rich.logging import RichHandler
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -22,6 +21,7 @@ from .downloader import DownloadError, DownloadResult, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
 from .models import Talk
+from .progress import shared_console
 from .scraper import ScraperError, fetch_available_conferences, scrape_conference
 
 logger = logging.getLogger(__name__)
@@ -30,8 +30,10 @@ _LOG_FILENAME = "gencon-audiobook.log"
 _MIN_PYTHON = (3, 10)
 _DISK_WARN_MB = 500
 
-# Module-level console so helpers can print without threading a Console argument.
-console = Console()
+# Use the shared console from progress.py so RichHandler and all Progress bars
+# write through the same Console — Rich then interleaves log messages correctly
+# above the live progress bar instead of clobbering the same terminal line.
+console = shared_console
 
 _CONF_BASE = "https://www.churchofjesuschrist.org/study/general-conference"
 _CONFERENCE_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
@@ -158,7 +160,7 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 
     # No filter — fetch listing, default to most recent.
     try:
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
+        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console) as sp:
             sp.add_task("Fetching available conferences...")
             refs = fetch_available_conferences()
     except ScraperError as exc:
@@ -475,6 +477,7 @@ def _run(
                 with Progress(
                     SpinnerColumn(),
                     TextColumn("[progress.description]{task.description}"),
+                    console=console,
                 ) as sp:
                     sp.add_task(f"Building EPUB: {conf_obj.title}")
                     build_epub(

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -17,10 +17,16 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
 from .cache import CACHE_FILENAME, load_cache, save_cache
-from .downloader import DownloadError, DownloadResult, download_conference
+from .downloader import (
+    AudioProbe,
+    DownloadError,
+    DownloadResult,
+    _probe_audio_info,
+    download_conference,
+)
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
-from .models import Talk
+from .models import Conference, Talk
 from .progress import shared_console
 from .scraper import ScraperError, fetch_available_conferences, scrape_conference
 
@@ -243,6 +249,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     default=False,
     help="Add left-margin paragraph numbers to each talk transcript in the EPUB.",
 )
+@click.option(
+    "--prefer-video-audio",
+    is_flag=True,
+    default=False,
+    help="Use higher-quality audio extracted from 360p video when it beats the MP3 source.",
+)
 @click.version_option(version=__version__, prog_name="gencon-audiobook")
 def main(
     output: str,
@@ -255,6 +267,7 @@ def main(
     bitrate: str | None,
     sample_rate: int | None,
     epub_paragraph_numbers: bool,
+    prefer_video_audio: bool,
 ) -> None:
     """Download General Conference talks as a chaptered m4b audiobook and epub companion."""
     _check_python_version()
@@ -271,6 +284,7 @@ def main(
             bitrate=bitrate,
             sample_rate=sample_rate,
             epub_paragraph_numbers=epub_paragraph_numbers,
+            prefer_video_audio=prefer_video_audio,
         )
     except KeyboardInterrupt:
         console.print(
@@ -297,7 +311,7 @@ def _format_duration(seconds: float) -> str:
 
 
 def _print_completion_report(
-    conf_title: str,
+    conference: Conference,
     conf_output_dir: Path,
     m4b_path: Path,
     epub_path: Path,
@@ -308,7 +322,7 @@ def _print_completion_report(
     """Print a structured completion report to the console.
 
     Args:
-        conf_title: Human-readable conference title.
+        conference: Conference metadata used for output names and session details.
         conf_output_dir: Conference output directory.
         m4b_path: Path to the built m4b file (may not exist if epub-only).
         epub_path: Path to the built epub file (may not exist if audiobook-only).
@@ -318,7 +332,10 @@ def _print_completion_report(
     """
     console.print("")
     console.print("--- Completion Report ---")
-    console.print(f"  Conference:    {conf_title}")
+    console.print(f"  Conference:    {conference.title}")
+    console.print(f"  Sessions:      {len(conference.sessions)}")
+    for session in conference.sessions:
+        console.print(f"    - {session.name}")
 
     if stats is not None:
         console.print(f"  Duration:      {_format_duration(stats.duration_seconds)}")
@@ -353,6 +370,108 @@ def _print_completion_report(
     console.print(f"  Log:    {conf_output_dir / _LOG_FILENAME}")
 
 
+def _format_bytes(size_bytes: float) -> str:
+    """Format a byte count as MB or GB for terminal display."""
+    if size_bytes >= 1024 ** 3:
+        return f"~{size_bytes / (1024 ** 3):.1f} GB"
+    return f"~{size_bytes / (1024 ** 2):.0f} MB"
+
+
+def _find_probe_talk(talks: list[Talk]) -> Talk | None:
+    """Return the first talk with both MP3 and video URLs."""
+    return next((talk for talk in talks if talk.mp3_url and talk.video_url), None)
+
+
+def _probe_conference_quality(conf_obj: Conference, ffprobe: Path) -> tuple[AudioProbe, AudioProbe] | None:
+    """Probe representative MP3 and video audio quality for a conference."""
+    probe_talk = _find_probe_talk(conf_obj.talks)
+    if probe_talk is None or probe_talk.mp3_url is None or probe_talk.video_url is None:
+        return None
+    try:
+        return (
+            _probe_audio_info(probe_talk.mp3_url, ffprobe),
+            _probe_audio_info(probe_talk.video_url, ffprobe),
+        )
+    except (OSError, ValueError, DownloadError) as exc:
+        logger.warning("Could not probe audio quality: %s", exc)
+        return None
+
+
+def _kbps(bit_rate: int | None) -> int:
+    return round((bit_rate or 0) / 1000)
+
+
+def _video_estimates(conf_obj: Conference, mp3_probe: AudioProbe, video_probe: AudioProbe) -> tuple[str, str, str, int, int]:
+    """Return display estimates for --prefer-video-audio confirmation."""
+    video_count = sum(1 for talk in conf_obj.talks if talk.video_url)
+    total_count = len(conf_obj.talks)
+    fallback_count = total_count - video_count
+    avg_duration = video_probe.duration_seconds or mp3_probe.duration_seconds or 0
+    video_download_bytes = ((video_probe.total_bitrate_bps or video_probe.audio_bitrate_bps or 0) * avg_duration * video_count) / 8
+    audio_cache_bytes = ((video_probe.audio_bitrate_bps or 0) * avg_duration * video_count) / 8
+    mp3_bytes = ((mp3_probe.audio_bitrate_bps or 0) * avg_duration * total_count) / 8
+    return (
+        _format_bytes(video_download_bytes),
+        _format_bytes(audio_cache_bytes),
+        _format_bytes(mp3_bytes),
+        video_count,
+        fallback_count,
+    )
+
+
+def _confirm_audio_choice(
+    conf_obj: Conference,
+    mp3_probe: AudioProbe,
+    video_probe: AudioProbe,
+    prefer_video_audio: bool,
+) -> bool:
+    """Return True when download_conference should extract video audio."""
+    mp3_bitrate = mp3_probe.audio_bitrate_bps
+    video_bitrate = video_probe.audio_bitrate_bps
+    if not mp3_bitrate or not video_bitrate:
+        return False
+
+    if video_bitrate <= mp3_bitrate:
+        if prefer_video_audio:
+            console.print(
+                "\n--prefer-video-audio was requested, but the MP3 source is already "
+                "equal or better for this conference."
+            )
+            console.print(f"\n  Source MP3:  {_kbps(mp3_bitrate)} kbps")
+            console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
+            if not click.confirm("\nContinue with standard MP3 audio?", default=True):
+                sys.exit(0)
+        return False
+
+    if not prefer_video_audio:
+        console.print("\nHigher quality audio is available for this conference.\n")
+        console.print(f"  Source MP3:  {_kbps(mp3_bitrate)} kbps")
+        console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
+        console.print(
+            "\nRe-run with --prefer-video-audio to download higher quality audio.\n"
+            "Note: video audio extraction takes significantly longer and requires\n"
+            "much more disk space than standard MP3 download."
+        )
+        if not click.confirm("\nContinue with lower quality?", default=False):
+            sys.exit(0)
+        return False
+
+    download_size, audio_cache_size, mp3_size, video_count, fallback_count = _video_estimates(
+        conf_obj, mp3_probe, video_probe
+    )
+    console.print("\n--prefer-video-audio is active.\n")
+    console.print(
+        f"  Talks to process:      {len(conf_obj.talks)}  "
+        f"({video_count} via video, {fallback_count} fallback to MP3)"
+    )
+    console.print(f"  Estimated download:    {download_size}  (vs {mp3_size} for MP3 only)")
+    console.print(f"  Estimated audio cache: {audio_cache_size}")
+    console.print("\nDownload time will be significantly longer than a standard run.")
+    if not click.confirm("\nProceed?", default=False):
+        sys.exit(0)
+    return True
+
+
 def _run(
     output: str,
     conference: str | None,
@@ -363,6 +482,7 @@ def _run(
     bitrate: str | None,
     sample_rate: int | None,
     epub_paragraph_numbers: bool = False,
+    prefer_video_audio: bool = False,
 ) -> None:
     """Inner implementation of main() — separated so KeyboardInterrupt is handled cleanly."""
     output_dir = Path(output).expanduser().resolve()
@@ -409,6 +529,23 @@ def _run(
         )
         sys.exit(1)
 
+    ffmpeg: Path | None = None
+    ffprobe: Path | None = None
+    use_video_audio = False
+    if not epub_only:
+        try:
+            ffmpeg = ensure_ffmpeg()
+            ffprobe = ensure_ffprobe()
+        except FfmpegNotFoundError as exc:
+            click.echo(f"Error: ffmpeg not available.\n{exc}", err=True)
+            sys.exit(1)
+        quality = _probe_conference_quality(conf_obj, ffprobe)
+        if quality is not None:
+            mp3_probe, video_probe = quality
+            use_video_audio = _confirm_audio_choice(
+                conf_obj, mp3_probe, video_probe, prefer_video_audio
+            )
+
     # Warn if disk space is low before starting downloads.
     _check_disk_space(conf_output_dir)
 
@@ -418,7 +555,11 @@ def _run(
     t0 = time.monotonic()
     try:
         dl_result: DownloadResult = download_conference(
-            conf_obj, conf_output_dir, skip_audio=epub_only
+            conf_obj,
+            conf_output_dir,
+            skip_audio=epub_only,
+            prefer_video_audio=use_video_audio,
+            ffmpeg_path=ffmpeg,
         )
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
@@ -433,12 +574,8 @@ def _run(
     # Build m4b audiobook
     if not epub_only:
         console.print("Building audiobook...")
-        try:
-            ffmpeg = ensure_ffmpeg()
-            ffprobe = ensure_ffprobe()
-        except FfmpegNotFoundError as exc:
-            click.echo(f"Error: ffmpeg not available.\n{exc}", err=True)
-            sys.exit(1)
+        assert ffmpeg is not None
+        assert ffprobe is not None
 
         audio_dir = conf_output_dir / "audio"
         cover_path = conf_output_dir / "cover.jpg"
@@ -492,7 +629,7 @@ def _run(
             phase_times["epub"] = time.monotonic() - t0
 
     _print_completion_report(
-        conf_title=conf_obj.title,
+        conference=conf_obj,
         conf_output_dir=conf_output_dir,
         m4b_path=m4b_path,
         epub_path=epub_path,

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -16,7 +16,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
 from .cache import CACHE_FILENAME, load_cache, save_cache
-from .downloader import DownloadError, download_conference
+from .downloader import DownloadError, DownloadResult, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
 from .models import Talk
@@ -407,16 +407,18 @@ def _run(
     _check_disk_space(conf_output_dir)
 
     # Download audio (skipped for --epub-only) and images.
-    console.print(f"Downloading files for {len(conf_obj.talks)} talks...")
+    # download_conference() prints its own contextual message and skips silently
+    # if all files are already present.
     t0 = time.monotonic()
     try:
-        failed_talks: list[Talk] = download_conference(
+        dl_result: DownloadResult = download_conference(
             conf_obj, conf_output_dir, skip_audio=epub_only
         )
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
         sys.exit(1)
     phase_times["download"] = time.monotonic() - t0
+    failed_talks = dl_result.failed_talks
 
     m4b_path = conf_output_dir / f"{conf_obj.title}.m4b"
     epub_path = conf_output_dir / f"{conf_obj.title}.epub"

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -12,17 +12,8 @@ from typing import cast
 
 import requests
 from PIL import Image
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TaskProgressColumn,
-    TextColumn,
-)
-
 from .models import Conference, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import standard_progress
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -316,14 +307,7 @@ def download_conference(
         len(image_queue),
     )
 
-    overall_progress = Progress(
-        SpinnerColumn(),
-        MofNCompleteColumn(),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeRemainingWithLabel(compact=True),
-        TextColumn("[progress.description]{task.description}"),
-    )
+    overall_progress = standard_progress()
 
     failed: list[str] = []
     failed_talks: list[Talk] = []

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -13,10 +13,8 @@ from typing import cast
 
 import requests
 from PIL import Image
-from rich.console import Console
-
 from .models import Conference, Talk
-from .progress import standard_progress
+from .progress import shared_console as _console, standard_progress
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -29,8 +27,6 @@ _IMAGE_WORKERS = 8              # concurrent image download threads
 # requests.Session is NOT thread-safe; sharing one across threads causes
 # intermittent connection errors and garbled responses.
 _thread_locals: threading.local = threading.local()
-
-_console = Console()
 
 
 class DownloadError(Exception):

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -48,6 +48,19 @@ class DownloadResult:
 
 
 @dataclass(frozen=True)
+class _DownloadItem:
+    """One queued download or extraction operation."""
+
+    url: str
+    dest: Path
+    label: str
+    is_image: bool
+    talk: Talk | None = None
+    fallback_url: str | None = None
+    fallback_dest: Path | None = None
+
+
+@dataclass(frozen=True)
 class AudioProbe:
     """Remote media probe details needed for quality comparison and estimates."""
 
@@ -338,6 +351,7 @@ def _extract_video_audio(video_url: str, dest: Path, ffmpeg_path: Path) -> bool:
         "-i", video_url,
         "-vn",
         "-acodec", "copy",
+        "-f", "ipod",
         "-y",
         str(tmp),
     ]
@@ -379,6 +393,36 @@ def _inline_image_path(output_dir: Path, talk: Talk, asset_id: str) -> Path:
     return output_dir / "inline" / f"{talk.talk_index:03d}-{safe_id}.jpg"
 
 
+def conference_downloads_complete(
+    conference: Conference,
+    output_dir: Path,
+    skip_audio: bool = False,
+    prefer_video_audio: bool = False,
+) -> bool:
+    """Return True when every file download_conference would queue already exists."""
+    expected: list[Path] = []
+
+    if not skip_audio:
+        for talk in conference.talks:
+            if prefer_video_audio and talk.video_url:
+                expected.append(_video_audio_path(output_dir, talk))
+            elif talk.mp3_url:
+                expected.append(_audio_path(output_dir, talk))
+
+    if conference.cover_image_url:
+        expected.append(output_dir / "cover.jpg")
+
+    for talk in conference.talks:
+        if talk.speaker_image_url:
+            expected.append(_speaker_path(output_dir, talk))
+        expected.extend(
+            _inline_image_path(output_dir, talk, img.asset_id)
+            for img in talk.inline_images
+        )
+
+    return bool(expected) and all(path.exists() for path in expected)
+
+
 def download_conference(
     conference: Conference,
     output_dir: Path,
@@ -413,34 +457,47 @@ def download_conference(
     session = _make_session()
     talks = conference.talks
 
-    # Build download queue: (url, dest, label, is_image, talk_or_none)
-    # talk_or_none is set for audio items so failed talks can be returned to the caller.
-    queue: list[tuple[str, Path, str, bool, Talk | None]] = []
+    # talk is set for audio items so failed talks can be returned to the caller.
+    queue: list[_DownloadItem] = []
 
     if not skip_audio:
         for talk in talks:
             if prefer_video_audio and talk.video_url:
                 dest = _video_audio_path(output_dir, talk)
-                queue.append((talk.video_url, dest, f"[video audio] {talk.title[:50]}", False, talk))
+                queue.append(_DownloadItem(
+                    url=talk.video_url,
+                    dest=dest,
+                    label=f"[video audio] {talk.title[:50]}",
+                    is_image=False,
+                    talk=talk,
+                    fallback_url=talk.mp3_url,
+                    fallback_dest=_audio_path(output_dir, talk) if talk.mp3_url else None,
+                ))
             elif talk.mp3_url:
                 dest = _audio_path(output_dir, talk)
-                queue.append((talk.mp3_url, dest, f"[audio] {talk.title[:50]}", False, talk))
+                queue.append(_DownloadItem(
+                    url=talk.mp3_url,
+                    dest=dest,
+                    label=f"[audio] {talk.title[:50]}",
+                    is_image=False,
+                    talk=talk,
+                ))
             else:
                 logger.warning("Talk %r has no mp3_url — skipping audio download", talk.title)
 
     if conference.cover_image_url:
         cover_dest = output_dir / "cover.jpg"
-        queue.append((conference.cover_image_url, cover_dest, "[cover] cover.jpg", True, None))
+        queue.append(_DownloadItem(conference.cover_image_url, cover_dest, "[cover] cover.jpg", True))
 
     for talk in talks:
         if talk.speaker_image_url:
             dest = _speaker_path(output_dir, talk)
-            queue.append((talk.speaker_image_url, dest, f"[photo] {talk.speaker[:40]}", True, None))
+            queue.append(_DownloadItem(talk.speaker_image_url, dest, f"[photo] {talk.speaker[:40]}", True))
 
     for talk in talks:
         for img in talk.inline_images:
             dest = _inline_image_path(output_dir, talk, img.asset_id)
-            queue.append((img.url, dest, f"[image] {img.asset_id[:40]}", True, None))
+            queue.append(_DownloadItem(img.url, dest, f"[image] {img.asset_id[:40]}", True))
 
     if not queue:
         logger.info("Nothing to download.")
@@ -449,23 +506,25 @@ def download_conference(
     # Pre-scan: count locally present files without making HEAD requests.
     # This is an approximation — audio files are further verified by Content-Length
     # inside download_file, but the pre-scan is cheap and accurate enough for UX.
-    pre_exists = sum(1 for _, dest, _, _, _ in queue if dest.exists())
+    pre_exists = sum(1 for item in queue if item.dest.exists())
     needs_download = len(queue) - pre_exists
 
     if needs_download == 0:
         logger.debug("All %d files already present — skipping download phase.", len(queue))
         return DownloadResult(skipped=len(queue))
 
+    image_queue = [item for item in queue if item.is_image]
+    audio_queue = [item for item in queue if not item.is_image]
+    needed_audio = sum(1 for item in audio_queue if not item.dest.exists())
+    needed_images = sum(1 for item in image_queue if not item.dest.exists())
+    breakdown = f"{needed_audio} audio, {needed_images} image(s)"
     if pre_exists > 0:
         _console.print(
             f"Downloading {needs_download} of {len(queue)} files "
-            f"({pre_exists} already present)..."
+            f"({breakdown}; {pre_exists} already present)..."
         )
     else:
-        _console.print(f"Downloading {len(queue)} files...")
-
-    image_queue = [(url, dest, label) for url, dest, label, is_image, _ in queue if is_image]
-    audio_queue = [(url, dest, label, talk) for url, dest, label, is_image, talk in queue if not is_image]
+        _console.print(f"Downloading {len(queue)} files ({breakdown})...")
 
     logger.debug(
         "Download queue: %d audio, %d image(s)",
@@ -488,15 +547,16 @@ def download_conference(
         # requests.Session is not thread-safe.
         if image_queue:
 
-            def _download_one_image(args: tuple[str, Path, str]) -> tuple[bool, str | None]:
+            def _download_one_image(item: _DownloadItem) -> tuple[bool, str | None]:
                 """Worker: download one image. Returns (was_downloaded, label_on_failure)."""
-                url, dest, label = args
                 try:
-                    was_downloaded = _download_image(url, dest, _get_thread_session(), retries=3)
+                    was_downloaded = _download_image(
+                        item.url, item.dest, _get_thread_session(), retries=3
+                    )
                     return was_downloaded, None
                 except (DownloadError, ValueError) as exc:
-                    logger.error("Failed to download %s: %s", label, exc)
-                    return False, label
+                    logger.error("Failed to download %s: %s", item.label, exc)
+                    return False, item.label
                 finally:
                     overall_progress.advance(overall_task)
 
@@ -516,24 +576,36 @@ def download_conference(
         # MP3s are large; parallel streaming of many large files simultaneously
         # would be impolite to the server and offers little wall-clock benefit
         # since the bottleneck is bandwidth, not latency.
-        for url, dest, label, queue_talk in audio_queue:
-            overall_progress.update(overall_task, description=label)
+        for item in audio_queue:
+            overall_progress.update(overall_task, description=item.label)
             try:
-                if dest.suffix == ".m4a":
+                if item.dest.suffix == ".m4a":
                     assert ffmpeg_path is not None
-                    was_downloaded = _extract_video_audio(url, dest, ffmpeg_path)
+                    try:
+                        was_downloaded = _extract_video_audio(item.url, item.dest, ffmpeg_path)
+                    except (DownloadError, ValueError) as exc:
+                        if item.fallback_url is None or item.fallback_dest is None:
+                            raise
+                        logger.warning(
+                            "Video audio extraction failed for %r; falling back to MP3: %s",
+                            item.talk.title if item.talk else item.label,
+                            exc,
+                        )
+                        was_downloaded = download_file(
+                            item.fallback_url, item.fallback_dest, session, retries=3
+                        )
                 else:
-                    was_downloaded = download_file(url, dest, session, retries=3)
+                    was_downloaded = download_file(item.url, item.dest, session, retries=3)
                 if was_downloaded:
                     downloaded += 1
                     time.sleep(delay)
                 else:
                     skipped += 1
             except (DownloadError, ValueError) as exc:
-                logger.error("Failed to download %s: %s", label, exc)
-                failed.append(label)
-                if queue_talk is not None:
-                    failed_talks.append(queue_talk)
+                logger.error("Failed to download %s: %s", item.label, exc)
+                failed.append(item.label)
+                if item.talk is not None:
+                    failed_talks.append(item.talk)
             finally:
                 overall_progress.advance(overall_task)
 

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -6,12 +6,14 @@ import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
 from typing import cast
 
 import requests
 from PIL import Image
+from rich.console import Console
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -36,9 +38,20 @@ _IMAGE_WORKERS = 8              # concurrent image download threads
 # intermittent connection errors and garbled responses.
 _thread_locals: threading.local = threading.local()
 
+_console = Console()
+
 
 class DownloadError(Exception):
     """Raised when a file download fails after all retries."""
+
+
+@dataclass
+class DownloadResult:
+    """Results returned by download_conference()."""
+
+    failed_talks: list[Talk] = field(default_factory=list)
+    downloaded: int = 0
+    skipped: int = 0
 
 
 def download_file(
@@ -47,7 +60,7 @@ def download_file(
     session: requests.Session,
     timeout: tuple[int, int] = (30, 120),
     retries: int = 3,
-) -> None:
+) -> bool:
     """Download a single file to dest, using .tmp + rename for atomicity.
 
     Skips download if dest already exists with expected size (from Content-Length).
@@ -59,6 +72,9 @@ def download_file(
         session: requests.Session to use.
         timeout: (connect_timeout, read_timeout) in seconds.
         retries: Number of retry attempts with exponential backoff.
+
+    Returns:
+        True if the file was downloaded, False if it was skipped (already present).
 
     Raises:
         DownloadError: if download fails after all retries.
@@ -74,7 +90,7 @@ def download_file(
             expected = int(head.headers.get("Content-Length", -1))
             if expected > 0 and dest.stat().st_size == expected:
                 logger.debug("Skipping %s — already downloaded (%d bytes)", dest.name, expected)
-                return
+                return False
         except Exception as exc:
             logger.debug("HEAD request failed for %s, re-downloading: %s", url, exc)
 
@@ -99,7 +115,7 @@ def download_file(
 
             tmp.replace(dest)
             logger.debug("Downloaded: %s (%d bytes)", dest.name, dest.stat().st_size)
-            return
+            return True
 
         except Exception as exc:
             last_exc = exc
@@ -140,7 +156,7 @@ def _download_image(
     session: requests.Session,
     timeout: tuple[int, int] = (30, 120),
     retries: int = 3,
-) -> None:
+) -> bool:
     """Download an image, convert to JPEG, and save to dest.
 
     Skips if dest already exists (images don't resume by size — content-identical
@@ -153,6 +169,9 @@ def _download_image(
         timeout: (connect_timeout, read_timeout) in seconds.
         retries: Number of retry attempts.
 
+    Returns:
+        True if the image was downloaded, False if it was skipped (already present).
+
     Raises:
         DownloadError: if download or conversion fails after all retries.
         ValueError: if url fails validate_url().
@@ -162,7 +181,7 @@ def _download_image(
 
     if dest.exists():
         logger.debug("Skipping image %s — already exists", dest.name)
-        return
+        return False
 
     tmp = dest.with_suffix(dest.suffix + ".tmp")
     last_exc: Exception | None = None
@@ -182,7 +201,7 @@ def _download_image(
             tmp.write_bytes(jpeg_bytes)
             tmp.replace(dest)
             logger.debug("Downloaded image: %s (%d bytes)", dest.name, dest.stat().st_size)
-            return
+            return True
 
         except Exception as exc:
             last_exc = exc
@@ -255,21 +274,22 @@ def download_conference(
     output_dir: Path,
     delay: float = 0.5,
     skip_audio: bool = False,
-) -> list[Talk]:
+) -> DownloadResult:
     """Download all MP3s, cover image, and speaker photos for a conference.
 
     Files are downloaded to .tmp first, renamed on success. Existing files of
     the correct size are skipped (resume behavior). Speaker photos are converted
-    to JPEG. Progress is shown via rich progress bars.
+    to JPEG. Progress is shown via rich progress bars only when files actually
+    need downloading.
 
     Args:
         conference: Fully populated Conference object with mp3_urls set.
         output_dir: Directory to download into. Created if it doesn't exist.
-        delay: Seconds to wait between HTTP requests.
+        delay: Seconds to wait between audio HTTP requests.
         skip_audio: If True, skip MP3 downloads (for --epub-only mode).
 
     Returns:
-        List of Talk objects whose audio download failed (empty if all succeeded).
+        DownloadResult with counts of downloaded/skipped files and any failed talks.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     cleanup_tmp_files(output_dir)
@@ -305,7 +325,25 @@ def download_conference(
 
     if not queue:
         logger.info("Nothing to download.")
-        return []
+        return DownloadResult()
+
+    # Pre-scan: count locally present files without making HEAD requests.
+    # This is an approximation — audio files are further verified by Content-Length
+    # inside download_file, but the pre-scan is cheap and accurate enough for UX.
+    pre_exists = sum(1 for _, dest, _, _, _ in queue if dest.exists())
+    needs_download = len(queue) - pre_exists
+
+    if needs_download == 0:
+        logger.debug("All %d files already present — skipping download phase.", len(queue))
+        return DownloadResult(skipped=len(queue))
+
+    if pre_exists > 0:
+        _console.print(
+            f"Downloading {needs_download} of {len(queue)} files "
+            f"({pre_exists} already present)..."
+        )
+    else:
+        _console.print(f"Downloading {len(queue)} files...")
 
     image_queue = [(url, dest, label) for url, dest, label, is_image, _ in queue if is_image]
     audio_queue = [(url, dest, label, talk) for url, dest, label, is_image, talk in queue if not is_image]
@@ -327,6 +365,8 @@ def download_conference(
 
     failed: list[str] = []
     failed_talks: list[Talk] = []
+    downloaded = 0
+    skipped = 0
 
     with overall_progress:
         overall_task = overall_progress.add_task("Downloading files", total=len(queue))
@@ -336,15 +376,15 @@ def download_conference(
         # requests.Session is not thread-safe.
         if image_queue:
 
-            def _download_one_image(args: tuple[str, Path, str]) -> str | None:
-                """Worker: download one image. Returns label on failure, None on success."""
+            def _download_one_image(args: tuple[str, Path, str]) -> tuple[bool, str | None]:
+                """Worker: download one image. Returns (was_downloaded, label_on_failure)."""
                 url, dest, label = args
                 try:
-                    _download_image(url, dest, _get_thread_session(), retries=3)
-                    return None
+                    was_downloaded = _download_image(url, dest, _get_thread_session(), retries=3)
+                    return was_downloaded, None
                 except (DownloadError, ValueError) as exc:
                     logger.error("Failed to download %s: %s", label, exc)
-                    return label
+                    return False, label
                 finally:
                     overall_progress.advance(overall_task)
 
@@ -352,9 +392,13 @@ def download_conference(
             with ThreadPoolExecutor(max_workers=workers) as executor:
                 futures = {executor.submit(_download_one_image, item): item for item in image_queue}
                 for future in as_completed(futures):
-                    result = future.result()
-                    if result is not None:
-                        failed.append(result)
+                    was_downloaded, error_label = future.result()
+                    if error_label is not None:
+                        failed.append(error_label)
+                    elif was_downloaded:
+                        downloaded += 1
+                    else:
+                        skipped += 1
 
         # Audio: sequential with courtesy delay between requests.
         # MP3s are large; parallel streaming of many large files simultaneously
@@ -363,8 +407,12 @@ def download_conference(
         for url, dest, label, queue_talk in audio_queue:
             overall_progress.update(overall_task, description=label)
             try:
-                download_file(url, dest, session, retries=3)
-                time.sleep(delay)
+                was_downloaded = download_file(url, dest, session, retries=3)
+                if was_downloaded:
+                    downloaded += 1
+                    time.sleep(delay)
+                else:
+                    skipped += 1
             except (DownloadError, ValueError) as exc:
                 logger.error("Failed to download %s: %s", label, exc)
                 failed.append(label)
@@ -380,4 +428,4 @@ def download_conference(
             ", ".join(failed),
         )
 
-    return failed_talks
+    return DownloadResult(failed_talks=failed_talks, downloaded=downloaded, skipped=skipped)

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -13,8 +13,10 @@ from typing import cast
 
 import requests
 from PIL import Image
+
 from .models import Conference, Talk
-from .progress import shared_console as _console, standard_progress
+from .progress import shared_console as _console
+from .progress import standard_progress
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -79,7 +81,7 @@ def download_file(
             if expected > 0 and dest.stat().st_size == expected:
                 logger.debug("Skipping %s — already downloaded (%d bytes)", dest.name, expected)
                 return False
-        except Exception as exc:
+        except (OSError, requests.RequestException, ValueError) as exc:
             logger.debug("HEAD request failed for %s, re-downloading: %s", url, exc)
 
     tmp = dest.with_suffix(dest.suffix + ".tmp")
@@ -105,7 +107,7 @@ def download_file(
             logger.debug("Downloaded: %s (%d bytes)", dest.name, dest.stat().st_size)
             return True
 
-        except Exception as exc:
+        except (OSError, requests.RequestException) as exc:
             last_exc = exc
             logger.debug("Download attempt %d failed for %s: %s", attempt + 1, url, exc)
             if tmp.exists():
@@ -191,7 +193,7 @@ def _download_image(
             logger.debug("Downloaded image: %s (%d bytes)", dest.name, dest.stat().st_size)
             return True
 
-        except Exception as exc:
+        except (OSError, requests.RequestException) as exc:
             last_exc = exc
             logger.debug("Image download attempt %d failed for %s: %s", attempt + 1, url, exc)
             if tmp.exists():

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import subprocess
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -24,6 +26,7 @@ logger = logging.getLogger(__name__)
 _DOWNLOAD_CHUNK_SIZE = 65_536  # 64 KB chunks for streaming downloads
 _JPEG_QUALITY = 85              # JPEG quality for converted images
 _IMAGE_WORKERS = 8              # concurrent image download threads
+_VIDEO_EXTRACT_TIMEOUT = 60 * 60 * 2
 
 # Thread-local storage so each worker gets its own requests.Session.
 # requests.Session is NOT thread-safe; sharing one across threads causes
@@ -42,6 +45,73 @@ class DownloadResult:
     failed_talks: list[Talk] = field(default_factory=list)
     downloaded: int = 0
     skipped: int = 0
+
+
+@dataclass(frozen=True)
+class AudioProbe:
+    """Remote media probe details needed for quality comparison and estimates."""
+
+    audio_bitrate_bps: int | None
+    duration_seconds: float | None
+    total_bitrate_bps: int | None
+
+
+def _probe_audio_info(url: str, ffprobe_path: Path) -> AudioProbe:
+    """Probe a remote media URL with ffprobe.
+
+    ffprobe uses HTTP range requests for MP3/MP4 metadata, so this does not
+    download the full file.
+    """
+    if not validate_url(url):
+        raise ValueError(f"URL not on allowlist: {url!r}")
+
+    try:
+        result = subprocess.run(
+            [
+                str(ffprobe_path),
+                "-v", "quiet",
+                "-print_format", "json",
+                "-show_streams",
+                "-show_format",
+                "-select_streams", "a:0",
+                url,
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        data = json.loads(result.stdout)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        raise DownloadError(f"ffprobe failed for {url!r}: {exc}") from exc
+    streams = data.get("streams", [])
+    audio_stream = streams[0] if streams else {}
+    fmt = data.get("format", {})
+
+    audio_bitrate = _parse_int(audio_stream.get("bit_rate"))
+    duration = _parse_float(audio_stream.get("duration")) or _parse_float(fmt.get("duration"))
+    total_bitrate = _parse_int(fmt.get("bit_rate")) or audio_bitrate
+    return AudioProbe(audio_bitrate, duration, total_bitrate)
+
+
+def _parse_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _parse_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
 
 
 def download_file(
@@ -247,6 +317,56 @@ def _audio_path(output_dir: Path, talk: Talk) -> Path:
     return output_dir / "audio" / f"{talk.talk_index:03d}-{name}.mp3"
 
 
+def _video_audio_path(output_dir: Path, talk: Talk) -> Path:
+    """Return the destination path for extracted video audio."""
+    return _audio_path(output_dir, talk).with_suffix(".m4a")
+
+
+def _extract_video_audio(video_url: str, dest: Path, ffmpeg_path: Path) -> bool:
+    """Extract AAC audio from a remote MP4 video URL into dest."""
+    if not validate_url(video_url):
+        raise ValueError(f"URL not on allowlist: {video_url!r}")
+    if dest.exists():
+        logger.debug("Skipping video audio %s — already extracted", dest.name)
+        return False
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    cmd = [
+        str(ffmpeg_path),
+        "-nostdin",
+        "-i", video_url,
+        "-vn",
+        "-acodec", "copy",
+        "-y",
+        str(tmp),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_VIDEO_EXTRACT_TIMEOUT,
+        )
+        if result.returncode != 0:
+            raise DownloadError(
+                f"ffmpeg video audio extraction failed for {video_url!r}: "
+                f"{result.stderr[-2000:]}"
+            )
+        tmp.replace(dest)
+        return True
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise DownloadError(f"Failed to extract video audio from {video_url!r}: {exc}") from exc
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
 def _speaker_path(output_dir: Path, talk: Talk) -> Path:
     """Return the destination path for a talk's speaker photo."""
     name = sanitize_filename(talk.speaker)
@@ -264,6 +384,8 @@ def download_conference(
     output_dir: Path,
     delay: float = 0.5,
     skip_audio: bool = False,
+    prefer_video_audio: bool = False,
+    ffmpeg_path: Path | None = None,
 ) -> DownloadResult:
     """Download all MP3s, cover image, and speaker photos for a conference.
 
@@ -277,12 +399,16 @@ def download_conference(
         output_dir: Directory to download into. Created if it doesn't exist.
         delay: Seconds to wait between audio HTTP requests.
         skip_audio: If True, skip MP3 downloads (for --epub-only mode).
+        prefer_video_audio: If True, extract audio from talk.video_url when present.
+        ffmpeg_path: Required when prefer_video_audio is True.
 
     Returns:
         DownloadResult with counts of downloaded/skipped files and any failed talks.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     cleanup_tmp_files(output_dir)
+    if prefer_video_audio and ffmpeg_path is None:
+        raise ValueError("ffmpeg_path is required when prefer_video_audio=True")
 
     session = _make_session()
     talks = conference.talks
@@ -293,7 +419,10 @@ def download_conference(
 
     if not skip_audio:
         for talk in talks:
-            if talk.mp3_url:
+            if prefer_video_audio and talk.video_url:
+                dest = _video_audio_path(output_dir, talk)
+                queue.append((talk.video_url, dest, f"[video audio] {talk.title[:50]}", False, talk))
+            elif talk.mp3_url:
                 dest = _audio_path(output_dir, talk)
                 queue.append((talk.mp3_url, dest, f"[audio] {talk.title[:50]}", False, talk))
             else:
@@ -390,7 +519,11 @@ def download_conference(
         for url, dest, label, queue_talk in audio_queue:
             overall_progress.update(overall_task, description=label)
             try:
-                was_downloaded = download_file(url, dest, session, retries=3)
+                if dest.suffix == ".m4a":
+                    assert ffmpeg_path is not None
+                    was_downloaded = _extract_video_audio(url, dest, ffmpeg_path)
+                else:
+                    was_downloaded = download_file(url, dest, session, retries=3)
                 if was_downloaded:
                     downloaded += 1
                     time.sleep(delay)

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -254,26 +254,44 @@ def _sanitize_transcript(
                 del tag.attrs[attr]
 
     # Preserve internal footnote links as EPUB 3 noterefs; unwrap everything else.
-    # Links whose href starts with "#note" connect superscript markers to footnote
-    # bodies on the same page. Adding epub:type="noteref" lets modern e-readers
-    # (Apple Books, Kobo, Thorium) display the footnote as a dismissible popup.
-    # All other <a> tags (scripture refs, cross-refs) point outside the EPUB
-    # container (RSC-033, RSC-026) and must be unwrapped.
+    # The Church site generates note-ref links with class="note-ref" and a full talk-page
+    # URL ending in "#noteN" (e.g. href="/study/general-conference/2024/04/31bowen?lang=eng#note1").
+    # These must be normalized to bare fragment refs ("#noteN") and marked epub:type="noteref"
+    # so e-readers (Apple Books, Kobo, Thorium) can display the footnote as a dismissible popup.
+    # Bare "#noteN" hrefs (from synthetic or pre-normalized content) are also accepted.
+    # All other <a> tags (scripture refs, cross-refs) point outside the EPUB container
+    # (RSC-033, RSC-026) and must be unwrapped.
+    _NOTE_FRAGMENT_RE = re.compile(r"#(note\d+)$")
     for a_tag in soup.find_all("a"):
         href = str(a_tag.get("href") or "")
-        if href.startswith("#note"):
-            # Strip all attrs except href; add EPUB 3 noteref semantics.
-            a_tag.attrs = {"href": href, "epub:type": "noteref"}
+        scroll_id = str(a_tag.get("data-scroll-id") or "")
+        note_id: str | None = None
+        if scroll_id and re.match(r"^note\d+$", scroll_id):
+            # Canonical case: Church note-ref link with data-scroll-id="noteN"
+            note_id = scroll_id
+        elif href.startswith("#note") and re.match(r"^#note\d+$", href):
+            # Pre-normalized bare fragment ref
+            note_id = href[1:]
+        else:
+            # Check for full URL ending in #noteN fragment
+            m = _NOTE_FRAGMENT_RE.search(href)
+            if m and "note-ref" in (a_tag.get("class") or []):
+                note_id = m.group(1)
+        if note_id:
+            a_tag.attrs = {"href": f"#{note_id}", "epub:type": "noteref"}
         else:
             a_tag.unwrap()
 
     # Wrap footnote body elements in <aside epub:type="footnote">.
-    # The Church site uses id="note1", id="note2", etc. on <p> or <div> elements
-    # for the footnote content. Moving the id to the wrapping <aside> satisfies
-    # EPUB 3 structure: the noteref href="#note1" links to the aside, which the
-    # reader renders as a popup.
+    # The Church site uses id="note1", id="note2", etc. on <li> elements inside
+    # footer.notes for the footnote content. Moving the id to the wrapping <aside>
+    # satisfies EPUB 3 structure: the noteref href="#note1" links to the aside, which
+    # the reader renders as a popup.
+    # Only match ids of exactly the form "note" + digits (e.g. "note1", "note12").
+    # Do NOT match "note_title1" (section headings) or "note1_p1" (child elements).
+    _FOOTNOTE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(
-        lambda t: isinstance(t.get("id"), str) and t["id"].startswith("note")
+        lambda t: isinstance(t.get("id"), str) and bool(_FOOTNOTE_ID_RE.match(t["id"]))
     ):
         note_id = str(tag["id"])
         del tag["id"]
@@ -291,14 +309,16 @@ def _sanitize_transcript(
 
     # Strip data-* attributes (React/JS rendering artifacts), random web IDs
     # (e.g., id="p_fvoG6"), and web CSS class names that have no corresponding
-    # rules in the EPUB stylesheet. Preserve id attributes beginning with "note"
-    # (footnote anchors). <img> class attrs are already cleared above.
+    # rules in the EPUB stylesheet. Preserve only footnote anchor ids of the
+    # form "noteN" (e.g., "note1") on <aside> elements. <img> class attrs are
+    # already cleared above.
+    _FOOTNOTE_ASIDE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(True):
         data_attrs = [attr for attr in tag.attrs if attr.startswith("data-")]
         for attr in data_attrs:
             del tag[attr]
         tag_id = tag.get("id")
-        if isinstance(tag_id, str) and not tag_id.startswith("note"):
+        if isinstance(tag_id, str) and not _FOOTNOTE_ASIDE_ID_RE.match(tag_id):
             del tag["id"]
         if "class" in tag.attrs:
             del tag["class"]

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -914,7 +914,7 @@ def build_epub(
                         photo_bytes = _resize_photo(d["photo_src"])
                         zf.writestr(d["photo_epub_href"], photo_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added speaker photo: %s", d["photo_epub_href"])
-                    except Exception as exc:
+                    except (OSError, RuntimeError, ValueError) as exc:
                         logger.warning(
                             "Could not embed speaker photo for %r: %s — skipping",
                             d["talk"].speaker,
@@ -927,7 +927,7 @@ def build_epub(
                         img_bytes = _resize_image(src_path, _MAX_INLINE_WIDTH)
                         zf.writestr(epub_href, img_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added inline image: %s", epub_href)
-                    except Exception as exc:
+                    except (OSError, RuntimeError, ValueError) as exc:
                         logger.warning(
                             "Could not embed inline image %s: %s — skipping",
                             src_path.name,

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -18,6 +18,13 @@ from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
 
+# Footnote regex constants — compiled once at module load to avoid per-call overhead.
+# Match the "noteN" fragment at the end of any URL (used to normalize full Church URLs).
+_NOTE_FRAGMENT_RE = re.compile(r"#(note\d+)$")
+# Match a valid footnote anchor id: exactly "note" followed by one or more digits.
+# Excludes "note_title1" (section headings) and "note1_p1" (child paragraph IDs).
+_FOOTNOTE_ID_RE = re.compile(r"^note\d+$")
+
 _COPYRIGHT = (
     "Copyright {year} Intellectual Reserve, Inc. "
     "All rights reserved. For personal, noncommercial use only."
@@ -261,15 +268,14 @@ def _sanitize_transcript(
     # Bare "#noteN" hrefs (from synthetic or pre-normalized content) are also accepted.
     # All other <a> tags (scripture refs, cross-refs) point outside the EPUB container
     # (RSC-033, RSC-026) and must be unwrapped.
-    _NOTE_FRAGMENT_RE = re.compile(r"#(note\d+)$")
     for a_tag in soup.find_all("a"):
         href = str(a_tag.get("href") or "")
         scroll_id = str(a_tag.get("data-scroll-id") or "")
         note_id: str | None = None
-        if scroll_id and re.match(r"^note\d+$", scroll_id):
+        if scroll_id and _FOOTNOTE_ID_RE.match(scroll_id):
             # Canonical case: Church note-ref link with data-scroll-id="noteN"
             note_id = scroll_id
-        elif href.startswith("#note") and re.match(r"^#note\d+$", href):
+        elif href.startswith("#note") and _FOOTNOTE_ID_RE.match(href[1:]):
             # Pre-normalized bare fragment ref
             note_id = href[1:]
         else:
@@ -289,7 +295,6 @@ def _sanitize_transcript(
     # the reader renders as a popup.
     # Only match ids of exactly the form "note" + digits (e.g. "note1", "note12").
     # Do NOT match "note_title1" (section headings) or "note1_p1" (child elements).
-    _FOOTNOTE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(
         lambda t: isinstance(t.get("id"), str) and bool(_FOOTNOTE_ID_RE.match(t["id"]))
     ):
@@ -312,13 +317,12 @@ def _sanitize_transcript(
     # rules in the EPUB stylesheet. Preserve only footnote anchor ids of the
     # form "noteN" (e.g., "note1") on <aside> elements. <img> class attrs are
     # already cleared above.
-    _FOOTNOTE_ASIDE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(True):
         data_attrs = [attr for attr in tag.attrs if attr.startswith("data-")]
         for attr in data_attrs:
             del tag[attr]
         tag_id = tag.get("id")
-        if isinstance(tag_id, str) and not _FOOTNOTE_ASIDE_ID_RE.match(tag_id):
+        if isinstance(tag_id, str) and not _FOOTNOTE_ID_RE.match(tag_id):
             del tag["id"]
         if "class" in tag.attrs:
             del tag["class"]

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -607,7 +607,8 @@ def _nav_xhtml(
         toc.append('      <ol>')
         for talk in session.talks:
             href = talk_hrefs[talk.talk_index]
-            toc.append(f'        <li><a href="{href}">{escape(talk.title)}</a></li>')
+            label = f"{talk.title} -- {talk.speaker}" if talk.speaker else talk.title
+            toc.append(f'        <li><a href="{href}">{escape(label)}</a></li>')
         toc.append('      </ol>')
         toc.append('    </li>')
     toc += ['  </ol>', '</nav>']

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -126,7 +126,6 @@ nav li {
 aside {
   margin: 1.5em 0 0.5em;
   padding-left: 1em;
-  font-size: 0.85em;
 }
 
 .transcript.numbered {
@@ -138,7 +137,6 @@ aside {
   width: 2em;
   margin-left: -2.5em;
   text-align: right;
-  font-size: 0.8em;
   line-height: inherit;
 }
 """

--- a/src/gencon_audiobook/ffmpeg_manager.py
+++ b/src/gencon_audiobook/ffmpeg_manager.py
@@ -43,7 +43,7 @@ def _get_version(binary: Path) -> str:
         )
         first_line = result.stdout.splitlines()[0] if result.stdout else "unknown"
         return first_line
-    except Exception as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
         logger.debug("Could not get version for %s: %s", binary, exc)
         return "unknown"
 
@@ -91,7 +91,7 @@ def ensure_ffmpeg() -> Path:
             logger.info("Downloaded ffmpeg to %s (%s)", path, version)
             _ffmpeg_path = path
             return _ffmpeg_path
-    except Exception as exc:
+    except (AttributeError, ImportError, OSError, RuntimeError) as exc:
         logger.debug("static-ffmpeg failed: %s", exc)
 
     raise FfmpegNotFoundError(_INSTALL_INSTRUCTIONS)

--- a/src/gencon_audiobook/models.py
+++ b/src/gencon_audiobook/models.py
@@ -29,6 +29,7 @@ class Talk:
         speaker: Speaker's full name.
         talk_url: URL of the talk page on churchofjesuschrist.org.
         mp3_url: URL of the MP3 audio file, if available.
+        video_url: URL of the 360p MP4 video file, if available.
         transcript_html: Raw HTML transcript, if available.
         speaker_image_url: URL of the speaker photo, if available.
         session_name: Name of the session this talk belongs to.
@@ -42,6 +43,7 @@ class Talk:
     speaker: str
     talk_url: str
     mp3_url: str | None = None
+    video_url: str | None = None
     transcript_html: str | None = None
     speaker_image_url: str | None = None
     inline_images: list[InlineImage] = field(default_factory=list)

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -11,6 +11,7 @@ from rich.progress import (
     Task,
     TaskProgressColumn,
     TextColumn,
+    TimeElapsedColumn,
     TimeRemainingColumn,
 )
 from rich.text import Text
@@ -53,13 +54,14 @@ def standard_progress() -> Progress:
     All full-width progress bars (scrape, download, convert) use this factory
     so their columns are identical and visually aligned.
 
-    Column order: spinner | N/M count | bar | percent | time remaining | description
+    Column order: spinner | N/M count | bar | percent | elapsed | remaining | description
     """
     return Progress(
         SpinnerColumn(),
         ConditionalMofNColumn(),
         BarColumn(),
         TaskProgressColumn(),
+        TimeElapsedColumn(),
         TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
         console=shared_console,

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from rich.progress import Task, TimeRemainingColumn
+from rich.progress import MofNCompleteColumn, Task, TimeRemainingColumn
 from rich.text import Text
 
 
@@ -14,3 +14,19 @@ class TimeRemainingWithLabel(TimeRemainingColumn):
         if text.plain.strip() and text.plain.strip() not in ("--:--", "-:--:--"):
             text.append(" remaining")
         return text
+
+
+class ConditionalMofNColumn(MofNCompleteColumn):
+    """MofNCompleteColumn that can be hidden per-task via a task field.
+
+    If the task's ``show_count`` field is False, renders blank padding of the
+    same width so columns remain aligned across tasks.
+    """
+
+    def render(self, task: Task) -> Text:
+        if not task.fields.get("show_count", True):
+            total = int(task.total) if task.total is not None else 1
+            total_width = len(str(total))
+            # Width matches f"{completed:{total_width}d}/{total}": 2*total_width + 1
+            return Text(" " * (2 * total_width + 1))
+        return super().render(task)

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -1,8 +1,17 @@
-"""Shared Rich progress column customizations."""
+"""Shared Rich progress column customizations and progress bar factory."""
 
 from __future__ import annotations
 
-from rich.progress import Task, TimeRemainingColumn
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    Task,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
 from rich.text import Text
 
 
@@ -14,3 +23,37 @@ class TimeRemainingWithLabel(TimeRemainingColumn):
         if text.plain.strip() and text.plain.strip() not in ("--:--", "-:--:--"):
             text.append(" remaining")
         return text
+
+
+class ConditionalMofNColumn(MofNCompleteColumn):
+    """MofNCompleteColumn that can be hidden per-task via a task field.
+
+    If the task's ``show_count`` field is False, renders blank padding of the
+    same width so columns remain aligned across tasks.
+    """
+
+    def render(self, task: Task) -> Text:
+        if not task.fields.get("show_count", True):
+            total = int(task.total) if task.total is not None else 1
+            total_width = len(str(total))
+            # Width matches f"{completed:{total_width}d}/{total}": 2*total_width + 1
+            return Text(" " * (2 * total_width + 1))
+        return super().render(task)
+
+
+def standard_progress() -> Progress:
+    """Return a Progress bar with the standard project column layout.
+
+    All full-width progress bars (scrape, download, convert) use this factory
+    so their columns are identical and visually aligned.
+
+    Column order: spinner | N/M count | bar | percent | time remaining | description
+    """
+    return Progress(
+        SpinnerColumn(),
+        ConditionalMofNColumn(),
+        BarColumn(),
+        TaskProgressColumn(),
+        TimeRemainingWithLabel(compact=True),
+        TextColumn("[progress.description]{task.description}"),
+    )

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from rich.console import Console
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -13,6 +14,11 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 from rich.text import Text
+
+# Single shared console used by all progress bars AND the RichHandler in cli.py.
+# When Progress and RichHandler share the same Console, Rich correctly interleaves
+# log messages above the live progress bar instead of clobbering the same line.
+shared_console = Console()
 
 
 class TimeRemainingWithLabel(TimeRemainingColumn):
@@ -56,4 +62,5 @@ def standard_progress() -> Progress:
         TaskProgressColumn(),
         TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
+        console=shared_console,
     )

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -538,9 +538,17 @@ def parse_conference_listing(html: str) -> list[Session]:
 
 
 def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
-    """Extract sessions from __INITIAL_STATE__ for the conference listing page."""
+    """Extract sessions from __INITIAL_STATE__ for the conference listing page.
+
+    Older conferences (pre-2020) have duplicate sections in the JSON: the real
+    sessions appear first, then a second set of unnamed sections that repeat the
+    same talks with a session landing page prepended. We deduplicate by tracking
+    seen talk URLs — any entry whose URL was already claimed by an earlier session
+    is skipped, and sections that produce zero new talks are dropped entirely.
+    """
     library = state.get("library", {})
     sessions: list[Session] = []
+    seen_urls: set[str] = set()
 
     # Find the library key that matches a conference listing URL
     for key, value in library.items():
@@ -555,10 +563,13 @@ def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
                 # Skip entries that don't look like conference sub-pages
                 if not _CONF_URL_RE.search(uri):
                     continue
+                talk_url = urljoin(_BASE_URL, uri.split("?")[0])
+                if talk_url in seen_urls:
+                    continue
                 title = entry.get("title", "")
                 speaker = entry.get("subtitle", "") or entry.get("author", "")
-                talk_url = urljoin(_BASE_URL, uri.split("?")[0])
                 if title:
+                    seen_urls.add(talk_url)
                     talks.append(Talk(title=title, speaker=speaker, talk_url=talk_url))
             if talks:
                 sessions.append(Session(name=name, number=i, talks=talks))

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -660,6 +660,14 @@ def _sessions_from_html(html: str) -> list[Session]:
         if isinstance(sub_ul, Tag) and sub_ul.find("a", href=_CONF_URL_RE):
             session_lis.append(li)
 
+    # Track session LIs by object identity so we can skip nested ones when
+    # iterating talks. Older conferences have 3-level nesting: an outer grouping
+    # <li> whose sub-<ul> contains session <li>s, each of which has a sub-<ul>
+    # of actual talks. Without this guard, the outer grouping treats each inner
+    # session <li>'s heading link as a "talk", producing bogus Talk objects for
+    # session landing pages.
+    session_li_ids: set[int] = {id(li) for li in session_lis}
+
     sessions: list[Session] = []
     session_number = 0
 
@@ -685,6 +693,9 @@ def _sessions_from_html(html: str) -> list[Session]:
 
             talks: list[Talk] = []
             for talk_li in sub_ul.find_all("li", recursive=False):
+                # Skip nested session LIs — they are processed in their own iteration.
+                if id(talk_li) in session_li_ids:
+                    continue
                 talk_a = talk_li.find("a", href=_CONF_URL_RE)
                 if not talk_a:
                     continue

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -15,17 +15,9 @@ from urllib.robotparser import RobotFileParser
 import requests
 from bs4 import BeautifulSoup, Tag
 from rich.console import Console
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TaskProgressColumn,
-    TextColumn,
-)
 
 from .models import Conference, InlineImage, Session, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import standard_progress
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
@@ -953,14 +945,7 @@ def scrape_conference(conference_url: str) -> Conference:
     skipped: list[Talk] = []
 
     console.print(f"Scraping: {title}")
-    scrape_progress = Progress(
-        SpinnerColumn(),
-        MofNCompleteColumn(),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeRemainingWithLabel(compact=True),
-        TextColumn("[progress.description]{task.description}"),
-    )
+    scrape_progress = standard_progress()
     with scrape_progress:
         task = scrape_progress.add_task("Scraping talks", total=len(all_talks))
         for i, talk in enumerate(all_talks, start=1):

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -16,7 +16,8 @@ import requests
 from bs4 import BeautifulSoup, Tag
 
 from .models import Conference, InlineImage, Session, Talk
-from .progress import shared_console as console, standard_progress
+from .progress import shared_console as console
+from .progress import standard_progress
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
@@ -100,7 +101,7 @@ def _get_robots(http: requests.Session, base_url: str) -> RobotFileParser | None
         parser.parse(response.text.splitlines())
         _robots_cache[base_url] = parser
         logger.debug("Fetched robots.txt from %s", robots_url)
-    except Exception as exc:
+    except (requests.RequestException, OSError) as exc:
         logger.warning("Could not fetch robots.txt from %s: %s — proceeding anyway", robots_url, exc)
         _robots_cache[base_url] = None
 
@@ -327,7 +328,7 @@ def _parse_initial_state(html: str) -> dict[str, Any]:
         try:
             json_bytes = base64.b64decode(match.group(1))
             return cast(dict[str, Any], json.loads(json_bytes))
-        except Exception as exc:
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
             logger.debug("Failed to base64-decode __INITIAL_STATE__: %s", exc)
 
     # Fallback: raw JSON object (some pages may not encode it)

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -68,12 +68,14 @@ def _upgrade_iiif(url: str) -> str:
     url = re.sub(r"/full/!\d+,/", "/full/!800,/", url)
     return url
 
-# Matches /study/general-conference/YYYY/MM/talk-id (individual talk URL).
-# Modern talk slugs use a numeric-prefix + speaker-name format with no hyphens
-# (e.g., "11oaks", "12christofferson"). Session-level links DO contain hyphens
-# (e.g., "saturday-morning-session") and must be excluded — [a-z0-9]+ achieves
-# this. Verified against fixture data; the weekly live test monitors for changes.
-_TALK_URL_RE = re.compile(r"/study/general-conference/\d{4}/\d{2}/[a-z0-9]+(?:\?|$)", re.IGNORECASE)
+# Matches any /study/general-conference/YYYY/MM/slug URL — talk and session links
+# alike. The character class [a-z0-9][-a-z0-9]* covers modern unhyphenated slugs
+# ("11oaks") and older hyphenated ones ("the-work-moves-forward"). Talk vs.
+# session is determined by DOM position in _sessions_from_html, not URL pattern.
+_CONF_URL_RE = re.compile(
+    r"/study/general-conference/\d{4}/\d{2}/[a-z0-9][-a-z0-9]*(?:\?|$)",
+    re.IGNORECASE,
+)
 
 
 # Cache of parsed RobotFileParser objects, keyed by scheme+host (e.g. "https://www.churchofjesuschrist.org")
@@ -558,8 +560,8 @@ def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
             talks: list[Talk] = []
             for entry in section.get("entries", []):
                 uri = entry.get("uri", "")
-                # Skip non-talk entries (e.g., session-level links)
-                if not _TALK_URL_RE.search(uri):
+                # Skip entries that don't look like conference sub-pages
+                if not _CONF_URL_RE.search(uri):
                     continue
                 title = entry.get("title", "")
                 speaker = entry.get("subtitle", "") or entry.get("author", "")
@@ -649,12 +651,12 @@ def _sessions_from_html(html: str) -> list[Session]:
     """
     soup = BeautifulSoup(html, "html.parser")
 
-    talk_links = soup.find_all("a", href=_TALK_URL_RE)
-    if not talk_links:
+    conf_links = soup.find_all("a", href=_CONF_URL_RE)
+    if not conf_links:
         return []
 
-    # Walk up: talk_a -> talk_li -> inner_ul -> session_li -> outer_ul
-    inner_ul = talk_links[0].find_parent("ul")
+    # Walk up: conf_a -> talk_li -> inner_ul -> session_li -> outer_ul
+    inner_ul = conf_links[0].find_parent("ul")
     if not inner_ul:
         return []
     session_li = inner_ul.parent
@@ -670,19 +672,23 @@ def _sessions_from_html(html: str) -> list[Session]:
                 # "Contents" or other non-session entry — skip
                 continue
 
-            # Session name: first <a> that is NOT a talk link
+            # Session name: direct-child <a> of the session <li> (the session heading link).
+            # URL matching is not used — all conf URLs look alike; DOM position distinguishes
+            # session <li> from talk <li>. Fall back to <h4> for older HTML that uses headings.
             session_name: str | None = None
             for a in li.find_all("a", recursive=False):
-                if not _TALK_URL_RE.search(a.get("href", "")):
-                    session_name = a.get_text(strip=True)
-                    break
-
+                session_name = a.get_text(strip=True)
+                break
+            if not session_name:
+                h4 = li.find("h4", recursive=False)
+                if isinstance(h4, Tag):
+                    session_name = h4.get_text(strip=True)
             if not session_name:
                 session_name = f"Session {session_number + 1}"
 
             talks: list[Talk] = []
             for talk_li in sub_ul.find_all("li", recursive=False):
-                talk_a = talk_li.find("a", href=_TALK_URL_RE)
+                talk_a = talk_li.find("a", href=_CONF_URL_RE)
                 if not talk_a:
                     continue
                 title = _extract_talk_title(talk_a)
@@ -699,7 +705,7 @@ def _sessions_from_html(html: str) -> list[Session]:
     if not sessions:
         logger.warning("No session structure detected; grouping all talks under one session")
         all_talks: list[Talk] = []
-        for a in talk_links:
+        for a in conf_links:
             title = _extract_talk_title(a)
             speaker = _extract_talk_speaker(a)
             if title:

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -529,7 +529,7 @@ def parse_conference_listing(html: str) -> list[Session]:
 
     # Fallback: HTML traversal
     if not sessions:
-        logger.warning("Listing JSON selector found nothing; falling back to HTML traversal")
+        logger.debug("Listing JSON selector found nothing; falling back to HTML traversal")
         sessions = _sessions_from_html(html)
         if sessions:
             logger.debug("Listing HTML fallback: %d sessions", len(sessions))

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -797,7 +797,17 @@ def parse_talk_page(html: str, talk_url: str) -> dict:
     # Transcript — primary: div.body-block
     body = soup.find("div", class_="body-block")
     if body:
-        result["transcript_html"] = str(body)
+        transcript_parts = [str(body)]
+        # The Church site places footnote bodies in <footer class="notes">, which is a
+        # sibling of div.body-block, not inside it. Append its HTML so the EPUB builder
+        # has the note bodies it needs to render footnotes. Guard against duplication:
+        # only append when the primary selector (not the article fallback) was used,
+        # since article fallbacks already capture the full article including the footer.
+        notes_footer = soup.find("footer", class_="notes")
+        if notes_footer:
+            transcript_parts.append(str(notes_footer))
+            logger.debug("transcript: appended footer.notes (%d chars)", len(str(notes_footer)))
+        result["transcript_html"] = "".join(transcript_parts)
         logger.debug("transcript (primary div.body-block): %d chars", len(result["transcript_html"] or ""))
 
     if not result["transcript_html"]:

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -14,14 +14,12 @@ from urllib.robotparser import RobotFileParser
 
 import requests
 from bs4 import BeautifulSoup, Tag
-from rich.console import Console
 
 from .models import Conference, InlineImage, Session, Talk
-from .progress import standard_progress
+from .progress import shared_console as console, standard_progress
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
-console = Console()
 
 _BASE_URL = "https://www.churchofjesuschrist.org"
 _ARCHIVE_PATH = "/study/general-conference"
@@ -677,14 +675,6 @@ def _sessions_from_html(html: str) -> list[Session]:
         if isinstance(sub_ul, Tag) and sub_ul.find("a", href=_CONF_URL_RE):
             session_lis.append(li)
 
-    # Track session LIs by object identity so we can skip nested ones when
-    # iterating talks. Older conferences have 3-level nesting: an outer grouping
-    # <li> whose sub-<ul> contains session <li>s, each of which has a sub-<ul>
-    # of actual talks. Without this guard, the outer grouping treats each inner
-    # session <li>'s heading link as a "talk", producing bogus Talk objects for
-    # session landing pages.
-    session_li_ids: set[int] = {id(li) for li in session_lis}
-
     sessions: list[Session] = []
     session_number = 0
 
@@ -706,13 +696,13 @@ def _sessions_from_html(html: str) -> list[Session]:
                 if isinstance(h4, Tag):
                     session_name = h4.get_text(strip=True)
             if not session_name:
-                session_name = f"Session {session_number + 1}"
+                # Unnamed session LIs are duplicates — the site renders each session twice:
+                # once with a direct-child <a> holding the name, once with a <div> and no name.
+                # Skip the unnamed copies.
+                continue
 
             talks: list[Talk] = []
             for talk_li in sub_ul.find_all("li", recursive=False):
-                # Skip nested session LIs — they are processed in their own iteration.
-                if id(talk_li) in session_li_ids:
-                    continue
                 talk_a = talk_li.find("a", href=_CONF_URL_RE)
                 if not talk_a:
                     continue

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -556,7 +556,13 @@ def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
             continue
         raw_sections = value.get("sections", [])
         for i, section in enumerate(raw_sections, start=1):
-            name = section.get("title", f"Session {i}")
+            name = section.get("title")
+            if not name:
+                # Older conferences have unnamed duplicate sections that repeat
+                # every talk from a named session plus a session landing page.
+                # Skip them — real sessions always have titles in the JSON.
+                logger.debug("Skipping unnamed JSON section %d (likely duplicate)", i)
+                continue
             talks: list[Talk] = []
             for entry in section.get("entries", []):
                 uri = entry.get("uri", "")

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -67,6 +67,10 @@ _CONF_URL_RE = re.compile(
     r"/study/general-conference/\d{4}/\d{2}/[a-z0-9][-a-z0-9]*(?:\?|$)",
     re.IGNORECASE,
 )
+_VIDEO_360P_RE = re.compile(
+    r"https://assets\.churchofjesuschrist\.org/[a-z0-9]+-360p-en\.mp4",
+    re.IGNORECASE,
+)
 
 
 # Cache of parsed RobotFileParser objects, keyed by scheme+host (e.g. "https://www.churchofjesuschrist.org")
@@ -238,6 +242,7 @@ def _fetch(http: requests.Session, url: str, delay: float = _REQUEST_DELAY) -> s
     """
     if not validate_url(url):
         raise ScraperError(f"URL not on allowlist: {url}")
+    _check_robots(http, url)
 
     last_exc: Exception | None = None
     for attempt in range(_MAX_RETRIES + 1):
@@ -344,6 +349,16 @@ def _parse_initial_state(html: str) -> dict[str, Any]:
             logger.debug("Failed to parse __INITIAL_STATE__ as raw JSON: %s", exc)
 
     return {}
+
+
+def _find_video_url(state: dict[str, Any]) -> str | None:
+    """Find a 360p MP4 URL anywhere in decoded page state."""
+    state_text = json.dumps(state, ensure_ascii=False)
+    match = _VIDEO_360P_RE.search(state_text)
+    if not match:
+        return None
+    video_url = match.group(0)
+    return video_url if validate_url(video_url) else None
 
 
 # ---------------------------------------------------------------------------
@@ -739,20 +754,21 @@ def _sessions_from_html(html: str) -> list[Session]:
 
 
 def parse_talk_page(html: str, talk_url: str) -> dict:
-    """Extract mp3_url, transcript_html, speaker_image_url, speaker, and inline_images from a talk page.
+    """Extract media, transcript, speaker, and inline images from a talk page.
 
     Args:
         html: HTML content of the individual talk page.
         talk_url: URL of this talk page (used only for logging).
 
     Returns:
-        Dict with keys: mp3_url, transcript_html, speaker_image_url, speaker,
-        inline_images. String values may be None if not found; inline_images
-        is always a list (possibly empty).
+        Dict with keys: mp3_url, video_url, transcript_html, speaker_image_url,
+        speaker, inline_images. String values may be None if not found;
+        inline_images is always a list (possibly empty).
     """
     soup = BeautifulSoup(html, "html.parser")
     result: dict = {
         "mp3_url": None,
+        "video_url": None,
         "transcript_html": None,
         "speaker_image_url": None,
         "speaker": None,
@@ -762,6 +778,10 @@ def parse_talk_page(html: str, talk_url: str) -> dict:
     # MP3 URL — primary: reader.contentStore[*].meta.audio[0].mediaUrl in __INITIAL_STATE__
     # The Church website embeds the audio URL in JS state; the HTML player is rendered client-side.
     state = _parse_initial_state(html)
+    result["video_url"] = _find_video_url(state)
+    if result["video_url"]:
+        logger.debug("video_url (state scan): %s", result["video_url"])
+
     content_store = state.get("reader", {}).get("contentStore", {})
     for _key, entry in content_store.items():
         audio_list = entry.get("meta", {}).get("audio", [])
@@ -1000,6 +1020,7 @@ def scrape_conference(conference_url: str) -> Conference:
                     talk.speaker = data["speaker"]
 
                 talk.mp3_url = data["mp3_url"]
+                talk.video_url = data["video_url"]
                 talk.transcript_html = data["transcript_html"]
                 talk.speaker_image_url = data["speaker_image_url"]
                 talk.inline_images = data["inline_images"]

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -622,24 +622,24 @@ def _sessions_from_html(html: str) -> list[Session]:
 
     Observed structure on the Church website (CSS-module class names may change):
 
-        outer_ul
-          <li>Contents link (no sub-ul, skip)</li>
-          <li>                                     <- session LI
-            <a class="sectionTitle-*">Saturday Morning Session</a>
-            inner_ul                               <- talks for this session
-              <li>
-                <a href="/study/general-conference/YYYY/MM/talk-id">
-                  <div class="itemTitle-*">
-                    <p>Talk Title</p>
-                    <p class="subtitle-*">Speaker Name</p>
-                  </div>
-                </a>
-              </li>
-              ...
-          </li>
-          ...
+        <li>                                     <- session LI
+          <a class="sectionTitle-*">Saturday Morning Session</a>
+          <ul>                                   <- talks for this session
+            <li>
+              <a href="/study/general-conference/YYYY/MM/talk-id">
+                <div class="itemTitle-*">
+                  <p>Talk Title</p>
+                  <p class="subtitle-*">Speaker Name</p>
+                </div>
+              </a>
+            </li>
+            ...
+          </ul>
+        </li>
 
-    Navigate to the outer UL by walking up from the first talk link.
+    Session <li> elements are identified by having a direct-child <ul> that contains
+    at least one conference link. This approach works across conference eras without
+    needing to bootstrap a walk from a specific link position.
     """
     soup = BeautifulSoup(html, "html.parser")
 
@@ -647,21 +647,26 @@ def _sessions_from_html(html: str) -> list[Session]:
     if not conf_links:
         return []
 
-    # Walk up: conf_a -> talk_li -> inner_ul -> session_li -> outer_ul
-    inner_ul = conf_links[0].find_parent("ul")
-    if not inner_ul:
-        return []
-    session_li = inner_ul.parent
-    outer_ul = session_li.parent if session_li and session_li.name == "li" else None
+    # Find session <li> elements directly: a <li> is a session if it has a
+    # direct-child <ul> that contains at least one conference link.
+    # Bootstrapping from conf_links[0] fails for older conferences where the
+    # first link in document order is a session landing page (in the outer UL),
+    # not a talk (in the inner UL).
+    session_lis: list[Tag] = []
+    for li in soup.find_all("li"):
+        if not isinstance(li, Tag):
+            continue
+        sub_ul = li.find("ul", recursive=False)
+        if isinstance(sub_ul, Tag) and sub_ul.find("a", href=_CONF_URL_RE):
+            session_lis.append(li)
 
     sessions: list[Session] = []
     session_number = 0
 
-    if outer_ul and outer_ul.name in ("ul", "ol"):
-        for li in outer_ul.find_all("li", recursive=False):
-            sub_ul = li.find("ul")
-            if not sub_ul:
-                # "Contents" or other non-session entry — skip
+    if session_lis:
+        for li in session_lis:
+            sub_ul = li.find("ul", recursive=False)
+            if not isinstance(sub_ul, Tag):
                 continue
 
             # Session name: direct-child <a> of the session <li> (the session heading link).
@@ -980,7 +985,7 @@ def scrape_conference(conference_url: str) -> Conference:
                     missing.append("mp3_url")
 
                 if missing:
-                    logger.error(
+                    logger.warning(
                         "Talk at %s missing required fields: %s — skipping",
                         talk.talk_url,
                         ", ".join(missing),

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -264,6 +264,11 @@ def _fetch(http: requests.Session, url: str, delay: float = _REQUEST_DELAY) -> s
                     "github.com/XeroIP/gencon-audiobook"
                 )
 
+            if response.status_code == 404:
+                # 404 is deterministic for conference/talk pages — retrying only
+                # hides the real problem behind a misleading connectivity error.
+                raise ScraperError(f"Page not found: {url}")
+
             if response.status_code == 429:
                 # 429 is a transient rate-limit signal — respect Retry-After if present,
                 # otherwise fall through to raise_for_status() which triggers the retry loop.

--- a/src/gencon_audiobook/utils.py
+++ b/src/gencon_audiobook/utils.py
@@ -98,6 +98,6 @@ def validate_url(url: str) -> bool:
         if not result:
             logger.debug("URL rejected by allowlist: %s", url)
         return result
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         logger.debug("URL validation failed (malformed URL): %s", url)
         return False

--- a/tests/fixtures/talk_page_with_notes.html
+++ b/tests/fixtures/talk_page_with_notes.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"/><title>Test Talk With Notes</title></head>
+<body>
+<article data-content-type="general-conference">
+  <header>
+    <h1 class="title">Miracles, Angels, and Priesthood Power</h1>
+    <p class="author-name">By Elder Shayne M. Bowen</p>
+    <div class="lumen-tile__image">
+      <img src="https://www.churchofjesuschrist.org/imgs/spkr-bowen/full/320/0/default" alt="Shayne M. Bowen"/>
+    </div>
+  </header>
+  <div class="body-block">
+    <p data-aid="159162981" id="p1">Many today say that miracles no longer exist, that angels are fictional, and that the heavens are closed. I testify that miracles have not ceased, angels are among us, and the heavens are truly open.</p>
+    <p data-aid="159162987" id="p2">When our Savior, Jesus Christ, was on the earth, He gave priesthood keys to His chief Apostle, Peter.<a class="note-ref" data-scroll-id="note1" href="/study/general-conference/2024/04/31bowen?lang=eng#note1"><sup class="marker" data-value="1"></sup></a> Through these keys, Peter and the other Apostles led the Savior's Church.</p>
+    <p data-aid="159162993" id="p3">Peter, James, and John and other ancient prophets appeared as resurrected beings, bestowing upon the Prophet Joseph Smith what the Lord described as "the keys of my kingdom, and a dispensation of the gospel."<a class="note-ref" data-scroll-id="note2" href="/study/general-conference/2024/04/31bowen?lang=eng#note2"><sup class="marker" data-value="2"></sup></a></p>
+    <p data-aid="159163134" id="p26">I testify that the holy priesthood with its keys, authority, and power has been restored to the earth in our day. In the name of Jesus Christ, amen.</p>
+  </div>
+  <footer class="notes">
+    <p class="title" data-aid="159163161" id="note_title1">Notes</p>
+    <ol class="decimal" data-type="marker" start="1">
+      <li data-marker="1." id="note1" data-full-marker="1.">
+        <p data-aid="159163167" id="note1_p1">See <a class="scripture-ref" href="/study/scriptures/nt/matt/16?lang=eng&amp;id=p17-p19#p17">Matthew 16:17&#x2013;19</a>; <a class="scripture-ref" href="/study/scriptures/dc-testament/dc/128?lang=eng&amp;id=p18,21#p18">Doctrine and Covenants 128:18, 21</a>.</p>
+      </li>
+      <li data-marker="2." id="note2" data-full-marker="2.">
+        <p data-aid="159163174" id="note2_p1">See <a class="scripture-ref" href="/study/scriptures/dc-testament/dc/27?lang=eng&amp;id=p12-p13#p12">Doctrine and Covenants 27:12&#x2013;13</a>.</p>
+      </li>
+    </ol>
+  </footer>
+</article>
+<div class="player-component">
+  <video>
+    <source src="https://assets.churchofjesuschrist.org/31bowen-32k-en.mp3" type="audio/mpeg"/>
+  </video>
+</div>
+</body>
+</html>

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -534,8 +534,7 @@ def test_run_ffmpeg_with_progress_parses_out_time() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter(stdout_lines)
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = ""
+    mock_proc.stderr = iter([])  # iterable — drained by stderr thread
     mock_proc.returncode = 0
     mock_proc.poll.return_value = 0
 
@@ -564,8 +563,7 @@ def test_run_ffmpeg_with_progress_nonzero_exit() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter(["progress=end\n"])
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = "some ffmpeg error"
+    mock_proc.stderr = iter(["some ffmpeg error\n"])  # iterable — drained by stderr thread
     mock_proc.returncode = 1
     mock_proc.poll.return_value = 1
 
@@ -587,8 +585,7 @@ def test_run_ffmpeg_with_progress_watchdog_kills_hung_process() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter([])  # EOF immediately so the readline loop exits
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = ""
+    mock_proc.stderr = iter([])  # iterable — drained by stderr thread
     mock_proc.returncode = -9
     mock_proc.poll.return_value = None  # process appears still running when watchdog fires
 
@@ -613,3 +610,32 @@ def test_run_ffmpeg_with_progress_watchdog_kills_hung_process() -> None:
                 progress=progress,
                 task_id=0,  # type: ignore[arg-type]
             )
+
+
+def test_run_ffmpeg_with_progress_noisy_stderr_does_not_deadlock() -> None:
+    """ffmpeg writing large amounts of stderr should not deadlock.
+
+    Previously, stderr was piped but never read, causing the OS pipe buffer
+    (4KB on Windows) to fill and deadlock both processes.
+    """
+    from unittest.mock import MagicMock, patch
+
+    # Simulate lots of stderr output (well beyond OS pipe buffer)
+    noisy_stderr = ["WARNING: something suspicious\n"] * 500
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter(["out_time_us=1000000\n", "progress=end\n"])
+    mock_proc.stderr = iter(noisy_stderr)
+    mock_proc.returncode = 0
+    mock_proc.poll.return_value = 0
+
+    progress = MagicMock()
+    with patch("subprocess.Popen", return_value=mock_proc):
+        # Should complete without hanging
+        _run_ffmpeg_with_progress(
+            ["ffmpeg", "-i", "in.mp3", "out.m4a"],
+            label="test",
+            source_duration_s=5.0,
+            progress=progress,
+            task_id=0,  # type: ignore[arg-type]
+        )

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -250,6 +250,51 @@ def test_build_m4b_skips_missing_mp3(tmp_path: Path) -> None:
     )
 
 
+@requires_ffmpeg
+def test_build_m4b_skips_talk_when_conversion_fails(tmp_path: Path) -> None:
+    """A mid-build conversion failure must not create a ghost chapter."""
+    from unittest.mock import patch
+
+    import gencon_audiobook.audio as audio_module
+
+    conference = _make_conference(tmp_path, n_talks=2)
+    audio_dir = tmp_path / "audio"
+    output = tmp_path / "output.m4b"
+    original_convert = audio_module.convert_mp3_to_aac
+
+    def convert_or_fail(*args, **kwargs):
+        mp3_path = args[0]
+        if mp3_path.name.startswith("002-"):
+            raise AudioError("simulated conversion failure")
+        return original_convert(*args, **kwargs)
+
+    with patch("gencon_audiobook.audio.convert_mp3_to_aac", side_effect=convert_or_fail):
+        stats = build_m4b(conference, audio_dir, output, None, _FFMPEG, _FFPROBE)
+
+    assert output.exists(), "m4b should still be produced when one conversion fails"
+    assert stats.chapter_count == 1, "Failed talk must not appear as a ghost chapter"
+    assert conference.talks[0].duration_seconds > 0
+    assert conference.talks[1].duration_seconds == 0.0
+
+
+@requires_ffmpeg
+def test_build_m4b_uses_existing_m4a_without_deleting_it(tmp_path: Path) -> None:
+    conference = _make_conference(tmp_path, n_talks=1)
+    audio_dir = tmp_path / "audio"
+    mp3_path = audio_dir / "001-Talk-1.mp3"
+    m4a_path = mp3_path.with_suffix(".m4a")
+    output = tmp_path / "output.m4b"
+
+    convert_mp3_to_aac(mp3_path, m4a_path, _FFMPEG, _FFPROBE)
+    mp3_path.unlink()
+
+    stats = build_m4b(conference, audio_dir, output, None, _FFMPEG, _FFPROBE)
+
+    assert output.exists(), "m4b should be produced from existing .m4a source"
+    assert m4a_path.exists(), "Extracted video audio cache must not be deleted"
+    assert stats.chapter_count == 1
+
+
 # ---------------------------------------------------------------------------
 # _ffmeta_escape — pure function tests
 # ---------------------------------------------------------------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -32,6 +32,7 @@ def _make_conference() -> Conference:
         speaker="President Henry B. Eyring",
         talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/talk1",
         mp3_url="https://assets.churchofjesuschrist.org/audio/talk1.mp3",
+        video_url="https://assets.churchofjesuschrist.org/video/talk1-360p-en.mp4",
         transcript_html="<p>Welcome.</p>",
         speaker_image_url="https://assets.churchofjesuschrist.org/photo1.jpg",
         inline_images=[inline],
@@ -46,6 +47,7 @@ def _make_conference() -> Conference:
         speaker="Elder Test Speaker",
         talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/talk2",
         mp3_url=None,
+        video_url=None,
         transcript_html=None,
         speaker_image_url=None,
         inline_images=[],
@@ -95,6 +97,7 @@ def test_save_load_round_trip(tmp_path: "pytest.TempPathFactory") -> None:
     assert loaded_talk.speaker == orig_talk.speaker
     assert loaded_talk.talk_url == orig_talk.talk_url
     assert loaded_talk.mp3_url == orig_talk.mp3_url
+    assert loaded_talk.video_url == orig_talk.video_url
     assert loaded_talk.transcript_html == orig_talk.transcript_html
     assert loaded_talk.speaker_image_url == orig_talk.speaker_image_url
     assert loaded_talk.session_name == orig_talk.session_name
@@ -136,6 +139,24 @@ def test_load_cache_corrupt_json(tmp_path: "pytest.TempPathFactory") -> None:
     (tmp_path / CACHE_FILENAME).write_text("this is not valid json{{{", encoding="utf-8")
     result = load_cache(tmp_path, expected_url="https://example.com/conf")
     assert result is None, "Expected None for corrupt JSON"
+
+
+def test_load_cache_malformed_conference_data(tmp_path: "pytest.TempPathFactory") -> None:
+    """Valid JSON with an invalid conference shape must fall back to re-scraping."""
+    expected_url = "https://www.churchofjesuschrist.org/study/general-conference/2024/04"
+    malformed = {
+        "cache_version": CACHE_VERSION,
+        "conference": {
+            "conference_url": expected_url,
+            "title": "April 2024 General Conference",
+            # Missing sessions/year/month/cover_image_url.
+        },
+    }
+    (tmp_path / CACHE_FILENAME).write_text(json.dumps(malformed), encoding="utf-8")
+
+    result = load_cache(tmp_path, expected_url=expected_url)
+
+    assert result is None, "Expected None for malformed conference cache data"
 
 
 def test_load_cache_version_mismatch(tmp_path: "pytest.TempPathFactory") -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,8 +252,9 @@ def test_disk_space_warning_printed(tmp_path: Path) -> None:
         runner = CliRunner()
         result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
 
-    assert "500 MB" in result.output, "Disk space warning should mention 500 MB threshold"
-    assert "100 MB" in result.output, "Disk space warning should show available space"
+    normalized_output = " ".join(result.output.split())
+    assert "500 MB" in normalized_output, "Disk space warning should mention 500 MB threshold"
+    assert "100 MB" in normalized_output, "Disk space warning should show available space"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,14 +163,11 @@ def test_defaults_to_most_recent_conference(tmp_path: Path) -> None:
 
 
 def test_conference_filter_selects_matching(tmp_path: Path) -> None:
-    refs = [
-        _make_ref("April 2024 General Conference", 2024, 4),
-        _make_ref("October 2023 General Conference", 2023, 10),
-    ]
+    """YYYY-MM format constructs the URL directly without fetching the listing."""
     conference = _make_conference("October 2023 General Conference")
 
     with (
-        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
+        patch("gencon_audiobook.cli.fetch_available_conferences") as mock_listing,
         patch("gencon_audiobook.cli.scrape_conference", return_value=conference) as mock_scrape,
         patch("gencon_audiobook.cli.download_conference"),
         patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
@@ -179,24 +176,53 @@ def test_conference_filter_selects_matching(tmp_path: Path) -> None:
     ):
         runner = CliRunner()
         result = runner.invoke(
-            main, ["--output", str(tmp_path), "--audiobook-only", "--conference", "October 2023"]
+            main, ["--output", str(tmp_path), "--audiobook-only", "--conference", "2023-10"]
         )
 
     assert result.exit_code == 0, result.output
+    mock_listing.assert_not_called()
     called_url = mock_scrape.call_args[0][0]
-    assert "2023/10" in called_url
+    assert "2023/10" in called_url, f"Expected 2023/10 in URL, got: {called_url}"
 
 
 def test_conference_filter_no_match_exits_nonzero(tmp_path: Path) -> None:
-    refs = [_make_ref("April 2024 General Conference")]
-
-    with patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs):
-        runner = CliRunner()
-        result = runner.invoke(
-            main, ["--output", str(tmp_path), "--conference", "Nonexistent 1800"]
-        )
+    """Invalid YYYY-MM format exits with a non-zero code."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--output", str(tmp_path), "--conference", "Nonexistent 1800"]
+    )
 
     assert result.exit_code != 0
+
+
+def test_conference_filter_invalid_format_exits_nonzero(tmp_path: Path) -> None:
+    """Month-first or free-text format is rejected with a clear error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--output", str(tmp_path), "--conference", "april-2024"]
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid conference format" in result.output, result.output
+
+
+def test_conference_direct_url_skips_listing_fetch(tmp_path: Path) -> None:
+    """When --conference YYYY-MM is given, fetch_available_conferences is never called."""
+    conference = _make_conference("April 2024 General Conference")
+
+    with (
+        patch("gencon_audiobook.cli.fetch_available_conferences") as mock_listing,
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.download_conference"),
+        patch("gencon_audiobook.cli.build_epub"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["--output", str(tmp_path), "--epub-only", "--conference", "2024-04"]
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_listing.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -485,28 +511,6 @@ def test_epub_summary_line_printed(tmp_path: Path) -> None:
     assert ".epub" in result.output, \
         f"EPUB filename should appear in the completion summary: {result.output!r}"
 
-
-def test_conference_filter_is_case_insensitive(tmp_path: Path) -> None:
-    """The --conference filter must match case-insensitively.
-
-    Users will naturally type 'april 2024' instead of 'April 2024'.
-    """
-    refs = [_make_ref("April 2024 General Conference", 2024, 4)]
-    conference = _make_conference()
-
-    with (
-        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
-        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
-        patch("gencon_audiobook.cli.download_conference"),
-        patch("gencon_audiobook.cli.build_epub"),
-    ):
-        runner = CliRunner()
-        result = runner.invoke(
-            main, ["--output", str(tmp_path), "--epub-only", "--conference", "april 2024"]
-        )
-
-    assert result.exit_code == 0, \
-        f"Lowercase --conference filter should match; got exit {result.exit_code}: {result.output}"
 
 
 def test_log_file_created_in_output_dir(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 
 from gencon_audiobook.audio import AudioError
 from gencon_audiobook.cli import main, _LOG_FILENAME
-from gencon_audiobook.downloader import DownloadError
+from gencon_audiobook.downloader import AudioProbe, DownloadError, DownloadResult
 from gencon_audiobook.models import Conference, Session, Talk
 from gencon_audiobook.scraper import ConferenceRef, ScraperError
 
@@ -30,12 +30,13 @@ def _make_ref(title: str = "April 2024 General Conference", year: int = 2024, mo
     )
 
 
-def _make_conference(title: str = "April 2024 General Conference") -> Conference:
+def _make_conference(title: str = "April 2024 General Conference", *, video_url: str | None = None) -> Conference:
     talk = Talk(
         title="Opening Remarks",
         speaker="President Eyring",
         talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/01",
         mp3_url="https://assets.churchofjesuschrist.org/test.mp3",
+        video_url=video_url,
         talk_index=1,
         duration_seconds=120.0,
     )
@@ -353,6 +354,8 @@ def test_completion_summary_printed(tmp_path: Path) -> None:
         result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
 
     assert "Completion Report" in result.output, result.output
+    assert "Sessions:" in result.output, result.output
+    assert "Saturday Morning Session" in result.output, result.output
     assert "Audiobook:" in result.output, result.output
 
 
@@ -601,3 +604,98 @@ def test_explicit_bitrate_passed_to_build_m4b(tmp_path: Path) -> None:
         f"Expected bitrate='48k', got {kwargs.get('bitrate')!r}"
     assert kwargs.get("sample_rate") == 22050, \
         f"Expected sample_rate=22050, got {kwargs.get('sample_rate')!r}"
+
+
+def test_quality_banner_exits_by_default_when_video_audio_is_better(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=32_000, duration_seconds=600.0, total_bitrate_bps=32_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference") as mock_download,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["--output", str(tmp_path), "--audiobook-only", "--conference", "2024-04"],
+            input="\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Higher quality audio is available" in result.output
+    mock_download.assert_not_called()
+
+
+def test_prefer_video_audio_prompts_with_estimates_and_enables_extraction(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=32_000, duration_seconds=600.0, total_bitrate_bps=32_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference", return_value=DownloadResult()) as mock_download,
+        patch("gencon_audiobook.cli.build_m4b"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--output", str(tmp_path),
+                "--audiobook-only",
+                "--conference", "2024-04",
+                "--prefer-video-audio",
+            ],
+            input="y\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "--prefer-video-audio is active" in result.output
+    assert "Estimated download" in result.output
+    assert mock_download.call_args.kwargs["prefer_video_audio"] is True
+
+
+def test_prefer_video_audio_does_not_downgrade_better_mp3(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=128_000, duration_seconds=600.0, total_bitrate_bps=128_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference", return_value=DownloadResult()) as mock_download,
+        patch("gencon_audiobook.cli.build_m4b"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--output", str(tmp_path),
+                "--audiobook-only",
+                "--conference", "2024-04",
+                "--prefer-video-audio",
+            ],
+            input="\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "MP3 source is already equal" in result.output
+    assert "better for this conference" in result.output
+    assert mock_download.call_args.kwargs["prefer_video_audio"] is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,16 @@ def test_help_exits_zero() -> None:
     assert "--conference" in result.output
 
 
+def test_output_missing_value_reports_output_error() -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["--output", "--conference", "2024-04", "--audiobook-only"])
+
+    assert result.exit_code != 0
+    assert "--output" in result.output
+    assert "requires a value" in result.output
+    assert "unexpected extra argument" not in result.output.lower()
+
+
 def test_version_flag() -> None:
     from gencon_audiobook import __version__
     runner = CliRunner()
@@ -116,6 +126,17 @@ def test_audiobook_only_skips_epub(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     mock_m4b.assert_called_once()
     mock_epub.assert_not_called()
+
+
+def test_audiobook_only_and_epub_only_are_mutually_exclusive(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--output", str(tmp_path), "--audiobook-only", "--epub-only"],
+    )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
 
 
 def test_default_builds_both(tmp_path: Path) -> None:
@@ -287,6 +308,22 @@ def test_scrape_conference_error_exits_nonzero(tmp_path: Path) -> None:
         result = runner.invoke(main, ["--output", str(tmp_path)])
 
     assert result.exit_code != 0
+
+
+def test_direct_conference_404_gets_conference_not_found_message(tmp_path: Path) -> None:
+    with patch(
+        "gencon_audiobook.cli.scrape_conference",
+        side_effect=ScraperError("Page not found: https://example.test/2099/04"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["--output", str(tmp_path), "--conference", "2099-04", "--epub-only"],
+        )
+
+    assert result.exit_code != 0
+    assert "Conference 2099-04 was not found" in result.output
+    assert "internet connection" not in result.output
 
 
 def test_audio_error_exits_nonzero(tmp_path: Path) -> None:
@@ -468,6 +505,30 @@ def test_download_error_exits_nonzero(tmp_path: Path) -> None:
     assert result.exit_code != 0
     assert "Download error" in result.output or "timed out" in result.output, \
         f"Expected download error message in output, got: {result.output!r}"
+
+
+def test_all_talk_download_failures_exit_before_audiobook_build(tmp_path: Path) -> None:
+    refs = [_make_ref()]
+    conference = _make_conference()
+
+    with (
+        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch(
+            "gencon_audiobook.cli.download_conference",
+            return_value=DownloadResult(failed_talks=conference.talks),
+        ),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli.build_m4b") as mock_build,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
+
+    assert result.exit_code != 0
+    assert "No talk audio files were downloaded" in result.output
+    assert "All 1 talk(s) failed" in result.output
+    mock_build.assert_not_called()
 
 
 def test_overwrite_skips_epub_when_epub_exists(tmp_path: Path) -> None:
@@ -665,6 +726,46 @@ def test_prefer_video_audio_prompts_with_estimates_and_enables_extraction(tmp_pa
     assert "--prefer-video-audio is active" in result.output
     assert "Estimated download" in result.output
     assert mock_download.call_args.kwargs["prefer_video_audio"] is True
+
+
+def test_prefer_video_audio_cached_noop_skips_heavy_confirmation(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+    output_dir = tmp_path / "April 2024 General Conference"
+    output_dir.mkdir()
+    (output_dir / "April 2024 General Conference.m4b").write_bytes(b"m4b")
+    (output_dir / "audio").mkdir()
+    (output_dir / "audio" / "001-Opening-Remarks.m4a").write_bytes(b"aac")
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=32_000, duration_seconds=600.0, total_bitrate_bps=32_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference", return_value=DownloadResult()) as mock_download,
+        patch("gencon_audiobook.cli.click.confirm") as mock_confirm,
+        patch("gencon_audiobook.cli.build_m4b") as mock_build,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--output", str(tmp_path),
+                "--audiobook-only",
+                "--conference", "2024-04",
+                "--prefer-video-audio",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "skipping download confirmation" in result.output
+    mock_confirm.assert_not_called()
+    assert mock_download.call_args.kwargs["prefer_video_audio"] is True
+    mock_build.assert_not_called()
 
 
 def test_prefer_video_audio_does_not_downgrade_better_mp3(tmp_path: Path) -> None:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -15,9 +15,11 @@ from gencon_audiobook.downloader import (
     DownloadError,
     DownloadResult,
     _audio_path,
+    _extract_video_audio,
     _probe_audio_info,
     _speaker_path,
     _video_audio_path,
+    conference_downloads_complete,
     cleanup_tmp_files,
     download_conference,
     download_file,
@@ -283,6 +285,29 @@ def test_video_audio_path_format(tmp_path: Path) -> None:
     assert path.parent == tmp_path / "audio"
 
 
+def test_conference_downloads_complete_checks_preferred_video_audio_cache(tmp_path: Path) -> None:
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    assert not conference_downloads_complete(
+        conference,
+        tmp_path,
+        prefer_video_audio=True,
+    )
+
+    (tmp_path / "audio").mkdir()
+    (tmp_path / "audio" / "001-Test-Talk.m4a").write_bytes(b"aac")
+    (tmp_path / "cover.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "speakers").mkdir()
+    (tmp_path / "speakers" / "001-Test-Speaker.jpg").write_bytes(_jpeg_bytes())
+
+    assert conference_downloads_complete(
+        conference,
+        tmp_path,
+        prefer_video_audio=True,
+    )
+
+
 def test_probe_audio_info_parses_ffprobe_json() -> None:
     result = MagicMock()
     result.stdout = """
@@ -298,6 +323,29 @@ def test_probe_audio_info_parses_ffprobe_json() -> None:
     assert probe.audio_bitrate_bps == 96_000
     assert probe.duration_seconds == 600.0
     assert probe.total_bitrate_bps == 600_000
+
+
+def test_extract_video_audio_specifies_muxer_for_tmp_output(tmp_path: Path) -> None:
+    result = MagicMock()
+    result.returncode = 0
+    result.stderr = ""
+    dest = tmp_path / "audio" / "001-Test-Talk.m4a"
+
+    def _write_tmp(cmd: list[str], **_: object) -> MagicMock:
+        tmp = Path(cmd[-1])
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_bytes(b"aac")
+        return result
+
+    with patch("gencon_audiobook.downloader.subprocess.run", side_effect=_write_tmp) as mock_run:
+        was_downloaded = _extract_video_audio(_ALLOWED_VIDEO, dest, Path("ffmpeg"))
+
+    assert was_downloaded is True
+    cmd = mock_run.call_args.args[0]
+    assert "-f" in cmd, f"ffmpeg command must specify output muxer for .m4a.tmp: {cmd}"
+    assert cmd[cmd.index("-f") + 1] == "ipod"
+    assert cmd[-1].endswith(".m4a.tmp")
+    assert dest.read_bytes() == b"aac"
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +394,52 @@ def test_download_conference_extracts_video_audio_when_preferred(tmp_path: Path)
     expected_dest = tmp_path / "audio" / "001-Test-Talk.m4a"
     mock_extract.assert_called_once_with(_ALLOWED_VIDEO, expected_dest, Path("ffmpeg"))
     assert result.downloaded == 1
+
+
+@rsps_lib.activate
+def test_download_conference_falls_back_to_mp3_when_video_extract_fails(tmp_path: Path) -> None:
+    rsps_lib.add(rsps_lib.GET, _MP3_URL, body=_small_mp3(), status=200)
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    with patch(
+        "gencon_audiobook.downloader._extract_video_audio",
+        side_effect=DownloadError("ffmpeg failed"),
+    ):
+        result = download_conference(
+            conference,
+            tmp_path,
+            delay=0,
+            prefer_video_audio=True,
+            ffmpeg_path=Path("ffmpeg"),
+        )
+
+    assert (tmp_path / "audio" / "001-Test-Talk.mp3").exists()
+    assert not (tmp_path / "audio" / "001-Test-Talk.m4a").exists()
+    assert result.downloaded == 1
+    assert result.failed_talks == []
+
+
+@rsps_lib.activate
+def test_download_conference_marks_talk_failed_when_video_and_mp3_fallback_fail(tmp_path: Path) -> None:
+    for _ in range(4):
+        rsps_lib.add(rsps_lib.GET, _MP3_URL, status=500)
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    with patch(
+        "gencon_audiobook.downloader._extract_video_audio",
+        side_effect=DownloadError("ffmpeg failed"),
+    ):
+        result = download_conference(
+            conference,
+            tmp_path,
+            delay=0,
+            prefer_video_audio=True,
+            ffmpeg_path=Path("ffmpeg"),
+        )
+
+    assert result.failed_talks == [conference.talks[0]]
 
 
 @rsps_lib.activate

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from gencon_audiobook.downloader import (
     DownloadError,
+    DownloadResult,
     _audio_path,
     _speaker_path,
     cleanup_tmp_files,
@@ -61,8 +62,9 @@ def test_download_file_success(tmp_path: Path) -> None:
     rsps_lib.add(rsps_lib.GET, _ALLOWED_URL, body=content, status=200)
 
     dest = tmp_path / "audio" / "001-test.mp3"
-    download_file(_ALLOWED_URL, dest, _make_session())
+    result = download_file(_ALLOWED_URL, dest, _make_session())
 
+    assert result is True, "download_file should return True when file is downloaded"
     assert dest.exists(), "Destination file should exist after download"
     assert dest.read_bytes() == content, "Destination content should match server response"
     assert not dest.with_suffix(dest.suffix + ".tmp").exists(), ".tmp file should be cleaned up"
@@ -91,8 +93,9 @@ def test_download_file_skips_existing(tmp_path: Path) -> None:
     dest = tmp_path / "001-test.mp3"
     dest.write_bytes(content)  # pre-existing correct file
 
-    download_file(_ALLOWED_URL, dest, _make_session())
+    result = download_file(_ALLOWED_URL, dest, _make_session())
 
+    assert result is False, "download_file should return False when file is skipped"
     get_calls = [c for c in rsps_lib.calls if c.request.method == "GET"]
     assert len(get_calls) == 0, "GET should not be issued when file is already complete"
 
@@ -335,6 +338,43 @@ def test_download_conference_audio_downloaded_by_default(tmp_path: Path) -> None
     mp3 = tmp_path / "audio" / "001-Test-Talk.mp3"
     assert mp3.exists(), \
         f"MP3 should be downloaded by default (skip_audio=False); expected {mp3}"
+
+
+@rsps_lib.activate
+def test_download_conference_returns_download_result(tmp_path: Path) -> None:
+    """download_conference() returns a DownloadResult with accurate counts."""
+    rsps_lib.add(rsps_lib.GET, _COVER_URL, body=_jpeg_bytes(), status=200)
+    rsps_lib.add(rsps_lib.GET, _PHOTO_URL, body=_jpeg_bytes(), status=200)
+    rsps_lib.add(rsps_lib.GET, _MP3_URL, body=_small_mp3(), status=200)
+
+    conference = _make_single_talk_conference()
+    result = download_conference(conference, tmp_path, delay=0, skip_audio=False)
+
+    assert isinstance(result, DownloadResult), "download_conference must return a DownloadResult"
+    assert result.failed_talks == [], "No talks should fail when all downloads succeed"
+    assert result.downloaded == 3, f"Expected 3 downloaded, got {result.downloaded}"
+    assert result.skipped == 0, f"Expected 0 skipped, got {result.skipped}"
+
+
+@rsps_lib.activate
+def test_download_conference_skips_silently_when_all_exist(tmp_path: Path) -> None:
+    """When all destination files already exist, no HTTP requests are made and no progress bar shown."""
+    conference = _make_single_talk_conference()
+
+    # Pre-create all destination files so the pre-scan short-circuits
+    (tmp_path / "cover.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "speakers").mkdir()
+    (tmp_path / "speakers" / "001-Test-Speaker.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "audio").mkdir()
+    (tmp_path / "audio" / "001-Test-Talk.mp3").write_bytes(_small_mp3())
+
+    result = download_conference(conference, tmp_path, delay=0, skip_audio=False)
+
+    assert result.downloaded == 0, "No files should be downloaded when all already exist"
+    assert result.skipped == 3, f"Expected 3 skipped, got {result.skipped}"
+    assert result.failed_talks == [], "No talks should fail on a fully-cached run"
+    # No HTTP calls — the pre-scan returns early before touching the network
+    assert len(rsps_lib.calls) == 0, "No HTTP requests should be made when all files exist"
 
 
 @rsps_lib.activate

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -14,7 +15,9 @@ from gencon_audiobook.downloader import (
     DownloadError,
     DownloadResult,
     _audio_path,
+    _probe_audio_info,
     _speaker_path,
+    _video_audio_path,
     cleanup_tmp_files,
     download_conference,
     download_file,
@@ -23,6 +26,7 @@ from gencon_audiobook.models import Conference, Session, Talk
 
 _ALLOWED_URL = "https://assets.churchofjesuschrist.org/test.mp3"
 _ALLOWED_IMG = "https://assets.churchofjesuschrist.org/test.jpg"
+_ALLOWED_VIDEO = "https://assets.churchofjesuschrist.org/testslug-360p-en.mp4"
 _BLOCKED_URL = "https://evil.example.com/test.mp3"
 
 
@@ -267,6 +271,35 @@ def test_speaker_path_format(tmp_path: Path) -> None:
     assert path.parent == tmp_path / "speakers"
 
 
+def test_video_audio_path_format(tmp_path: Path) -> None:
+    talk = Talk(
+        title="Welcome to Conference",
+        speaker="John Smith",
+        talk_url="https://www.churchofjesuschrist.org/t",
+        talk_index=7,
+    )
+    path = _video_audio_path(tmp_path, talk)
+    assert path.name == "007-Welcome-to-Conference.m4a", f"Unexpected name: {path.name!r}"
+    assert path.parent == tmp_path / "audio"
+
+
+def test_probe_audio_info_parses_ffprobe_json() -> None:
+    result = MagicMock()
+    result.stdout = """
+    {
+      "streams": [{"bit_rate": "96000", "duration": "600.0"}],
+      "format": {"bit_rate": "600000", "duration": "600.0"}
+    }
+    """
+
+    with patch("gencon_audiobook.downloader.subprocess.run", return_value=result):
+        probe = _probe_audio_info(_ALLOWED_VIDEO, Path("ffprobe"))
+
+    assert probe.audio_bitrate_bps == 96_000
+    assert probe.duration_seconds == 600.0
+    assert probe.total_bitrate_bps == 600_000
+
+
 # ---------------------------------------------------------------------------
 # download_conference — integration of the full download queue
 # ---------------------------------------------------------------------------
@@ -295,6 +328,41 @@ def _make_single_talk_conference() -> Conference:
         sessions=[session],
         conference_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04",
     )
+
+
+def test_download_conference_extracts_video_audio_when_preferred(tmp_path: Path) -> None:
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    with patch("gencon_audiobook.downloader._extract_video_audio", return_value=True) as mock_extract:
+        result = download_conference(
+            conference,
+            tmp_path,
+            delay=0,
+            prefer_video_audio=True,
+            ffmpeg_path=Path("ffmpeg"),
+        )
+
+    expected_dest = tmp_path / "audio" / "001-Test-Talk.m4a"
+    mock_extract.assert_called_once_with(_ALLOWED_VIDEO, expected_dest, Path("ffmpeg"))
+    assert result.downloaded == 1
+
+
+@rsps_lib.activate
+def test_download_conference_prefers_mp3_when_video_missing(tmp_path: Path) -> None:
+    rsps_lib.add(rsps_lib.GET, _MP3_URL, body=_small_mp3(), status=200)
+    conference = _make_single_talk_conference()
+
+    result = download_conference(
+        conference,
+        tmp_path,
+        delay=0,
+        prefer_video_audio=True,
+        ffmpeg_path=Path("ffmpeg"),
+    )
+
+    assert (tmp_path / "audio" / "001-Test-Talk.mp3").exists()
+    assert result.downloaded == 1
 
 
 @rsps_lib.activate

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -376,6 +376,16 @@ def test_build_epub_talk_titles_in_nav(tmp_path: Path) -> None:
         assert talk.title in nav, f"Talk title {talk.title!r} not found in nav.xhtml"
 
 
+def test_build_epub_talk_speakers_in_nav(tmp_path: Path) -> None:
+    conference = _make_conference(n_talks=3)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    nav = _epub_read(output, "nav.xhtml").decode("utf-8")
+    for talk in conference.talks:
+        expected = f"{talk.title} -- {talk.speaker}"
+        assert expected in nav, f"TOC entry {expected!r} not found in nav.xhtml"
+
+
 def test_build_epub_sessions_in_nav(tmp_path: Path) -> None:
     conference = _make_conference(n_talks=4)
     output = tmp_path / "test.epub"
@@ -823,6 +833,19 @@ def test_build_epub_title_with_special_chars_escaped(tmp_path: Path) -> None:
     assert "&amp;" in page, "Ampersand in title must be HTML-escaped as &amp;"
     assert "<Elder" not in page, "Unescaped angle bracket in speaker name must not appear"
     assert "<Test>" not in page, "Unescaped angle brackets must not appear in XHTML"
+
+
+def test_build_epub_nav_speaker_label_escaped(tmp_path: Path) -> None:
+    conference = _make_conference(n_talks=1)
+    conference.talks[0].title = "Faith & Works"
+    conference.talks[0].speaker = "Elder A. <Test>"
+
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    nav = _epub_read(output, "nav.xhtml").decode("utf-8")
+    assert "Faith &amp; Works -- Elder A. &lt;Test&gt;" in nav
+    assert "<Test>" not in nav, "TOC speaker label must be escaped"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -569,15 +569,15 @@ def test_build_epub_css_has_no_font_family(tmp_path: Path) -> None:
         "CSS must not contain font-family declarations"
 
 
-def test_build_epub_css_has_no_absolute_font_sizes(tmp_path: Path) -> None:
+def test_build_epub_css_has_no_font_size_declarations(tmp_path: Path) -> None:
     conference = _make_conference(n_talks=2)
     output = tmp_path / "test.epub"
     build_epub(conference, tmp_path, output)
     css = _epub_read(output, "style.css").decode("utf-8")
     css_no_comments = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
-    # Absolute units: px, pt, cm, mm, in, pc
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", css_no_comments), \
-        "CSS must not use absolute font-size units (px, pt, cm, mm, in, pc)"
+    # font-size of any unit is banned — defer text sizing entirely to the reader
+    assert not re.search(r"\bfont-size\s*:", css_no_comments), \
+        "CSS must not contain any font-size declarations (any unit)"
 
 
 # ---------------------------------------------------------------------------
@@ -1135,5 +1135,5 @@ def test_build_epub_css_para_num_theme_safe(tmp_path: Path) -> None:
     assert not re.search(r"\bcolor\s*:", block), ".para-num must not set color"
     assert not re.search(r"\bbackground(-color)?\s*:", block), ".para-num must not set background"
     assert not re.search(r"\bfont-family\s*:", block), ".para-num must not set font-family"
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", block), \
-        ".para-num must not use absolute font-size units"
+    assert not re.search(r"\bfont-size\s*:", block), \
+        ".para-num must not contain any font-size declaration (any unit)"

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -185,6 +185,65 @@ def test_sanitize_transcript_noteref_link_preserved_with_epub_type() -> None:
     assert "<sup" in result, "Superscript inside noteref must be preserved"
 
 
+def test_sanitize_transcript_real_noteref_url_normalized() -> None:
+    """Church note-ref links use full talk-page URLs ending in #noteN, not bare fragments.
+
+    A link like href="/study/general-conference/2024/04/31bowen?lang=eng#note1" with
+    class="note-ref" and data-scroll-id="note1" must be normalized to href="#note1"
+    and marked as epub:type="noteref". The existing href-fragment check does not handle
+    this case — it only matches bare "#note" prefixes.
+    """
+    html = (
+        '<p>Priesthood keys.<a class="note-ref" '
+        'data-scroll-id="note1" '
+        'href="/study/general-conference/2024/04/31bowen?lang=eng#note1">'
+        '<sup class="marker" data-value="1"></sup></a></p>'
+    )
+    result = _sanitize_transcript(html)
+    assert 'href="#note1"' in result, (
+        f"Full URL note-ref must be normalized to bare fragment, got: {result!r}"
+    )
+    assert 'epub:type="noteref"' in result, (
+        f"epub:type noteref must be added to normalized note-ref, got: {result!r}"
+    )
+
+
+def test_sanitize_transcript_li_footnote_body_wrapped_in_aside() -> None:
+    """Real Church footnote bodies use <li id='noteN'>, not <p id='noteN'>.
+
+    The EPUB builder must wrap <li id="noteN"> in <aside epub:type="footnote"> just
+    as it does for <p id="noteN"> shapes, since the real site uses list items.
+    """
+    html = (
+        '<ol><li id="note1">'
+        '<p>See <a href="/study/scriptures/nt/matt/16">Matthew 16:17</a>.</p>'
+        '</li></ol>'
+    )
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote" id="note1">' in result, (
+        f"<li id='note1'> must become <aside epub:type='footnote' id='note1'>, got: {result!r}"
+    )
+    assert "Matthew 16:17" in result, "Footnote body text must survive wrapping"
+
+
+def test_sanitize_transcript_note_title_id_not_wrapped() -> None:
+    """id='note_title1' is a section heading, not a footnote body — must not be wrapped."""
+    html = '<p id="note_title1">Notes</p>'
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote"' not in result, (
+        f"note_title* id must not produce a footnote aside, got: {result!r}"
+    )
+
+
+def test_sanitize_transcript_child_note_id_not_wrapped() -> None:
+    """id='note1_p1' is a child element ID, not a footnote body — must not be wrapped."""
+    html = '<p id="note1_p1">Child paragraph text.</p>'
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote"' not in result, (
+        f"note1_p1 id must not produce a footnote aside, got: {result!r}"
+    )
+
+
 def test_sanitize_transcript_non_note_links_still_unwrapped() -> None:
     """Non-footnote <a> tags (scripture refs, cross-refs) must still be unwrapped."""
     html = '<p>See <a href="https://www.churchofjesuschrist.org/scripture/1ne/1.1">1 Ne. 1:1</a>.</p>'
@@ -339,6 +398,71 @@ def test_build_epub_session_headers_are_links(tmp_path: Path) -> None:
         "Session header must not use <span>"
     assert f">{session_name}</a>" in nav, \
         "Session header must use <a> linking to first talk"
+
+
+# ---------------------------------------------------------------------------
+# build_epub — footnote end-to-end (ZIP-level assertions)
+# ---------------------------------------------------------------------------
+
+
+def _make_conference_with_notes() -> Conference:
+    """Return a one-talk Conference whose transcript contains realistic Church note markup."""
+    # Note refs use full talk-page URLs (as the Church site generates them), not bare fragments.
+    # Note bodies come from footer.notes as <li id="noteN"> elements (already appended to
+    # transcript_html by the scraper — this simulates a post-fix scrape result).
+    transcript = (
+        '<div class="body-block">'
+        '<p>Priesthood keys.'
+        '<a class="note-ref" data-scroll-id="note1" '
+        'href="/study/general-conference/2024/04/31bowen?lang=eng#note1">'
+        '<sup class="marker" data-value="1"></sup></a></p>'
+        '</div>'
+        '<footer class="notes">'
+        '<ol class="decimal">'
+        '<li id="note1"><p>See Matthew 16:17&#x2013;19.</p></li>'
+        '</ol>'
+        '</footer>'
+    )
+    talk = Talk(
+        title="Miracles, Angels, and Priesthood Power",
+        speaker="Elder Shayne M. Bowen",
+        talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/31bowen?lang=eng",
+        talk_index=1,
+        transcript_html=transcript,
+    )
+    session = Session(name="Saturday Morning Session", number=1, talks=[talk])
+    return Conference(
+        title="April 2024 General Conference",
+        year=2024,
+        month=4,
+        cover_image_url=None,
+        sessions=[session],
+        conference_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04",
+    )
+
+
+def test_build_epub_footnotes_noteref_in_output(tmp_path: Path) -> None:
+    """A talk with Church-style note refs must produce epub:type="noteref" in the EPUB ZIP.
+
+    This is a build-level regression test: it verifies that the entire pipeline from
+    transcript_html through _sanitize_transcript() and into the final EPUB file preserves
+    footnote markup — not just that the sanitizer function returns the right string.
+    """
+    conference = _make_conference_with_notes()
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    talk_files = [n for n in _epub_names(output) if n.startswith("text/talk-")]
+    assert talk_files, "Expected at least one talk XHTML file in the EPUB"
+    talk_content = _epub_read(output, talk_files[0]).decode("utf-8")
+    assert 'epub:type="noteref"' in talk_content, (
+        f"epub:type='noteref' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
+    assert 'epub:type="footnote"' in talk_content, (
+        f"epub:type='footnote' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
+    assert 'href="#note1"' in talk_content, (
+        f"Normalized note href '#note1' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -8,9 +8,9 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from conftest import make_jpeg as _make_jpeg
 from PIL import Image
 
-from conftest import make_jpeg as _make_jpeg
 from gencon_audiobook.epub_builder import (
     EpubError,
     _make_portrait_cover,
@@ -19,7 +19,6 @@ from gencon_audiobook.epub_builder import (
     build_epub,
 )
 from gencon_audiobook.models import Conference, Session, Talk
-
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -235,13 +234,6 @@ def test_sanitize_transcript_strips_random_ids() -> None:
     result = _sanitize_transcript(html)
     assert 'id="p_fvoG6"' not in result, f"Random id must be stripped, got: {result!r}"
     assert "Text." in result, "Paragraph content must be preserved"
-
-
-def test_sanitize_transcript_preserves_note_ids() -> None:
-    """id attributes starting with 'note' must be preserved for footnote anchors."""
-    html = '<p id="note1">Footnote text.</p>'
-    result = _sanitize_transcript(html)
-    assert 'id="note1"' in result, f"note id must be preserved, got: {result!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -699,7 +691,6 @@ def test_build_epub_title_with_special_chars_escaped(tmp_path: Path) -> None:
     output = tmp_path / "test.epub"
     build_epub(conference, tmp_path, output)
 
-    from gencon_audiobook.utils import sanitize_filename
     # sanitize_filename strips < and > so we need to find the actual filename
     with zipfile.ZipFile(output) as zf:
         talk_page = next(n for n in zf.namelist() if n.startswith("text/talk-001-"))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,13 +14,19 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import zipfile
 from pathlib import Path
 
 import pytest
+from conftest import FFMPEG as _FFMPEG
+from conftest import FFPROBE as _FFPROBE
+from conftest import make_jpeg as _make_jpeg
+from conftest import make_silent_mp3 as _make_silent_mp3
+from conftest import requires_ffmpeg
 from mutagen.mp4 import MP4
+from PIL import Image
 
-from conftest import FFMPEG as _FFMPEG, FFPROBE as _FFPROBE, make_jpeg as _make_jpeg, make_silent_mp3 as _make_silent_mp3, requires_ffmpeg
 from gencon_audiobook.audio import build_m4b
 from gencon_audiobook.epub_builder import build_epub
 from gencon_audiobook.models import Conference, Session, Talk

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -485,3 +485,40 @@ def test_upgrade_iiif_leaves_non_iiif_url_unchanged() -> None:
     assert _upgrade_iiif(url) == url, (
         f"Non-IIIF URL must pass through unchanged, got: {_upgrade_iiif(url)!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _CONF_URL_RE
+# ---------------------------------------------------------------------------
+
+
+def test_conf_url_re_matches_modern_slug() -> None:
+    """_CONF_URL_RE must match modern (no-hyphen) talk slugs."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04/11oaks"
+    assert _CONF_URL_RE.search(url), f"Expected match for modern slug: {url!r}"
+
+
+def test_conf_url_re_matches_hyphenated_slug() -> None:
+    """_CONF_URL_RE must match pre-2020 hyphenated talk slugs (the old bug)."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/1999/04/the-work-moves-forward"
+    assert _CONF_URL_RE.search(url), f"Expected match for hyphenated slug: {url!r}"
+
+
+def test_conf_url_re_matches_session_slug() -> None:
+    """Session slugs also match _CONF_URL_RE — DOM position distinguishes sessions from talks."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04/saturday-morning-session"
+    assert _CONF_URL_RE.search(url), f"Expected match for session slug: {url!r}"
+
+
+def test_conf_url_re_rejects_archive_url() -> None:
+    """_CONF_URL_RE must not match the top-level archive URL (no talk slug)."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04"
+    assert not _CONF_URL_RE.search(url), f"Should not match bare conference URL: {url!r}"

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -268,6 +268,28 @@ def test_parse_talk_page_deduplicates_inline_images():
     assert len(data["inline_images"]) == 1, "Duplicate asset_id should be deduplicated"
 
 
+def test_parse_talk_page_captures_footnote_bodies_from_footer():
+    """footer.notes content must appear in transcript_html so the EPUB builder can render it.
+
+    The Church site places footnote bodies in <footer class="notes"> as a sibling of
+    <div class="body-block">, not inside it. parse_talk_page() must capture both
+    so the EPUB builder has the note bodies it needs.
+    """
+    html = _load("talk_page_with_notes.html")
+    data = parse_talk_page(html, "https://www.churchofjesuschrist.org/study/general-conference/2024/04/31bowen?lang=eng")
+    transcript = data["transcript_html"] or ""
+    assert 'id="note1"' in transcript, (
+        "Footnote body id='note1' must be present in transcript_html"
+    )
+    assert 'id="note2"' in transcript, (
+        "Footnote body id='note2' must be present in transcript_html"
+    )
+    # Verify note content survived
+    assert "Matthew 16" in transcript, (
+        "Footnote body text must be present in transcript_html"
+    )
+
+
 # ---------------------------------------------------------------------------
 # robots.txt (#23)
 # ---------------------------------------------------------------------------

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -6,6 +6,8 @@ or after the Church website structure changes.
 
 from __future__ import annotations
 
+import base64
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -155,6 +157,39 @@ def test_parse_talk_page_mp3_url_passes_validate_url():
     assert data["mp3_url"] is not None
     assert validate_url(data["mp3_url"]), \
         f"mp3_url should pass validate_url(), got {data['mp3_url']!r}"
+
+
+def test_parse_talk_page_extracts_video_url_from_decoded_state():
+    video_url = "https://assets.churchofjesuschrist.org/utshiqnoy1y8xchu1tdwi860yku3zl2jw56xcbbx-360p-en.mp4"
+    state = {
+        "reader": {
+            "contentStore": {
+                "talk": {
+                    "meta": {
+                        "audio": [{"mediaUrl": "https://assets.churchofjesuschrist.org/audio-32k-en.mp3"}],
+                        "video": [{"mediaUrl": video_url}],
+                    }
+                }
+            }
+        }
+    }
+    encoded = base64.b64encode(json.dumps(state).encode("utf-8")).decode("ascii")
+    html = f'<html><body><script>window.__INITIAL_STATE__ = "{encoded}"</script></body></html>'
+
+    data = parse_talk_page(html, "https://www.churchofjesuschrist.org/test")
+
+    assert data["video_url"] == video_url
+
+
+def test_parse_talk_page_video_url_regex_accepts_uppercase_hash():
+    video_url = "https://assets.churchofjesuschrist.org/59C8428CEF2EDDFAB2352EF6F3011D57B4772C28-360p-en.mp4"
+    state = {"video": {"url": video_url}}
+    encoded = base64.b64encode(json.dumps(state).encode("utf-8")).decode("ascii")
+    html = f'<html><body><script>window.__INITIAL_STATE__ = "{encoded}"</script></body></html>'
+
+    data = parse_talk_page(html, "https://www.churchofjesuschrist.org/test")
+
+    assert data["video_url"] == video_url
 
 
 def test_parse_talk_page_extracts_transcript():
@@ -307,6 +342,17 @@ def _make_http_session(robots_text: str, status: int = 200) -> MagicMock:
     return session
 
 
+def _add_robots_response(body: str = "User-agent: *\nDisallow:\n") -> None:
+    """Register an allow-all robots.txt response for _fetch tests."""
+    reset_robots_cache()
+    responses_lib.add(
+        responses_lib.GET,
+        "https://www.churchofjesuschrist.org/robots.txt",
+        status=200,
+        body=body,
+    )
+
+
 def test_check_robots_allows_permitted_url() -> None:
     """A URL permitted by robots.txt must not raise."""
     robots_text = "User-agent: *\nDisallow: /private/\n"
@@ -385,6 +431,7 @@ def test_fetch_retries_on_429_then_succeeds() -> None:
     url = "https://www.churchofjesuschrist.org/study/general-conference"
     minimal_html = "<html><body>" + "x" * 1200 + "</body></html>"
 
+    _add_robots_response()
     responses_lib.add(responses_lib.GET, url, status=429, body="Too Many Requests")
     responses_lib.add(responses_lib.GET, url, status=200, body=minimal_html)
 
@@ -402,6 +449,7 @@ def test_fetch_403_raises_immediately_without_retry() -> None:
     from gencon_audiobook.scraper import _fetch
 
     url = "https://www.churchofjesuschrist.org/study/general-conference"
+    _add_robots_response()
     responses_lib.add(responses_lib.GET, url, status=403, body="Forbidden")
     # Only one response registered — if retry occurs, responses_lib raises ConnectionError
 
@@ -410,9 +458,28 @@ def test_fetch_403_raises_immediately_without_retry() -> None:
         with pytest.raises(ScraperError, match="403"):
             _fetch(session, url)
 
-    assert len(responses_lib.calls) == 1, (
-        f"403 must not be retried — expected 1 request, got {len(responses_lib.calls)}"
+    assert len(responses_lib.calls) == 2, (
+        f"403 must not be retried — expected robots + 1 request, got {len(responses_lib.calls)}"
     )
+
+
+@responses_lib.activate
+def test_fetch_enforces_robots_txt_before_request() -> None:
+    """_fetch must enforce robots.txt, not just direct _check_robots() calls."""
+    from gencon_audiobook.scraper import _fetch
+
+    url = "https://www.churchofjesuschrist.org/study/general-conference/2024/04"
+    _add_robots_response("User-agent: *\nDisallow: /study/general-conference/\n")
+    responses_lib.add(responses_lib.GET, url, status=200, body="x" * 1200)
+
+    session = _scraper_make_session()
+    with pytest.raises(ScraperError, match="disallowed by robots.txt"):
+        _fetch(session, url)
+
+    assert len(responses_lib.calls) == 1, (
+        "_fetch should stop after robots.txt and never request a disallowed page"
+    )
+    assert responses_lib.calls[0].request.url.endswith("/robots.txt")
 
 
 # ---------------------------------------------------------------------------

--- a/wiki-Architecture.md
+++ b/wiki-Architecture.md
@@ -1,0 +1,292 @@
+# Architecture
+
+This page describes the structure of the codebase for contributors and developers.
+
+---
+
+## Data flow
+
+```
+churchofjesuschrist.org
+        |
+        v
+  [ scraper.py ]
+  Fetch conference archive -> parse ConferenceRef list
+  Fetch conference listing -> parse Session/Talk stubs
+  Fetch each talk page    -> extract mp3_url, transcript_html,
+                             speaker_image_url, inline_images, speaker name
+        |
+        v
+  [ cache.py ]
+  Save Conference to conference.json after first scrape.
+  Load from conference.json on subsequent runs (skips scraping).
+  --force-scrape bypasses the cache.
+        |
+        v
+  [ models.py ]
+  Conference(title, year, month, sessions, cover_image_url)
+    Session(name, number, talks)
+      Talk(title, speaker, mp3_url, transcript_html,
+           speaker_image_url, inline_images, talk_index, session_name, ...)
+        |
+        v
+  [ downloader.py ]
+  Images (parallel, up to 8 threads):
+    Download cover      -> cover.jpg
+    Download photos     -> speakers/{index}-{speaker}.jpg
+    Download body imgs  -> inline/{index}-{asset_id}.jpg
+  Audio (sequential, 0.5s delay):
+    Download MP3s       -> audio/{index}-{title}.mp3
+  (JPEG conversion applied to all images via Pillow)
+  (resume: skips files already at correct size)
+        |
+        +---------------------------+
+        |                           |
+        v                           v
+  [ audio.py ]               [ epub_builder.py ]
+  Probe source quality        Sanitize transcripts
+  MP3 -> AAC-LC (ffmpeg)      Resize speaker photos (IIIF 800px -> 300px embed)
+  Write FFMETADATA1           Compose portrait cover (landscape -> 1200x1800 canvas)
+  Concat AAC files            Embed inline body images
+  Mux chapters + cover        Assemble EPUB 3 ZIP:
+  Verify with mutagen           mimetype (ZIP_STORED)
+  Delete intermediate .m4a      META-INF/container.xml
+        |                        content.opf
+        v                        nav.xhtml (toc + landmarks)
+  output.m4b                     style.css
+                                 text/cover.xhtml
+                                 text/copyright.xhtml
+                                 text/session-NNN-*.xhtml
+                                 text/talk-NNN-*.xhtml
+                                 images/cover.jpg (ZIP_STORED)
+                                 images/spk-NNN-*.jpg (ZIP_STORED)
+                                 images/inline-NNN-*.jpg (ZIP_STORED)
+                                 |
+                                 v
+                            output.epub
+```
+
+ffmpeg is located by `ffmpeg_manager.py` before either audio pipeline starts.
+
+---
+
+## Module responsibilities
+
+### `cli.py`
+
+The Click entry point. Parses CLI arguments, orchestrates the pipeline, and handles user-facing output.
+
+Responsibilities:
+- Configure console logging (Rich handler) and file logging
+- Validate Python version and warn on low disk space
+- Call `fetch_available_conferences()` and present a selection
+- Call `scrape_conference()` to get the full Conference object
+- Call `download_conference()` and surface any failed talks
+- Call `build_m4b()` and `build_epub()` based on `--audiobook-only` / `--epub-only` flags
+- Print the completion summary
+
+The `main()` function is thin: it calls `_run()` and wraps it in a `KeyboardInterrupt` handler. All logic lives in `_run()` and the helper functions `_setup_logging`, `_add_file_logging`, `_check_python_version`, `_check_disk_space`, and `_select_conference`.
+
+### `scraper.py`
+
+Fetches and parses all conference data from the Church website.
+
+Public API: `fetch_available_conferences() -> list[ConferenceRef]`, `scrape_conference(url) -> Conference`
+
+Two-layer parsing strategy for resilience against site changes:
+1. **Primary:** Extract `window.__INITIAL_STATE__` (base64-encoded JSON embedded in a `<script>` tag). This is structured and stable.
+2. **Fallback:** BeautifulSoup HTML traversal. Triggered when the JSON selector finds nothing and logged as a WARNING.
+
+After extracting the main talk body (`div.body-block`), the scraper also checks for a sibling `<footer class="notes">` element and appends its HTML to `transcript_html`. This is necessary because footnote bodies on Church talk pages live outside `div.body-block` and would otherwise be discarded.
+
+HTTP behavior: `requests.Session` with custom User-Agent, explicit timeouts, exponential backoff retry on transient errors, robots.txt compliance check, and 4-priority encoding detection for multi-language resilience.
+
+Depends on: `models.py`, `utils.py` (for `validate_url`)
+
+### `downloader.py`
+
+Downloads all files for a conference: MP3 audio, conference cover image, speaker photos, and inline body images.
+
+Public API: `download_conference(conference, output_dir, delay, skip_audio) -> list[Talk]`
+
+The returned list contains talks whose audio download failed -- these are surfaced to the user as warnings after the build. All other failures (images) are logged but do not affect the return value.
+
+Download behavior: atomic `.tmp` + rename, resume by Content-Length comparison, exponential backoff retry. Images are converted to JPEG via Pillow before saving (handles PNG, WebP, and other formats from the Church CDN). Progress is shown with a Rich progress bar.
+
+Images (cover, speaker photos, inline body images) download in parallel using `ThreadPoolExecutor` with up to 8 workers. Each worker thread gets its own `requests.Session` via `threading.local` (`_get_thread_session()`). MP3 audio downloads remain sequential with a 0.5s courtesy delay.
+
+Depends on: `models.py`, `utils.py`
+
+### `audio.py`
+
+Converts downloaded MP3 files to AAC and assembles the chaptered m4b audiobook.
+
+Public API: `build_m4b(conference, audio_dir, output_path, cover_path, ffmpeg_path, ffprobe_path, bitrate, sample_rate)`, `convert_mp3_to_aac(mp3_path, aac_path, ffmpeg_path, bitrate, sample_rate) -> float`
+
+Pipeline inside `build_m4b`:
+1. Probe the first available MP3 with ffprobe to detect source bitrate/sample rate (unless `--bitrate`/`--sample-rate` were passed explicitly)
+2. Convert each MP3 to AAC-LC mono (`-vn` strips embedded cover art that would cause container errors)
+3. Write an FFMETADATA1 chapter file with millisecond-precision chapter boundaries
+4. Concatenate all AAC files using the ffmpeg concat demuxer
+5. Mux the concatenated AAC, chapter metadata, and optional cover art into the m4b
+6. Delete intermediate `.m4a` files
+7. Verify with mutagen (cover art present) and ffprobe (chapter count and title format)
+
+Chapter titles are ASCII-safe (`_ascii_safe()`) to avoid ffmpeg codepage/UTF-8 conflicts on Windows. Format is `"Talk Title -- Speaker Name"`.
+
+Depends on: `models.py`, `utils.py`, ffmpeg and ffprobe binaries
+
+### `epub_builder.py`
+
+Builds an EPUB 3 companion with transcripts, speaker photos, inline images, session divider pages, and a nested table of contents.
+
+Public API: `build_epub(conference, images_dir, output_path)`
+
+Assembles a ZIP archive directly (no ebooklib). The `mimetype` entry is always first and stored uncompressed (`ZIP_STORED`), as required by the EPUB specification. All JPEG images are also stored with `ZIP_STORED` to avoid the double-compression problem (JPEG is already compressed; DEFLATE adds negligible size reduction but causes bugs on some older e-ink readers).
+
+Speaker photos are fetched at 800px via IIIF URL rewriting, then resized to at most 300px wide before embedding. The landscape cover image is centered on a 1200x1800 gray canvas to produce a proper 2:3 portrait cover. Inline body images from talk pages are downloaded to `inline/` and embedded in the EPUB.
+
+Transcripts are sanitized via BeautifulSoup: `<script>`, `<style>`, `<iframe>` tags removed; external `href`/`src` stripped; web CSS class names and `data-*` attributes removed. Footnote superscript links are detected via `class="note-ref"` + `data-scroll-id` (the Church site generates full talk-page URLs, not bare `#noteN` fragments); they are normalised to bare fragment hrefs and marked `epub:type="noteref"`. Footnote body elements (`<li id="noteN">` in `footer.notes`, matching `^note\d+$`) are wrapped in `<aside epub:type="footnote">` for popup support in Apple Books, Kobo, and Thorium.
+
+Session divider pages (`text/session-NNN-*.xhtml`) are included so TOC session headers link to a unique destination. EPUB landmarks navigation (`<nav epub:type="landmarks">`) is included with cover, TOC, and bodymatter entries.
+
+CSS is theme-safe: zero `color`, `background-color`, or `font-family` declarations. All visual styling is deferred to the reader application. (Note: two `font-size` declarations using relative `em` units currently exist and are tracked for removal; see Technical Decisions section 5 for details.)
+
+A post-write ZIP integrity check (`testzip()`) runs after the EPUB is assembled and raises `EpubError` if any entry is corrupt.
+
+Depends on: `models.py`, `utils.py`, Pillow for image resizing and canvas composition, BeautifulSoup for transcript sanitization
+
+### `ffmpeg_manager.py`
+
+Locates ffmpeg and ffprobe, downloading via `static-ffmpeg` if they are not on the system PATH.
+
+Public API: `ensure_ffmpeg() -> Path`, `ensure_ffprobe() -> Path`, `reset_cache()` (testing only)
+
+Search order for ffmpeg:
+1. `shutil.which("ffmpeg")` -- system PATH
+2. `static_ffmpeg.add_paths()` -- automatic download
+
+ffprobe is located by looking next to the ffmpeg binary (same directory, same `.exe` suffix on Windows), then falling back to PATH. Both paths are cached after the first call.
+
+Depends on: `static-ffmpeg` package (optional, only imported if ffmpeg is not on PATH)
+
+### `models.py`
+
+Data classes for the domain model.
+
+- `Conference(title, year, month, cover_image_url, sessions, conference_url)` -- top-level container
+- `Session(name, number, talks)` -- a single conference session
+- `Talk(title, speaker, talk_url, mp3_url, transcript_html, speaker_image_url, inline_images, session_name, session_number, talk_number, talk_index, duration_seconds)` -- a single talk with all metadata
+- `InlineImage(url, asset_id)` -- a single inline body image referenced in a talk's transcript
+
+`talk_index` is a 1-based integer across the whole conference (not per-session). It is used as the numeric prefix in filenames (`001-`, `002-`, etc.) to ensure stable ordering. `duration_seconds` starts at 0.0 and is set by `audio.py` during MP3-to-AAC conversion. `inline_images` is populated by `scraper.py` from `<img>` tags in the talk transcript (srcset parsed for largest resolution).
+
+`Conference.talks` is a convenience property that returns all talks from all sessions in order.
+
+### `cache.py`
+
+Serializes and deserializes `Conference` objects to/from `conference.json` in the output directory.
+
+Public API: `save_conference(conference, path)`, `load_conference(path) -> Conference | None`
+
+The JSON file uses the same structure as the `Conference` dataclass. A `cache_version` field allows future format changes to invalidate stale caches automatically. `load_conference` returns `None` (cache miss) if the file is absent, unreadable, or from an incompatible version.
+
+Used by `cli.py`: after scraping, the Conference is saved. On the next run, `cli.py` loads from cache and skips scraping entirely. `--force-scrape` bypasses this and scrapes fresh data regardless.
+
+Depends on: `models.py`
+
+### `progress.py`
+
+Custom Rich progress column for the time-remaining display.
+
+Contains `TimeRemainingWithLabel`, a `rich.progress.TimeRemainingColumn` subclass that appends a "remaining" label and supports a `compact` mode for narrower terminals.
+
+Used by: `downloader.py`, `audio.py`, `epub_builder.py`
+
+### `utils.py`
+
+Two utility functions used across multiple modules.
+
+`sanitize_filename(name) -> str`: Replaces characters outside `[a-zA-Z0-9 ._-]` with underscores, collapses consecutive underscores, strips leading/trailing underscores and dots, truncates to 200 characters, and rejects path traversal patterns. Returns `"unnamed"` for empty or entirely-unsafe inputs.
+
+`validate_url(url) -> bool`: Returns True only if the URL hostname matches the allowlist (`churchofjesuschrist.org`, `*.churchofjesuschrist.org`, `*.ldscdn.org`). Never raises -- malformed URLs return False.
+
+---
+
+## Error handling strategy
+
+### Where errors propagate vs. are caught
+
+**Unrecoverable errors abort the run** with a user-facing message:
+- `ScraperError`: Conference page unreachable, no talks found, access blocked
+- `DownloadError` (raised from `download_conference`): Only if the entire download system fails (individual talk failures are collected and reported, not raised)
+- `FfmpegNotFoundError`: ffmpeg cannot be located or downloaded
+- `AudioError`: ffmpeg step fails (the m4b cannot be partially assembled)
+- `EpubError`: Output file cannot be written
+
+**Recoverable errors skip the affected item and continue:**
+- A single talk page fails to scrape: logged at ERROR, talk is marked as skipped, scraping continues
+- A single MP3 download fails: logged at ERROR, talk is added to `failed_talks`, download continues, warning shown at end
+- A single speaker photo fails to download: logged at ERROR, photo is absent from epub, not fatal
+- A single AAC conversion fails: logged at ERROR, talk is skipped from the m4b (chapter count will be lower than expected)
+- A single speaker photo fails to embed in the EPUB: logged at WARNING, photo is absent
+
+### Retry strategy
+
+Both the scraper and downloader use exponential backoff:
+- Attempt 0: immediate
+- Attempt 1: wait 1s
+- Attempt 2: wait 2s
+- Attempt 3: wait 4s (3 retries = 4 total attempts)
+
+HTTP errors that are not retried: 403 Forbidden, 429 Too Many Requests. These indicate intentional blocking and raise `ScraperError` immediately.
+
+### User-facing error format
+
+Errors shown to the user (via `click.echo(..., err=True)`) follow this pattern:
+```
+Error: <what failed>
+<actionable next step>
+(<original exception if useful>)
+```
+
+---
+
+## Extensibility points
+
+### Multi-language support
+
+Three places need changes:
+1. `scraper.py`: The archive URL (`/study/general-conference`) and library key (`/eng/general-conference`) contain `eng`. A `--language` flag would need to parameterize these.
+2. `epub_builder.py`: The `xml:lang` and `lang` attributes on the `<html>` element are hardcoded to `"en"`. These need to reflect the actual language.
+3. `epub_builder.py`: The OPF `<dc:language>` element is hardcoded to `"en"`.
+
+Encoding is already multi-language resilient -- the 4-priority encoding detection in `scraper._decode_response()` handles non-ASCII charsets.
+
+### Batch mode (multiple conferences)
+
+`cli.py` calls `_run()` once. A `--batch` flag could loop `_run()` over a list of conferences. The output directory structure already supports this: each conference gets its own subdirectory under `--output`.
+
+### Alternative audio sources
+
+`downloader.download_conference()` reads `talk.mp3_url` from the `Talk` objects. If the Church changes their CDN, only `scraper.parse_talk_page()` needs to update the URL extraction logic. The downloader, audio pipeline, and epub builder are all URL-agnostic.
+
+### Adding new output formats
+
+The pipeline passes a `Conference` object to both `build_m4b()` and `build_epub()`. A new output format (e.g., a plain text transcript dump, an RSS feed, or an MP3 playlist) would be a new function that accepts a `Conference` and an output path, called from `cli._run()` with a corresponding `--format-only` flag.
+
+---
+
+## Patterns that look wrong but are correct
+
+These are code patterns a new contributor might flag as bugs or code smells. They are intentional. See [Technical Decisions, section 20](Technical-Decisions#20-design-patterns-that-look-suspicious-but-are-correct) for the full rationale behind each.
+
+**Global cached paths in `ffmpeg_manager.py`:** Module-level globals cache the ffmpeg/ffprobe binary paths after first lookup. Looks like a code smell, but the lookup is expensive (PATH search + potential 80 MB download). `reset_cache()` exists for test isolation.
+
+**Duplicate `sanitize_filename()` calls in `downloader.py` and `audio.py`:** Both modules independently sanitize the same talk title to construct the same filename. This is intentional decoupling -- sharing the computed name would couple the modules for negligible savings.
+
+**Broad try/except in `audio.py._run()`:** Catches ffmpeg `-progress` flag failures and retries without it. Not a swallowed exception -- it is a deliberate fallback for older ffmpeg builds that do not support progress reporting.
+
+**Per-thread `requests.Session` in `downloader.py`:** Each `ThreadPoolExecutor` worker creates its own session via `threading.local`. `requests.Session` is not thread-safe; sharing one would cause intermittent header/connection-pool corruption.
+
+**`Progress.advance()` from worker threads:** Rich's `Progress` is documented as thread-safe. The cross-thread `advance()` calls in parallel image downloads are correct.

--- a/wiki-Technical-Decisions.md
+++ b/wiki-Technical-Decisions.md
@@ -1,0 +1,327 @@
+# Technical Decisions
+
+This page documents every significant design decision in the project: what was chosen, what alternatives were considered, and why. This is the project's institutional memory.
+
+---
+
+## 1. Language: Python 3.10+
+
+**Chosen:** Python 3.10+
+
+**Alternatives considered:** Node.js/TypeScript, Go, Rust
+
+**Rationale:**
+Best library ecosystem for the problem:
+- `requests` + `beautifulsoup4` for HTTP and HTML parsing
+- `mutagen` for MP4/m4b metadata verification
+- `Pillow` for image conversion and resizing
+- `click` for CLI argument parsing
+- `rich` for progress bars and formatted terminal output
+- `static-ffmpeg` for automatic ffmpeg bundling
+
+Python also has the largest pool of potential open-source contributors and is cross-platform without requiring compilation. Go or Rust would produce faster binaries, but the bottleneck here is network I/O and ffmpeg subprocess calls -- not Python interpretation speed.
+
+---
+
+## 2. ffmpeg: auto-download via static-ffmpeg
+
+**Chosen:** `static-ffmpeg` Python package, which downloads a platform-specific static ffmpeg binary on first use
+
+**Alternatives considered:**
+- Require users to install ffmpeg manually
+- Bundle ffmpeg binaries directly in the release archives
+
+**Rationale:**
+Manual installation is the single biggest source of support issues in open source audio tools. PATH problems, wrong versions, missing codecs, and platform-specific install differences all cause real friction. `static-ffmpeg` eliminates this entirely -- the user types one `pip install` and ffmpeg is handled automatically.
+
+Bundling ffmpeg in releases was rejected because it inflates package size by ~80 MB per platform and has LGPL licensing implications that complicate the project's MIT license.
+
+The tool still checks the system PATH first. If ffmpeg is already installed, `static-ffmpeg` is never invoked. The auto-download is a fallback, not a replacement.
+
+---
+
+## 3. Distribution: PyPI
+
+**Chosen:** `pip install gencon-audiobook`
+
+**Alternatives considered:** Standalone binaries (PyInstaller), Docker, Homebrew formula
+
+**Rationale:**
+PyPI is the standard Python distribution mechanism. It provides:
+- Easy updates: `pip install --upgrade gencon-audiobook`
+- Works on all platforms where Python works
+- No special infrastructure to maintain
+
+Standalone binaries (PyInstaller, Nuitka) are attractive for non-Python users but are fragile to cross-compile, large (include the Python runtime), and require per-platform build infrastructure. Docker adds unnecessary complexity for a simple CLI tool with no server component. A Homebrew formula would be macOS-only.
+
+---
+
+## 4. Audio format: m4b with AAC-LC, source-matched quality, mono
+
+**Chosen:** AAC-LC codec, source-matched bitrate and sample rate, mono channel, `.m4b` container
+
+**Alternatives considered:** HE-AAC v2, fixed bitrate defaults, stereo
+
+**Bitrate/sample-rate: match the source**
+The tool probes the first downloaded MP3 with ffprobe and uses the detected bitrate and sample rate as the AAC encoding target. Older conferences provide 32k MP3s; recent ones provide 128k. Encoding at a fixed default would either upsize low-quality sources (wasting space with no quality gain) or downsample high-quality sources (losing quality unnecessarily). Use `--bitrate` and `--sample-rate` to override.
+
+**Codec: AAC-LC (not HE-AAC)**
+HE-AAC v2 produces smaller files but has spotty decoder support on older Android audiobook players. AAC-LC is universally decoded on every modern platform.
+
+**Channels: mono (not stereo)**
+Conference talks are spoken word recorded in mono. Converting to stereo doubles the file size for zero audible benefit.
+
+**Container: .m4b (not .mp3 or .aac)**
+`.m4b` is the standard audiobook container. It supports chapters, embedded cover art, and full metadata. Every major audiobook player (Apple Books, Smart AudioBook Player, Sirin, Bound, BookPlayer) understands it. A plain MP3 has no standard chapter format.
+
+**Platform compatibility:** Apple Books (iOS/macOS), Smart AudioBook Player (Android), Sirin (Android), BookPlayer (iOS), Bound (iOS), iTunes/Apple Music (Windows/macOS). Note: Google Play Books does **not** support `.m4b`.
+
+---
+
+## 5. EPUB: EPUB 3 reflowable, manual ZIP assembly, no hardcoded styles
+
+**Chosen:** EPUB 3.0, reflowable layout, built by assembling a ZIP archive directly, JPEG images only, zero hardcoded colors/fonts/sizes in CSS
+
+**Alternatives considered:** EPUB 2, fixed layout, ebooklib, WebP images
+
+**EPUB 3 over EPUB 2:** All modern readers support EPUB 3. It is the current W3C standard. EPUB 2 was last revised in 2010.
+
+**Reflowable over fixed layout:** Fixed-layout EPUB renders as garbled text on many Android readers. Reflowable adapts to any screen size and font size.
+
+**Manual ZIP assembly over ebooklib:** `ebooklib` abstracts away too much of the EPUB structure and has historically had issues with EPUB 3 compliance. Building the ZIP directly gives full control over file structure, metadata, and the `mimetype` entry (which must be first and uncompressed per the EPUB spec). The EPUB format is not complex enough to justify a library abstraction.
+
+**JPEG only, no WebP:** WebP is not yet a required EPUB media type. Older readers ignore or fail on WebP images. All images are converted to JPEG before embedding.
+
+**No hardcoded CSS styles:** The stylesheet contains zero `color`, `background-color`, or `font-family` declarations. All visual styling is deferred to the reader application. This ensures dark mode, sepia mode, custom fonts, large text, and accessibility modes all work automatically on every reader.
+
+> **Known issue:** The stylesheet currently contains two `font-size` declarations using relative `em` units (`0.85em` on `aside`, `0.8em` on `.para-num`). While `em` units are relative and less harmful than `px`/`pt`, they still override reader font-size preferences and interfere with accessibility large-text modes on some e-ink readers. These should be removed; see the open GitHub issue tracking the fix.
+
+**Kindle:** Amazon accepts EPUB natively via "Send to Kindle" and auto-converts to AZW3. MOBI is dead (Amazon stopped accepting it in 2022). A valid EPUB 3 produces a clean Kindle conversion.
+
+---
+
+## 6. Scraping: requests + BeautifulSoup + html.parser
+
+**Chosen:** `requests` for HTTP, `beautifulsoup4` with Python's built-in `html.parser` for parsing
+
+**Alternatives considered:** Selenium/Playwright (headless browser), Scrapy, lxml parser
+
+**No headless browser:** The Church website serves HTML with embedded JSON application state (`window.__INITIAL_STATE__`). No JavaScript execution is required to extract conference listings, talk metadata, audio URLs, or transcripts. A headless browser would add ~400 MB of dependencies and 10x the runtime for zero benefit.
+
+**html.parser over lxml:** `html.parser` is part of the Python standard library -- no additional dependency. lxml is faster but requires a C extension, which complicates installation on some platforms. For this use case (parsing one HTML page at a time, not streaming gigabytes), the speed difference is immaterial.
+
+**No Scrapy:** Scrapy is a framework designed for multi-site crawling at scale. This tool scrapes one site with a fixed structure. Using Scrapy would mean adopting a framework, learning its conventions, and accepting its abstractions for no benefit over plain requests.
+
+**Dual-strategy parsing:** The scraper tries `__INITIAL_STATE__` JSON first (more stable, structured). If that fails (site redesign, A/B test, etc.), it falls back to HTML traversal using BeautifulSoup. This layered approach means a partial site change does not immediately break the tool.
+
+---
+
+## 7. Chapter metadata: "Title -- Speaker" format
+
+**Chosen:** Chapter titles formatted as `"Talk Title -- Speaker Name"` (double ASCII hyphen)
+
+**Alternatives considered:** Title only; separate metadata fields
+
+**Rationale:**
+The m4b chapter specification (FFMETADATA1) has no per-chapter "author" field -- only a title string. Embedding the speaker name in the chapter title is the only way to surface this information in audiobook players. Every major player (Apple Books, Smart AudioBook Player, Sirin) displays the chapter title prominently.
+
+An em dash (`—`) would be more typographically correct, but FFMETADATA1 files are read by ffmpeg using the system codepage on Windows, which conflicts with the UTF-8 requirement of the MP4 container. ASCII-only chapter titles (using `--`) avoid this encoding conflict entirely.
+
+---
+
+## 8. Testing strategy
+
+**Chosen:** Fixture-based unit tests + live smoke tests + weekly CI cron job
+
+**Rationale:**
+
+**Fixtures (`tests/fixtures/*.html`):** Saved HTML snapshots from the real website. Tests run against these snapshots so they are fast (no network), deterministic, and document exactly what the scraper expects. `scripts/update_fixtures.py` refreshes them when the site changes.
+
+**Live smoke tests (`@pytest.mark.live`):** A small set of tests that hit the real website and verify that the scraper still works end-to-end. Excluded from normal CI (too slow, network-dependent). Run manually when making scraper changes.
+
+**Weekly CI cron (`live-test.yml`):** GitHub Actions runs the live smoke tests every Monday. If they fail, a GitHub issue is automatically opened. This provides early warning when the Church updates their website structure between releases.
+
+**Integration tests (`@pytest.mark.integration`):** Full pipeline test (scrape → download fixtures → build m4b → build epub) using programmatically generated silent MP3s. Requires ffmpeg on PATH. Excluded from normal CI.
+
+---
+
+## 9. Copyright handling
+
+Downloaded content is copyright Intellectual Reserve, Inc. Tool code is MIT licensed. These are kept strictly separate.
+
+- The m4b `comment` metadata field contains: "Copyright {year} Intellectual Reserve, Inc. All rights reserved. For personal, noncommercial use only."
+- The EPUB includes a copyright page after the cover with the same notice and a disclaimer that the tool is unofficial and not affiliated with the Church.
+- The README has a prominent disclaimer near the top.
+- `LICENSE-CONTENT.md` in the repository explains the distinction between tool license and content license.
+- Copyright year is derived from the conference year (not the current year).
+
+---
+
+## 10. Rate limiting: 0.5s delay between requests
+
+**Chosen:** 500ms delay after each HTTP request
+
+**Rationale:**
+A full conference involves approximately:
+- 1 archive page fetch
+- 1 conference listing fetch
+- ~33 individual talk page fetches
+- ~33 MP3 downloads
+- ~33 speaker photo downloads
+- 1 cover image download
+
+That is roughly 100 requests. Without any delay, these would fire as fast as the network allows -- potentially hitting the Church's servers with 100 rapid requests in a short window. That is rude, risks IP-based rate limiting, and is unnecessary. The 0.5s delay adds about 50 seconds to the total runtime, which is acceptable.
+
+---
+
+## 11. User-Agent transparency
+
+**Chosen:** `gencon-audiobook/<version> (open source; github.com/XeroIP/gencon-audiobook)`
+
+**Alternatives considered:** Impersonate a browser User-Agent string
+
+**Rationale:**
+Impersonating a browser to bypass bot detection is ethically problematic and unnecessary. The Church website does not require browser impersonation for publicly accessible content. Identifying as `gencon-audiobook` with a link to the GitHub repository allows the Church's infrastructure team to identify the tool, understand its purpose, and contact the project if needed.
+
+---
+
+## 12. Security decisions
+
+**URL allowlisting:** Every URL is validated against an allowlist before any HTTP request is made. Only `churchofjesuschrist.org`, `*.churchofjesuschrist.org`, and `*.ldscdn.org` are permitted. This prevents the scraper from following unexpected redirects to third-party domains. Rejected URLs are logged at DEBUG level.
+
+**Filename sanitization:** All file and directory names are derived from scraped content and sanitized to characters in `[a-zA-Z0-9 ._-]`. This prevents path traversal attacks, OS-specific filename issues, and null byte injection.
+
+**No eval/exec:** The Church website embeds base64-encoded JSON in `window.__INITIAL_STATE__`. The scraper decodes the base64 and calls `json.loads()` only. The data is never executed.
+
+**SSL always on:** `verify=False` is never used. If a certificate fails, it is a real problem worth surfacing, not something to bypass quietly.
+
+**Explicit HTTP timeouts:** Every `requests` call has explicit connect and read timeouts (15s connect, 30s read for HTML; 30s connect, 120s read for MP3 downloads). There are no requests without timeouts.
+
+**Encoding resilience:** HTTP responses are decoded using a 4-priority system: Content-Type header charset, HTML `<meta charset>` tag scanned from raw bytes, charset-normalizer statistical detection, UTF-8 fallback. Decoding uses `errors='replace'` so a single malformed byte never crashes the scraper.
+
+---
+
+## 13. Logging architecture
+
+**Two destinations, always:**
+
+1. **Console** (via `rich`): WARNING level by default. Only warnings, errors, and critical failures appear without `--verbose`. Add `--verbose` to see INFO and DEBUG-level detail including key milestones, URLs fetched, ffmpeg commands, file paths, and timing.
+
+2. **Log file** (`<output_dir>/gencon-audiobook.log`): Always written at DEBUG level, regardless of `--verbose`. Full trace for troubleshooting. Created in the conference output directory so it stays with the data it describes.
+
+**Log level conventions:**
+- `DEBUG`: URLs fetched, CSS selectors matched, file paths, ffmpeg commands, timing
+- `INFO`: Conference selected, downloading N talks, building audiobook/epub, output summary
+- `WARNING`: Missing speaker photo, fallback selector used, retry attempt, single talk skipped
+- `ERROR`: Single file failed after retries, single talk parse failed (recoverable, execution continues)
+- `CRITICAL`: No valid talks found, ffmpeg unavailable, output directory not writable (unrecoverable)
+
+**Common troubleshooting patterns:**
+- "Could not find any talks" -- look for WARNING or ERROR about JSON selector and HTML fallback in the log
+- "Download failed" -- look for HTTP status codes, timeout messages, and retry attempts
+- "ffmpeg error" -- look for the exact ffmpeg command and the stderr output captured by the `_run()` helper
+- A single bad talk -- look for ERROR lines mentioning the talk title; the rest of the conference continues
+
+---
+
+## 14. Conference metadata caching
+
+**Chosen:** Serialize scraped `Conference` data to `conference.json` in the output directory after the first run. Subsequent runs load from this file, skipping ~38 HTTP requests per conference. Use `--force-scrape` to bypass.
+
+**Rationale:**
+Scraping a conference requires one archive page fetch, one listing page fetch, and one talk-page fetch per talk (~33+ requests). At 0.5s between requests, this is 15-20 seconds of network overhead even when nothing has changed. Caching eliminates this on every run after the first.
+
+The cache file is stored in the conference output directory (next to the `.m4b` and `.epub`) rather than a global cache directory because it is tied to that specific conference's data. It is version-tagged so future format changes can invalidate old caches automatically. `--force-scrape` bypasses the cache when the user suspects stale data (e.g., after the Church corrects a transcript or MP3 URL).
+
+**Format:** JSON, same structure as the `Conference` dataclass. Serialized by `cache.py` (`save_conference` / `load_conference`).
+
+---
+
+## 15. Parallel image downloads
+
+**Chosen:** Cover image, speaker photos, and inline body images download concurrently using `ThreadPoolExecutor` with up to 8 worker threads. Each worker gets its own `requests.Session` via `threading.local`. MP3 audio downloads remain sequential.
+
+**Alternatives considered:** Sequential download for all files; `asyncio`/`aiohttp`.
+
+**Rationale:**
+Images are small (typically 20-200 KB each) and numerous (~35+ per conference). Sequential downloading at 0.5s per image adds 15-20 seconds of latency-dominated wait time for no benefit. Parallelism eliminates this latency without stressing the server.
+
+MP3 files are large (~3-5 MB each, 33+ files) and bandwidth-limited. Parallel MP3 downloads would compete for bandwidth without reducing wall-clock time, and would be impolite to the server. They remain sequential with a 0.5s courtesy delay.
+
+`asyncio`/`aiohttp` was rejected because the rest of the pipeline is synchronous. Adding async to one phase would require propagating it up through `cli.py` or isolating it in a `asyncio.run()` call -- added complexity for no meaningful benefit over `ThreadPoolExecutor` for this workload.
+
+`requests.Session` is not thread-safe. Each worker thread creates its own session on first use via `threading.local` storage (`_get_thread_session()`). The session is created once per thread and reused for all images that thread downloads.
+
+---
+
+## 16. EPUB 3 popup footnotes
+
+**Chosen:** Footnote superscript links (`href="#noteN"`) are preserved through HTML sanitization with `epub:type="noteref"`. Footnote body elements are wrapped in `<aside epub:type="footnote">`. Modern EPUB 3 readers (Apple Books, Kobo, Thorium) display these as dismissible inline popovers; older readers fall back to an in-page anchor jump.
+
+**Alternatives considered:** Strip all footnote links and render footnote text inline; ignore footnote structure entirely.
+
+**Rationale:**
+Conference talks occasionally include footnotes with scripture references. Stripping footnote links entirely loses this information. Rendering footnote text inline bloats the transcript and breaks the reading flow. EPUB 3's `epub:type="noteref"` / `epub:type="footnote"` semantics provide the ideal experience: the footnote is accessible without interrupting reading, and e-readers with popup support (most modern readers) handle it automatically.
+
+The sanitizer's default behavior unwraps all `<a>` tags to remove external URLs. Footnote links are the deliberate exception: links with `class="note-ref"` and a `data-scroll-id="noteN"` attribute are preserved and normalised to a bare `href="#noteN"`, then annotated with `epub:type="noteref"`. The `data-scroll-id` attribute is used as the canonical note ID because the Church site generates full talk-page URLs (e.g. `/study/general-conference/2024/04/31bowen?lang=eng#note1`) rather than bare fragment hrefs, making `data-scroll-id` the more reliable signal. Bare `href="#noteN"` links are also accepted for robustness.
+
+---
+
+## 17. Portrait cover image
+
+**Chosen:** The landscape conference cover image from the Church website is centered on a 1200x1800 gray canvas, producing a proper 2:3 portrait cover for reader library grids.
+
+**Alternatives considered:** Use the landscape image as-is; crop to square.
+
+**Rationale:**
+EPUB reader library grids (Apple Books, Kindle, Kobo) display covers in portrait orientation. A landscape cover is squeezed, letterboxed, or distorted. Centering on a gray canvas preserves the original image without cropping and fills the expected 2:3 frame.
+
+1200x1800 px matches the resolution of the source cover (fetched at 800px wide via IIIF; the 2:3 canvas results in 1200x1800 at that width). The gray background (`#808080`) is visually neutral on both light and dark reader themes.
+
+---
+
+## 18. JPEG images stored uncompressed in EPUB ZIP
+
+**Chosen:** All JPEG images (cover, speaker photos, inline images) are stored with `ZIP_STORED` (no compression) in the EPUB ZIP archive. Other files use the default `ZIP_DEFLATED`.
+
+**Alternatives considered:** Compress all files uniformly with DEFLATE.
+
+**Rationale:**
+JPEG is already a compressed format. Applying DEFLATE compression to a JPEG produces negligible size reduction (typically < 1%) because JPEG entropy is close to the theoretical minimum. However, some older e-ink readers decompress the ZIP entry before passing it to their JPEG decoder and have bugs when the JPEG is DEFLATE-wrapped. Using `ZIP_STORED` for JPEGs avoids this entirely with no meaningful size penalty.
+
+---
+
+## 19. IIIF URL resolution upgrade
+
+**Chosen:** Conference cover and speaker photo URLs from the Church website are IIIF image URLs at 250px thumbnail resolution. The tool rewrites these to request 800px wide images before downloading.
+
+**Rationale:**
+The Church website embeds IIIF URLs sized for thumbnails (`/full/250,/0/default.jpg`). These look acceptable on the website but appear soft and pixelated when displayed as a cover in a reader app or as a speaker portrait in the EPUB. The IIIF spec allows requesting any resolution by replacing the size segment. Requesting 800px wide images costs no extra latency (same CDN, same request count) and dramatically improves image sharpness in the output files.
+
+---
+
+## 20. Design patterns that look suspicious but are correct
+
+Several patterns in the codebase look like bugs or code smells on first read. They are intentional. This section documents them so future contributors do not "fix" them.
+
+### Global state in `ffmpeg_manager.py`
+
+`ffmpeg_manager.py` uses module-level globals (`_ffmpeg_path`, `_ffprobe_path`) to cache the discovered binary paths. This looks like a textbook code smell, but it is justified: locating ffmpeg involves `shutil.which()` and potentially downloading a ~80 MB binary via `static-ffmpeg`. That should happen exactly once per process. The module exposes `reset_cache()` for tests that need to swap mock paths between runs.
+
+A class-based or context-manager approach was considered but rejected as unnecessary ceremony for what amounts to a pair of cached file paths with a well-defined lifetime (the process).
+
+### Double `sanitize_filename()` calls for the same talk
+
+Both `downloader.py` and `audio.py` independently call `sanitize_filename(talk.title)` to construct the same filename (e.g., `001-talk-title.mp3`). This looks like a DRY violation. It is intentional: the alternative is passing the sanitized filename between modules, which couples them. Both modules independently compute the same deterministic result from the same input. The redundancy keeps the modules independent and is cheaper than the abstraction that would eliminate it.
+
+### Broad `try/except` in `audio.py._run()`
+
+The `_run()` helper wraps ffmpeg subprocess calls in a broad try/except that catches failure of the `-progress` flag and retries without it. This looks like a swallowed exception, but it is deliberate fallback behavior: some older ffmpeg builds do not support `-progress pipe:1`, and the non-streaming fallback produces the same output. The behavior is documented in a code comment at the call site.
+
+### `requests.Session` not shared across threads
+
+`downloader.py` creates a new `requests.Session` per thread via `threading.local` instead of sharing one session. This looks like it wastes connections, but `requests.Session` is not thread-safe. Sharing it across `ThreadPoolExecutor` workers would cause intermittent corruption of headers, cookies, or connection pools. The per-thread pattern is the documented correct approach.
+
+### Rich progress bar `advance()` called from worker threads
+
+`downloader.py` calls `overall_progress.advance()` from within `ThreadPoolExecutor` worker threads. This looks like a thread-safety violation, but Rich's `Progress` class is documented as thread-safe. The pattern is correct and intentional.


### PR DESCRIPTION
## Summary
- Change `logger.warning` → `logger.debug` for the HTML traversal fallback message in `scraper.py:532`
- The fallback is a designed code path that succeeds — not a non-fatal issue

## Why
Every first run printed `WARNING: Listing JSON selector found nothing; falling back to HTML traversal` on the console. Since the fallback produces valid data, the WARNING level was misleading. It will still be visible under `--verbose`.

## Test plan
- [ ] CI passes
- [ ] Normal run produces no WARNING for the fallback
- [ ] `--verbose` run still shows the fallback message at DEBUG level

Closes #134