### PR TITLE
fix: hide inner progress bar M/N count for per-file conversion

### DIFF
--- a/.claude/rules/epub-style.md
+++ b/.claude/rules/epub-style.md
@@ -12,7 +12,7 @@ high contrast, accessibility modes). This is achieved by deferring ALL visual st
 - `color` (including `currentColor` in color properties)
 - `background-color`
 - `font-family`
-- Absolute font sizes: `px`, `pt`, `cm`, `mm`, `in`, `pc`
+- `font-size` (any unit — `px`, `pt`, `em`, `%`, `rem`, `vw`, etc. — defer text sizing to the reader)
 
 **Only allowed:**
 - Structural layout: `margin`, `padding`, `text-align`, `line-height` in `em` or `%`

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from mutagen.mp4 import MP4
 from rich.progress import (
     BarColumn,
-    MofNCompleteColumn,
     Progress,
     SpinnerColumn,
     TaskID,
@@ -23,7 +22,7 @@ from rich.progress import (
 )
 
 from .models import Conference, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import ConditionalMofNColumn, TimeRemainingWithLabel
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -647,7 +646,7 @@ def build_m4b(
     logger.info("Converting %d talks to AAC...", len(talks))
     conv_progress = Progress(
         SpinnerColumn(),
-        MofNCompleteColumn(),
+        ConditionalMofNColumn(),
         BarColumn(),
         TaskProgressColumn(),
         TimeRemainingWithLabel(compact=True),
@@ -655,7 +654,7 @@ def build_m4b(
     )
     with conv_progress:
         outer_task = conv_progress.add_task("Converting to AAC", total=len(talks))
-        inner_task = conv_progress.add_task("", total=1.0, visible=False)
+        inner_task = conv_progress.add_task("", total=1.0, visible=False, show_count=False)
         for talk in talks:
             conv_progress.update(outer_task, description=talk.title[:60])
             mp3_path = audio_dir / f"{talk.talk_index:03d}-{sanitize_filename(talk.title)}.mp3"

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -126,7 +126,6 @@ nav li {
 aside {
   margin: 1.5em 0 0.5em;
   padding-left: 1em;
-  font-size: 0.85em;
 }
 
 .transcript.numbered {
@@ -138,7 +137,6 @@ aside {
   width: 2em;
   margin-left: -2.5em;
   text-align: right;
-  font-size: 0.8em;
   line-height: inherit;
 }
 """

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from rich.progress import Task, TimeRemainingColumn
+from rich.progress import MofNCompleteColumn, Task, TimeRemainingColumn
 from rich.text import Text
 
 
@@ -14,3 +14,19 @@ class TimeRemainingWithLabel(TimeRemainingColumn):
         if text.plain.strip() and text.plain.strip() not in ("--:--", "-:--:--"):
             text.append(" remaining")
         return text
+
+
+class ConditionalMofNColumn(MofNCompleteColumn):
+    """MofNCompleteColumn that can be hidden per-task via a task field.
+
+    If the task's ``show_count`` field is False, renders blank padding of the
+    same width so columns remain aligned across tasks.
+    """
+
+    def render(self, task: Task) -> Text:
+        if not task.fields.get("show_count", True):
+            total = int(task.total) if task.total is not None else 1
+            total_width = len(str(total))
+            # Width matches f"{completed:{total_width}d}/{total}": 2*total_width + 1
+            return Text(" " * (2 * total_width + 1))
+        return super().render(task)

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -569,15 +569,15 @@ def test_build_epub_css_has_no_font_family(tmp_path: Path) -> None:
         "CSS must not contain font-family declarations"
 
 
-def test_build_epub_css_has_no_absolute_font_sizes(tmp_path: Path) -> None:
+def test_build_epub_css_has_no_font_size_declarations(tmp_path: Path) -> None:
     conference = _make_conference(n_talks=2)
     output = tmp_path / "test.epub"
     build_epub(conference, tmp_path, output)
     css = _epub_read(output, "style.css").decode("utf-8")
     css_no_comments = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
-    # Absolute units: px, pt, cm, mm, in, pc
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", css_no_comments), \
-        "CSS must not use absolute font-size units (px, pt, cm, mm, in, pc)"
+    # font-size of any unit is banned — defer text sizing entirely to the reader
+    assert not re.search(r"\bfont-size\s*:", css_no_comments), \
+        "CSS must not contain any font-size declarations (any unit)"
 
 
 # ---------------------------------------------------------------------------
@@ -1135,5 +1135,5 @@ def test_build_epub_css_para_num_theme_safe(tmp_path: Path) -> None:
     assert not re.search(r"\bcolor\s*:", block), ".para-num must not set color"
     assert not re.search(r"\bbackground(-color)?\s*:", block), ".para-num must not set background"
     assert not re.search(r"\bfont-family\s*:", block), ".para-num must not set font-family"
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", block), \
-        ".para-num must not use absolute font-size units"
+    assert not re.search(r"\bfont-size\s*:", block), \
+        ".para-num must not contain any font-size declaration (any unit)"


### PR DESCRIPTION
## Summary
- Adds `ConditionalMofNColumn` to `progress.py` — renders blank padding (same width as M/N) when a task's `show_count` field is `False`
- Replaces `MofNCompleteColumn()` with `ConditionalMofNColumn()` in the conversion progress bar
- Sets `show_count=False` on the inner per-file task so the meaningless frame count (e.g. `559/647`) no longer appears; outer task count still shows

## Test plan
- [ ] All 238 unit tests pass
- [ ] Visual: outer bar shows `N/M` talk count; inner bar shows only the progress bar and time remaining, no count

Closes #136