### PR TITLE
fix: suppress download phase when all files already exist

### DIFF
--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -16,7 +16,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
 from .cache import CACHE_FILENAME, load_cache, save_cache
-from .downloader import DownloadError, download_conference
+from .downloader import DownloadError, DownloadResult, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
 from .models import Talk
@@ -407,16 +407,18 @@ def _run(
     _check_disk_space(conf_output_dir)
 
     # Download audio (skipped for --epub-only) and images.
-    console.print(f"Downloading files for {len(conf_obj.talks)} talks...")
+    # download_conference() prints its own contextual message and skips silently
+    # if all files are already present.
     t0 = time.monotonic()
     try:
-        failed_talks: list[Talk] = download_conference(
+        dl_result: DownloadResult = download_conference(
             conf_obj, conf_output_dir, skip_audio=epub_only
         )
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
         sys.exit(1)
     phase_times["download"] = time.monotonic() - t0
+    failed_talks = dl_result.failed_talks
 
     m4b_path = conf_output_dir / f"{conf_obj.title}.m4b"
     epub_path = conf_output_dir / f"{conf_obj.title}.epub"

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -6,12 +6,14 @@ import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
 from typing import cast
 
 import requests
 from PIL import Image
+from rich.console import Console
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -36,9 +38,20 @@ _IMAGE_WORKERS = 8              # concurrent image download threads
 # intermittent connection errors and garbled responses.
 _thread_locals: threading.local = threading.local()
 
+_console = Console()
+
 
 class DownloadError(Exception):
     """Raised when a file download fails after all retries."""
+
+
+@dataclass
+class DownloadResult:
+    """Results returned by download_conference()."""
+
+    failed_talks: list[Talk] = field(default_factory=list)
+    downloaded: int = 0
+    skipped: int = 0
 
 
 def download_file(
@@ -47,7 +60,7 @@ def download_file(
     session: requests.Session,
     timeout: tuple[int, int] = (30, 120),
     retries: int = 3,
-) -> None:
+) -> bool:
     """Download a single file to dest, using .tmp + rename for atomicity.
 
     Skips download if dest already exists with expected size (from Content-Length).
@@ -59,6 +72,9 @@ def download_file(
         session: requests.Session to use.
         timeout: (connect_timeout, read_timeout) in seconds.
         retries: Number of retry attempts with exponential backoff.
+
+    Returns:
+        True if the file was downloaded, False if it was skipped (already present).
 
     Raises:
         DownloadError: if download fails after all retries.
@@ -74,7 +90,7 @@ def download_file(
             expected = int(head.headers.get("Content-Length", -1))
             if expected > 0 and dest.stat().st_size == expected:
                 logger.debug("Skipping %s — already downloaded (%d bytes)", dest.name, expected)
-                return
+                return False
         except Exception as exc:
             logger.debug("HEAD request failed for %s, re-downloading: %s", url, exc)
 
@@ -99,7 +115,7 @@ def download_file(
 
             tmp.replace(dest)
             logger.debug("Downloaded: %s (%d bytes)", dest.name, dest.stat().st_size)
-            return
+            return True
 
         except Exception as exc:
             last_exc = exc
@@ -140,7 +156,7 @@ def _download_image(
     session: requests.Session,
     timeout: tuple[int, int] = (30, 120),
     retries: int = 3,
-) -> None:
+) -> bool:
     """Download an image, convert to JPEG, and save to dest.
 
     Skips if dest already exists (images don't resume by size — content-identical
@@ -153,6 +169,9 @@ def _download_image(
         timeout: (connect_timeout, read_timeout) in seconds.
         retries: Number of retry attempts.
 
+    Returns:
+        True if the image was downloaded, False if it was skipped (already present).
+
     Raises:
         DownloadError: if download or conversion fails after all retries.
         ValueError: if url fails validate_url().
@@ -162,7 +181,7 @@ def _download_image(
 
     if dest.exists():
         logger.debug("Skipping image %s — already exists", dest.name)
-        return
+        return False
 
     tmp = dest.with_suffix(dest.suffix + ".tmp")
     last_exc: Exception | None = None
@@ -182,7 +201,7 @@ def _download_image(
             tmp.write_bytes(jpeg_bytes)
             tmp.replace(dest)
             logger.debug("Downloaded image: %s (%d bytes)", dest.name, dest.stat().st_size)
-            return
+            return True
 
         except Exception as exc:
             last_exc = exc
@@ -255,21 +274,22 @@ def download_conference(
     output_dir: Path,
     delay: float = 0.5,
     skip_audio: bool = False,
-) -> list[Talk]:
+) -> DownloadResult:
     """Download all MP3s, cover image, and speaker photos for a conference.
 
     Files are downloaded to .tmp first, renamed on success. Existing files of
     the correct size are skipped (resume behavior). Speaker photos are converted
-    to JPEG. Progress is shown via rich progress bars.
+    to JPEG. Progress is shown via rich progress bars only when files actually
+    need downloading.
 
     Args:
         conference: Fully populated Conference object with mp3_urls set.
         output_dir: Directory to download into. Created if it doesn't exist.
-        delay: Seconds to wait between HTTP requests.
+        delay: Seconds to wait between audio HTTP requests.
         skip_audio: If True, skip MP3 downloads (for --epub-only mode).
 
     Returns:
-        List of Talk objects whose audio download failed (empty if all succeeded).
+        DownloadResult with counts of downloaded/skipped files and any failed talks.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     cleanup_tmp_files(output_dir)
@@ -305,7 +325,25 @@ def download_conference(
 
     if not queue:
         logger.info("Nothing to download.")
-        return []
+        return DownloadResult()
+
+    # Pre-scan: count locally present files without making HEAD requests.
+    # This is an approximation — audio files are further verified by Content-Length
+    # inside download_file, but the pre-scan is cheap and accurate enough for UX.
+    pre_exists = sum(1 for _, dest, _, _, _ in queue if dest.exists())
+    needs_download = len(queue) - pre_exists
+
+    if needs_download == 0:
+        logger.debug("All %d files already present — skipping download phase.", len(queue))
+        return DownloadResult(skipped=len(queue))
+
+    if pre_exists > 0:
+        _console.print(
+            f"Downloading {needs_download} of {len(queue)} files "
+            f"({pre_exists} already present)..."
+        )
+    else:
+        _console.print(f"Downloading {len(queue)} files...")
 
     image_queue = [(url, dest, label) for url, dest, label, is_image, _ in queue if is_image]
     audio_queue = [(url, dest, label, talk) for url, dest, label, is_image, talk in queue if not is_image]
@@ -327,6 +365,8 @@ def download_conference(
 
     failed: list[str] = []
     failed_talks: list[Talk] = []
+    downloaded = 0
+    skipped = 0
 
     with overall_progress:
         overall_task = overall_progress.add_task("Downloading files", total=len(queue))
@@ -336,15 +376,15 @@ def download_conference(
         # requests.Session is not thread-safe.
         if image_queue:
 
-            def _download_one_image(args: tuple[str, Path, str]) -> str | None:
-                """Worker: download one image. Returns label on failure, None on success."""
+            def _download_one_image(args: tuple[str, Path, str]) -> tuple[bool, str | None]:
+                """Worker: download one image. Returns (was_downloaded, label_on_failure)."""
                 url, dest, label = args
                 try:
-                    _download_image(url, dest, _get_thread_session(), retries=3)
-                    return None
+                    was_downloaded = _download_image(url, dest, _get_thread_session(), retries=3)
+                    return was_downloaded, None
                 except (DownloadError, ValueError) as exc:
                     logger.error("Failed to download %s: %s", label, exc)
-                    return label
+                    return False, label
                 finally:
                     overall_progress.advance(overall_task)
 
@@ -352,9 +392,13 @@ def download_conference(
             with ThreadPoolExecutor(max_workers=workers) as executor:
                 futures = {executor.submit(_download_one_image, item): item for item in image_queue}
                 for future in as_completed(futures):
-                    result = future.result()
-                    if result is not None:
-                        failed.append(result)
+                    was_downloaded, error_label = future.result()
+                    if error_label is not None:
+                        failed.append(error_label)
+                    elif was_downloaded:
+                        downloaded += 1
+                    else:
+                        skipped += 1
 
         # Audio: sequential with courtesy delay between requests.
         # MP3s are large; parallel streaming of many large files simultaneously
@@ -363,8 +407,12 @@ def download_conference(
         for url, dest, label, queue_talk in audio_queue:
             overall_progress.update(overall_task, description=label)
             try:
-                download_file(url, dest, session, retries=3)
-                time.sleep(delay)
+                was_downloaded = download_file(url, dest, session, retries=3)
+                if was_downloaded:
+                    downloaded += 1
+                    time.sleep(delay)
+                else:
+                    skipped += 1
             except (DownloadError, ValueError) as exc:
                 logger.error("Failed to download %s: %s", label, exc)
                 failed.append(label)
@@ -380,4 +428,4 @@ def download_conference(
             ", ".join(failed),
         )
 
-    return failed_talks
+    return DownloadResult(failed_talks=failed_talks, downloaded=downloaded, skipped=skipped)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from gencon_audiobook.downloader import (
     DownloadError,
+    DownloadResult,
     _audio_path,
     _speaker_path,
     cleanup_tmp_files,
@@ -61,8 +62,9 @@ def test_download_file_success(tmp_path: Path) -> None:
     rsps_lib.add(rsps_lib.GET, _ALLOWED_URL, body=content, status=200)
 
     dest = tmp_path / "audio" / "001-test.mp3"
-    download_file(_ALLOWED_URL, dest, _make_session())
+    result = download_file(_ALLOWED_URL, dest, _make_session())
 
+    assert result is True, "download_file should return True when file is downloaded"
     assert dest.exists(), "Destination file should exist after download"
     assert dest.read_bytes() == content, "Destination content should match server response"
     assert not dest.with_suffix(dest.suffix + ".tmp").exists(), ".tmp file should be cleaned up"
@@ -91,8 +93,9 @@ def test_download_file_skips_existing(tmp_path: Path) -> None:
     dest = tmp_path / "001-test.mp3"
     dest.write_bytes(content)  # pre-existing correct file
 
-    download_file(_ALLOWED_URL, dest, _make_session())
+    result = download_file(_ALLOWED_URL, dest, _make_session())
 
+    assert result is False, "download_file should return False when file is skipped"
     get_calls = [c for c in rsps_lib.calls if c.request.method == "GET"]
     assert len(get_calls) == 0, "GET should not be issued when file is already complete"
 
@@ -335,6 +338,43 @@ def test_download_conference_audio_downloaded_by_default(tmp_path: Path) -> None
     mp3 = tmp_path / "audio" / "001-Test-Talk.mp3"
     assert mp3.exists(), \
         f"MP3 should be downloaded by default (skip_audio=False); expected {mp3}"
+
+
+@rsps_lib.activate
+def test_download_conference_returns_download_result(tmp_path: Path) -> None:
+    """download_conference() returns a DownloadResult with accurate counts."""
+    rsps_lib.add(rsps_lib.GET, _COVER_URL, body=_jpeg_bytes(), status=200)
+    rsps_lib.add(rsps_lib.GET, _PHOTO_URL, body=_jpeg_bytes(), status=200)
+    rsps_lib.add(rsps_lib.GET, _MP3_URL, body=_small_mp3(), status=200)
+
+    conference = _make_single_talk_conference()
+    result = download_conference(conference, tmp_path, delay=0, skip_audio=False)
+
+    assert isinstance(result, DownloadResult), "download_conference must return a DownloadResult"
+    assert result.failed_talks == [], "No talks should fail when all downloads succeed"
+    assert result.downloaded == 3, f"Expected 3 downloaded, got {result.downloaded}"
+    assert result.skipped == 0, f"Expected 0 skipped, got {result.skipped}"
+
+
+@rsps_lib.activate
+def test_download_conference_skips_silently_when_all_exist(tmp_path: Path) -> None:
+    """When all destination files already exist, no HTTP requests are made and no progress bar shown."""
+    conference = _make_single_talk_conference()
+
+    # Pre-create all destination files so the pre-scan short-circuits
+    (tmp_path / "cover.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "speakers").mkdir()
+    (tmp_path / "speakers" / "001-Test-Speaker.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "audio").mkdir()
+    (tmp_path / "audio" / "001-Test-Talk.mp3").write_bytes(_small_mp3())
+
+    result = download_conference(conference, tmp_path, delay=0, skip_audio=False)
+
+    assert result.downloaded == 0, "No files should be downloaded when all already exist"
+    assert result.skipped == 3, f"Expected 3 skipped, got {result.skipped}"
+    assert result.failed_talks == [], "No talks should fail on a fully-cached run"
+    # No HTTP calls — the pre-scan returns early before touching the network
+    assert len(rsps_lib.calls) == 0, "No HTTP requests should be made when all files exist"
 
 
 @rsps_lib.activate


### PR DESCRIPTION
## Summary
- `download_conference()` now pre-scans destination paths with `dest.exists()` before starting any downloads
- If all files exist: returns immediately — no progress bar, no console message, no network calls
- If some files exist: prints `"Downloading N of M files (K already present)..."` then shows bar for only the new files
- If no files exist: prints `"Downloading M files..."` as before
- Skips `time.sleep(delay)` for audio files that are already cached (saves wall time on large partial-cache runs)
- Returns `DownloadResult` dataclass (`failed_talks`, `downloaded`, `skipped`) instead of bare `list[Talk]`
- Removes unconditional `"Downloading files for N talks..."` from `cli.py` — `download_conference()` owns that messaging now

## Test plan
- [ ] All 240 unit tests pass
- [ ] First run: shows "Downloading M files..." followed by progress bar
- [ ] Second run: silent — no message, no progress bar
- [ ] Partial cache run: shows "Downloading N of M files (K already present)..."

Closes #137