### PR TITLE
fix: drain ffmpeg stderr in background thread to prevent pipe deadlock

### DIFF
--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -110,7 +110,8 @@ def _ffmeta_escape(value: str) -> str:
     return value
 
 
-_SUBPROCESS_TIMEOUT = 600   # 10 minutes — generous for large conference builds
+_SUBPROCESS_TIMEOUT = 600   # 10 minutes — for concat/mux of full conference
+_CONVERT_TIMEOUT = 120      # 2 minutes — per-file AAC conversion
 _FALLBACK_BITRATE = "64k"   # used when ffprobe quality probe fails
 _FALLBACK_SAMPLE_RATE = 44100  # used when ffprobe quality probe fails
 
@@ -163,7 +164,11 @@ def _run_ffmpeg_with_progress(
 
     The command must already include `-progress pipe:1 -nostats` so ffmpeg writes
     key=value progress lines to stdout. A watchdog timer kills the process if it
-    exceeds _SUBPROCESS_TIMEOUT seconds without finishing.
+    exceeds _CONVERT_TIMEOUT seconds without finishing.
+
+    stderr is drained in a background thread to prevent pipe deadlock: if ffmpeg
+    writes more than the OS pipe buffer (4KB on Windows) to stderr while Python
+    is blocked reading stdout, both processes stall indefinitely.
 
     Args:
         cmd: Complete ffmpeg command including -progress pipe:1 -nostats flags.
@@ -185,6 +190,17 @@ def _run_ffmpeg_with_progress(
         errors="replace",
     )
 
+    # Drain stderr in a background thread to prevent pipe buffer deadlock.
+    stderr_lines: list[str] = []
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_lines.append(line)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
     killed_by_watchdog = False
 
     def _watchdog() -> None:
@@ -193,7 +209,7 @@ def _run_ffmpeg_with_progress(
             killed_by_watchdog = True
             proc.kill()
 
-    timer = threading.Timer(_SUBPROCESS_TIMEOUT, _watchdog)
+    timer = threading.Timer(_CONVERT_TIMEOUT, _watchdog)
     timer.start()
     try:
         assert proc.stdout is not None  # guaranteed by stdout=PIPE
@@ -212,17 +228,16 @@ def _run_ffmpeg_with_progress(
         timer.cancel()
 
     proc.wait()
+    stderr_thread.join(timeout=5)
 
     if killed_by_watchdog:
         raise AudioError(
-            f"{label} timed out after {_SUBPROCESS_TIMEOUT}s. "
-            "The ffmpeg process was killed. Try with fewer talks or check for corrupt MP3 files."
+            f"{label} timed out after {_CONVERT_TIMEOUT}s. "
+            "The ffmpeg process was killed. Check for corrupt or unsupported MP3 files."
         )
 
     if proc.returncode != 0:
-        stderr = ""
-        if proc.stderr:
-            stderr = proc.stderr.read()
+        stderr = "".join(stderr_lines)
         raise AudioError(
             f"{label} failed (exit {proc.returncode}).\n"
             f"Command: {' '.join(cmd)}\n"

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -534,8 +534,7 @@ def test_run_ffmpeg_with_progress_parses_out_time() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter(stdout_lines)
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = ""
+    mock_proc.stderr = iter([])  # iterable — drained by stderr thread
     mock_proc.returncode = 0
     mock_proc.poll.return_value = 0
 
@@ -564,8 +563,7 @@ def test_run_ffmpeg_with_progress_nonzero_exit() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter(["progress=end\n"])
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = "some ffmpeg error"
+    mock_proc.stderr = iter(["some ffmpeg error\n"])  # iterable — drained by stderr thread
     mock_proc.returncode = 1
     mock_proc.poll.return_value = 1
 
@@ -587,8 +585,7 @@ def test_run_ffmpeg_with_progress_watchdog_kills_hung_process() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter([])  # EOF immediately so the readline loop exits
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = ""
+    mock_proc.stderr = iter([])  # iterable — drained by stderr thread
     mock_proc.returncode = -9
     mock_proc.poll.return_value = None  # process appears still running when watchdog fires
 
@@ -613,3 +610,32 @@ def test_run_ffmpeg_with_progress_watchdog_kills_hung_process() -> None:
                 progress=progress,
                 task_id=0,  # type: ignore[arg-type]
             )
+
+
+def test_run_ffmpeg_with_progress_noisy_stderr_does_not_deadlock() -> None:
+    """ffmpeg writing large amounts of stderr should not deadlock.
+
+    Previously, stderr was piped but never read, causing the OS pipe buffer
+    (4KB on Windows) to fill and deadlock both processes.
+    """
+    from unittest.mock import MagicMock, patch
+
+    # Simulate lots of stderr output (well beyond OS pipe buffer)
+    noisy_stderr = ["WARNING: something suspicious\n"] * 500
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter(["out_time_us=1000000\n", "progress=end\n"])
+    mock_proc.stderr = iter(noisy_stderr)
+    mock_proc.returncode = 0
+    mock_proc.poll.return_value = 0
+
+    progress = MagicMock()
+    with patch("subprocess.Popen", return_value=mock_proc):
+        # Should complete without hanging
+        _run_ffmpeg_with_progress(
+            ["ffmpeg", "-i", "in.mp3", "out.m4a"],
+            label="test",
+            source_duration_s=5.0,
+            progress=progress,
+            task_id=0,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary
- Spawn a daemon thread to drain `proc.stderr` continuously in `_run_ffmpeg_with_progress()`
- Captured stderr is included in `AudioError` on non-zero exit (no change to error quality)
- Add `_CONVERT_TIMEOUT = 120s` for per-file conversion (separate from 600s concat/mux timeout)
- Update existing tests to use iterable `iter([...])` for stderr mock (was `MagicMock().read()`)
- Add `test_run_ffmpeg_with_progress_noisy_stderr_does_not_deadlock`

## Why
Piping both stdout and stderr without reading stderr causes a deadlock when ffmpeg writes enough output to fill the OS pipe buffer (4KB on Windows). Python blocks on stdout, ffmpeg blocks on stderr — neither can proceed. Discovered during UAT: `--audiobook-only --conference "April 2024"` hung indefinitely with Ctrl+C unresponsive.

Closes #143

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>