### PR TITLE
fix: remove font-size declarations from EPUB stylesheet

### DIFF
--- a/.claude/rules/epub-style.md
+++ b/.claude/rules/epub-style.md
@@ -12,7 +12,7 @@ high contrast, accessibility modes). This is achieved by deferring ALL visual st
 - `color` (including `currentColor` in color properties)
 - `background-color`
 - `font-family`
-- Absolute font sizes: `px`, `pt`, `cm`, `mm`, `in`, `pc`
+- `font-size` (any unit — `px`, `pt`, `em`, `%`, `rem`, `vw`, etc. — defer text sizing to the reader)
 
 **Only allowed:**
 - Structural layout: `margin`, `padding`, `text-align`, `line-height` in `em` or `%`

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -126,7 +126,6 @@ nav li {
 aside {
   margin: 1.5em 0 0.5em;
   padding-left: 1em;
-  font-size: 0.85em;
 }
 
 .transcript.numbered {
@@ -138,7 +137,6 @@ aside {
   width: 2em;
   margin-left: -2.5em;
   text-align: right;
-  font-size: 0.8em;
   line-height: inherit;
 }
 """

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -569,15 +569,15 @@ def test_build_epub_css_has_no_font_family(tmp_path: Path) -> None:
         "CSS must not contain font-family declarations"
 
 
-def test_build_epub_css_has_no_absolute_font_sizes(tmp_path: Path) -> None:
+def test_build_epub_css_has_no_font_size_declarations(tmp_path: Path) -> None:
     conference = _make_conference(n_talks=2)
     output = tmp_path / "test.epub"
     build_epub(conference, tmp_path, output)
     css = _epub_read(output, "style.css").decode("utf-8")
     css_no_comments = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
-    # Absolute units: px, pt, cm, mm, in, pc
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", css_no_comments), \
-        "CSS must not use absolute font-size units (px, pt, cm, mm, in, pc)"
+    # font-size of any unit is banned — defer text sizing entirely to the reader
+    assert not re.search(r"\bfont-size\s*:", css_no_comments), \
+        "CSS must not contain any font-size declarations (any unit)"
 
 
 # ---------------------------------------------------------------------------
@@ -1135,5 +1135,5 @@ def test_build_epub_css_para_num_theme_safe(tmp_path: Path) -> None:
     assert not re.search(r"\bcolor\s*:", block), ".para-num must not set color"
     assert not re.search(r"\bbackground(-color)?\s*:", block), ".para-num must not set background"
     assert not re.search(r"\bfont-family\s*:", block), ".para-num must not set font-family"
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", block), \
-        ".para-num must not use absolute font-size units"
+    assert not re.search(r"\bfont-size\s*:", block), \
+        ".para-num must not contain any font-size declaration (any unit)"


### PR DESCRIPTION
## Summary
- Remove `font-size: 0.85em` from `aside` rule (`epub_builder.py:129`)
- Remove `font-size: 0.8em` from `.para-num` rule (`epub_builder.py:141`)
- Tighten `test_build_epub_css_has_no_absolute_font_sizes` → `test_build_epub_css_has_no_font_size_declarations`: assert zero `font-size` declarations of any unit
- Tighten `.para-num` theme-safety test with same regex change
- Update `.claude/rules/epub-style.md` to ban `font-size` of any unit

## Why
`font-size` declarations — even in relative units like `em` — override reader accessibility settings and interfere with user font-size preferences on e-ink readers. The test only caught absolute units (`px`, `pt`, etc.) and missed the `em`-based violations.

Closes #138, Closes #139

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>