### PR TITLE
fix: broaden scraper regex + switch --conference to YYYY-MM (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ New to the terminal or Python? See the [User Guide](https://github.com/XeroIP/ge
 gencon-audiobook
 
 # Select a specific conference
-gencon-audiobook --conference "April 2024"
+gencon-audiobook --conference 2024-04
 
 # Audiobook only (skip epub)
 gencon-audiobook --audiobook-only

--- a/docs/phases/phase-1-scraper-audiobook.md
+++ b/docs/phases/phase-1-scraper-audiobook.md
@@ -599,7 +599,7 @@ Implement a minimal but functional CLI. Full error handling and polish comes in 
 @click.option("--output", default="~/gencon-audiobook", show_default=True,
               help="Directory to save output files.")
 @click.option("--conference", default=None,
-              help="Conference to download (e.g., 'April 2024'). Defaults to most recent.")
+              help="Conference date as YYYY-MM (e.g., '2024-04'). Defaults to most recent.")
 @click.option("--audiobook-only", is_flag=True, default=False,
               help="Produce only the m4b audiobook, skip epub.")
 @click.option("--epub-only", is_flag=True, default=False,
@@ -682,7 +682,7 @@ gencon-audiobook --audiobook-only --output ./test_output
 
 # 7. Resume behavior
 # Delete one MP3 from test_output, re-run:
-gencon-audiobook --audiobook-only --output ./test_output --conference "April 2024"
+gencon-audiobook --audiobook-only --output ./test_output --conference 2024-04
 # Expected: only the deleted file re-downloads; all others skipped
 
 # 8. ffmpeg fallback (on clean venv without system ffmpeg)

--- a/docs/phases/phase-3-cli-polish.md
+++ b/docs/phases/phase-3-cli-polish.md
@@ -189,8 +189,8 @@ Handle gracefully (no traceback):
 - **Conference already downloaded**: If output files already exist and `--overwrite` is not set,
   print a message and exit with code 0. Never prompt interactively — the tool must be
   scriptable. `--overwrite` was declared in Phase 1 and is wired up here.
-- **Conference selection**: If `--conference` value doesn't match any available conference,
-  print the list of available conferences and exit with a helpful message
+- **Conference selection**: If `--conference` value is not in YYYY-MM format,
+  print a clear error and exit with a helpful message
 
 ---
 
@@ -220,9 +220,9 @@ ls -la ./test_output/<conference>/gencon-audiobook.log
 gencon-audiobook --output ./test_output  # second run
 # Expected: "Output files already exist. Use --overwrite to replace them."
 
-# 6. Invalid conference name
-gencon-audiobook --conference "Fake Conference 9999"
-# Expected: lists available conferences, clean error message
+# 6. Invalid conference format
+gencon-audiobook --conference "April 2024"
+# Expected: "Invalid conference format" error message, exit non-zero
 
 # 7. Disk space warning
 # (Hard to test without filling disk — verify the logic in code review)

--- a/docs/phases/phase-5-documentation.md
+++ b/docs/phases/phase-5-documentation.md
@@ -50,7 +50,7 @@ contribute.
 6. **Usage**
    ```bash
    gencon-audiobook                               # Most recent conference
-   gencon-audiobook --conference "April 2024"     # Specific conference
+   gencon-audiobook --conference 2024-04          # Specific conference
    gencon-audiobook --audiobook-only              # m4b only
    gencon-audiobook --epub-only                   # epub only
    gencon-audiobook --output ~/Books              # Custom output directory

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -42,7 +42,7 @@ The epub-only pass covers scraping, image downloading, HTML sanitization, and EP
 without needing ffmpeg or a 200 MB MP3 download. Run this first.
 
 ```bash
-gencon-audiobook --epub-only --conference "April 2024" --output ~/gc-test
+gencon-audiobook --epub-only --conference 2024-04 --output ~/gc-test
 ```
 
 **What to check:**
@@ -65,7 +65,7 @@ gencon-audiobook --epub-only --conference "April 2024" --output ~/gc-test
 ## Step 3: Full run — audiobook + epub (~30–60 min)
 
 ```bash
-gencon-audiobook --conference "April 2024" --output ~/gc-test --overwrite
+gencon-audiobook --conference 2024-04 --output ~/gc-test --overwrite
 ```
 
 **What to check in the completion report:**

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -14,7 +14,7 @@ and speaker photos.
 pip install gencon-audiobook
 
 gencon-audiobook                          # List available conferences, default to most recent
-gencon-audiobook --conference "April 2024"  # Select a specific conference
+gencon-audiobook --conference 2024-04       # Select a specific conference
 gencon-audiobook --audiobook-only         # Produce only the m4b
 gencon-audiobook --epub-only              # Produce only the epub
 gencon-audiobook --output ~/Books         # Custom output directory

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import calendar
 import logging
+import re
 import shutil
 import sys
 import time
@@ -30,6 +32,9 @@ _DISK_WARN_MB = 500
 
 # Module-level console so helpers can print without threading a Console argument.
 console = Console()
+
+_CONF_BASE = "https://www.churchofjesuschrist.org/study/general-conference"
+_CONFERENCE_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
 
 
 # ---------------------------------------------------------------------------
@@ -124,18 +129,34 @@ def _check_disk_space(path: Path) -> None:
 def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     """Resolve the conference to download.
 
-    If conference_filter is given, find the first match (case-insensitive).
-    Otherwise print a numbered menu and default to the most recent.
+    If conference_filter is given as YYYY-MM, construct the URL directly — no
+    listing fetch needed. Otherwise fetch the listing and default to the most recent.
 
     Args:
-        conference_filter: Partial conference name to match, or None.
+        conference_filter: Conference date as YYYY-MM (e.g., '2024-04'), or None.
 
     Returns:
         (title, url) of the selected conference.
 
     Raises:
-        SystemExit: if the filter matches nothing or the list cannot be fetched.
+        SystemExit: if the format is invalid or the listing cannot be fetched.
     """
+    if conference_filter:
+        m = _CONFERENCE_RE.match(conference_filter)
+        if not m:
+            click.echo(
+                f"Error: Invalid conference format {conference_filter!r}.\n"
+                "Expected YYYY-MM (e.g., '2024-04' or '1999-10').",
+                err=True,
+            )
+            sys.exit(1)
+        year, month = int(m.group(1)), int(m.group(2))
+        title = f"{calendar.month_name[month]} {year} General Conference"
+        url = f"{_CONF_BASE}/{year}/{month:02d}"
+        console.print(f"Selected: {title}")
+        return title, url
+
+    # No filter — fetch listing, default to most recent.
     try:
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
             sp.add_task("Fetching available conferences...")
@@ -152,23 +173,6 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
         )
         sys.exit(1)
 
-    if conference_filter:
-        needle = conference_filter.lower()
-        matches = [r for r in refs if needle in r.title.lower()]
-        if not matches:
-            click.echo(
-                f"Error: No conference matching {conference_filter!r}.\n\n"
-                "Available conferences:",
-                err=True,
-            )
-            for i, r in enumerate(refs[:10], 1):
-                click.echo(f"  {i}. {r.title}", err=True)
-            sys.exit(1)
-        selected = matches[0]
-        console.print(f"Selected: {selected.title}")
-        return selected.title, selected.url
-
-    # Default: most recent (first in list)
     console.print(f"Found {len(refs)} conferences. Using: {refs[0].title}")
     return refs[0].title, refs[0].url
 
@@ -188,7 +192,7 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 @click.option(
     "--conference",
     default=None,
-    help="Conference to download (e.g., 'April 2024'). Defaults to most recent.",
+    help="Conference date as YYYY-MM (e.g., '2024-04'). Defaults to most recent.",
 )
 @click.option(
     "--audiobook-only",

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -68,12 +68,14 @@ def _upgrade_iiif(url: str) -> str:
     url = re.sub(r"/full/!\d+,/", "/full/!800,/", url)
     return url
 
-# Matches /study/general-conference/YYYY/MM/talk-id (individual talk URL).
-# Modern talk slugs use a numeric-prefix + speaker-name format with no hyphens
-# (e.g., "11oaks", "12christofferson"). Session-level links DO contain hyphens
-# (e.g., "saturday-morning-session") and must be excluded — [a-z0-9]+ achieves
-# this. Verified against fixture data; the weekly live test monitors for changes.
-_TALK_URL_RE = re.compile(r"/study/general-conference/\d{4}/\d{2}/[a-z0-9]+(?:\?|$)", re.IGNORECASE)
+# Matches any /study/general-conference/YYYY/MM/slug URL — talk and session links
+# alike. The character class [a-z0-9][-a-z0-9]* covers modern unhyphenated slugs
+# ("11oaks") and older hyphenated ones ("the-work-moves-forward"). Talk vs.
+# session is determined by DOM position in _sessions_from_html, not URL pattern.
+_CONF_URL_RE = re.compile(
+    r"/study/general-conference/\d{4}/\d{2}/[a-z0-9][-a-z0-9]*(?:\?|$)",
+    re.IGNORECASE,
+)
 
 
 # Cache of parsed RobotFileParser objects, keyed by scheme+host (e.g. "https://www.churchofjesuschrist.org")
@@ -558,8 +560,8 @@ def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
             talks: list[Talk] = []
             for entry in section.get("entries", []):
                 uri = entry.get("uri", "")
-                # Skip non-talk entries (e.g., session-level links)
-                if not _TALK_URL_RE.search(uri):
+                # Skip entries that don't look like conference sub-pages
+                if not _CONF_URL_RE.search(uri):
                     continue
                 title = entry.get("title", "")
                 speaker = entry.get("subtitle", "") or entry.get("author", "")
@@ -649,12 +651,12 @@ def _sessions_from_html(html: str) -> list[Session]:
     """
     soup = BeautifulSoup(html, "html.parser")
 
-    talk_links = soup.find_all("a", href=_TALK_URL_RE)
-    if not talk_links:
+    conf_links = soup.find_all("a", href=_CONF_URL_RE)
+    if not conf_links:
         return []
 
-    # Walk up: talk_a -> talk_li -> inner_ul -> session_li -> outer_ul
-    inner_ul = talk_links[0].find_parent("ul")
+    # Walk up: conf_a -> talk_li -> inner_ul -> session_li -> outer_ul
+    inner_ul = conf_links[0].find_parent("ul")
     if not inner_ul:
         return []
     session_li = inner_ul.parent
@@ -670,19 +672,23 @@ def _sessions_from_html(html: str) -> list[Session]:
                 # "Contents" or other non-session entry — skip
                 continue
 
-            # Session name: first <a> that is NOT a talk link
+            # Session name: direct-child <a> of the session <li> (the session heading link).
+            # URL matching is not used — all conf URLs look alike; DOM position distinguishes
+            # session <li> from talk <li>. Fall back to <h4> for older HTML that uses headings.
             session_name: str | None = None
             for a in li.find_all("a", recursive=False):
-                if not _TALK_URL_RE.search(a.get("href", "")):
-                    session_name = a.get_text(strip=True)
-                    break
-
+                session_name = a.get_text(strip=True)
+                break
+            if not session_name:
+                h4 = li.find("h4", recursive=False)
+                if isinstance(h4, Tag):
+                    session_name = h4.get_text(strip=True)
             if not session_name:
                 session_name = f"Session {session_number + 1}"
 
             talks: list[Talk] = []
             for talk_li in sub_ul.find_all("li", recursive=False):
-                talk_a = talk_li.find("a", href=_TALK_URL_RE)
+                talk_a = talk_li.find("a", href=_CONF_URL_RE)
                 if not talk_a:
                     continue
                 title = _extract_talk_title(talk_a)
@@ -699,7 +705,7 @@ def _sessions_from_html(html: str) -> list[Session]:
     if not sessions:
         logger.warning("No session structure detected; grouping all talks under one session")
         all_talks: list[Talk] = []
-        for a in talk_links:
+        for a in conf_links:
             title = _extract_talk_title(a)
             speaker = _extract_talk_speaker(a)
             if title:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,14 +163,11 @@ def test_defaults_to_most_recent_conference(tmp_path: Path) -> None:
 
 
 def test_conference_filter_selects_matching(tmp_path: Path) -> None:
-    refs = [
-        _make_ref("April 2024 General Conference", 2024, 4),
-        _make_ref("October 2023 General Conference", 2023, 10),
-    ]
+    """YYYY-MM format constructs the URL directly without fetching the listing."""
     conference = _make_conference("October 2023 General Conference")
 
     with (
-        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
+        patch("gencon_audiobook.cli.fetch_available_conferences") as mock_listing,
         patch("gencon_audiobook.cli.scrape_conference", return_value=conference) as mock_scrape,
         patch("gencon_audiobook.cli.download_conference"),
         patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
@@ -179,24 +176,53 @@ def test_conference_filter_selects_matching(tmp_path: Path) -> None:
     ):
         runner = CliRunner()
         result = runner.invoke(
-            main, ["--output", str(tmp_path), "--audiobook-only", "--conference", "October 2023"]
+            main, ["--output", str(tmp_path), "--audiobook-only", "--conference", "2023-10"]
         )
 
     assert result.exit_code == 0, result.output
+    mock_listing.assert_not_called()
     called_url = mock_scrape.call_args[0][0]
-    assert "2023/10" in called_url
+    assert "2023/10" in called_url, f"Expected 2023/10 in URL, got: {called_url}"
 
 
 def test_conference_filter_no_match_exits_nonzero(tmp_path: Path) -> None:
-    refs = [_make_ref("April 2024 General Conference")]
-
-    with patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs):
-        runner = CliRunner()
-        result = runner.invoke(
-            main, ["--output", str(tmp_path), "--conference", "Nonexistent 1800"]
-        )
+    """Invalid YYYY-MM format exits with a non-zero code."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--output", str(tmp_path), "--conference", "Nonexistent 1800"]
+    )
 
     assert result.exit_code != 0
+
+
+def test_conference_filter_invalid_format_exits_nonzero(tmp_path: Path) -> None:
+    """Month-first or free-text format is rejected with a clear error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--output", str(tmp_path), "--conference", "april-2024"]
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid conference format" in result.output, result.output
+
+
+def test_conference_direct_url_skips_listing_fetch(tmp_path: Path) -> None:
+    """When --conference YYYY-MM is given, fetch_available_conferences is never called."""
+    conference = _make_conference("April 2024 General Conference")
+
+    with (
+        patch("gencon_audiobook.cli.fetch_available_conferences") as mock_listing,
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.download_conference"),
+        patch("gencon_audiobook.cli.build_epub"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["--output", str(tmp_path), "--epub-only", "--conference", "2024-04"]
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_listing.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -485,28 +511,6 @@ def test_epub_summary_line_printed(tmp_path: Path) -> None:
     assert ".epub" in result.output, \
         f"EPUB filename should appear in the completion summary: {result.output!r}"
 
-
-def test_conference_filter_is_case_insensitive(tmp_path: Path) -> None:
-    """The --conference filter must match case-insensitively.
-
-    Users will naturally type 'april 2024' instead of 'April 2024'.
-    """
-    refs = [_make_ref("April 2024 General Conference", 2024, 4)]
-    conference = _make_conference()
-
-    with (
-        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
-        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
-        patch("gencon_audiobook.cli.download_conference"),
-        patch("gencon_audiobook.cli.build_epub"),
-    ):
-        runner = CliRunner()
-        result = runner.invoke(
-            main, ["--output", str(tmp_path), "--epub-only", "--conference", "april 2024"]
-        )
-
-    assert result.exit_code == 0, \
-        f"Lowercase --conference filter should match; got exit {result.exit_code}: {result.output}"
 
 
 def test_log_file_created_in_output_dir(tmp_path: Path) -> None:

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -485,3 +485,40 @@ def test_upgrade_iiif_leaves_non_iiif_url_unchanged() -> None:
     assert _upgrade_iiif(url) == url, (
         f"Non-IIIF URL must pass through unchanged, got: {_upgrade_iiif(url)!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _CONF_URL_RE
+# ---------------------------------------------------------------------------
+
+
+def test_conf_url_re_matches_modern_slug() -> None:
+    """_CONF_URL_RE must match modern (no-hyphen) talk slugs."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04/11oaks"
+    assert _CONF_URL_RE.search(url), f"Expected match for modern slug: {url!r}"
+
+
+def test_conf_url_re_matches_hyphenated_slug() -> None:
+    """_CONF_URL_RE must match pre-2020 hyphenated talk slugs (the old bug)."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/1999/04/the-work-moves-forward"
+    assert _CONF_URL_RE.search(url), f"Expected match for hyphenated slug: {url!r}"
+
+
+def test_conf_url_re_matches_session_slug() -> None:
+    """Session slugs also match _CONF_URL_RE — DOM position distinguishes sessions from talks."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04/saturday-morning-session"
+    assert _CONF_URL_RE.search(url), f"Expected match for session slug: {url!r}"
+
+
+def test_conf_url_re_rejects_archive_url() -> None:
+    """_CONF_URL_RE must not match the top-level archive URL (no talk slug)."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04"
+    assert not _CONF_URL_RE.search(url), f"Should not match bare conference URL: {url!r}"


### PR DESCRIPTION
## Summary

- **Scraper fix:** Renamed `_TALK_URL_RE` to `_CONF_URL_RE` and extended the character class from `[a-z0-9]+` to `[a-z0-9][-a-z0-9]*`. Pre-2020 conferences use hyphenated talk slugs (e.g. `the-work-moves-forward`) that the old regex rejected, returning only 1 talk instead of ~30+.
- **Session name detection:** Replaced URL-heuristic session detection with DOM structure. The session `<li>` direct-child `<a>` (with `<h4>` fallback) is used — resilient across all conference eras.
- **`--conference` format:** Changed from free-text partial match to `YYYY-MM` (e.g. `2024-04`). When provided, URL is constructed directly — no listing fetch needed. Title derived from `calendar.month_name`.
- **Docs and wiki:** All `"April 2024"` examples updated to `2024-04` format.

## Test plan

- [ ] `pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py` — 243 passed
- [ ] `gencon-audiobook --epub-only --conference 1999-04 --output C:\temp\gencon\test-144` — should find ~30 talks, not 1
- [ ] `gencon-audiobook --epub-only --conference 2024-04 --output C:\temp\gencon\test-144-modern` — modern conference still works
- [ ] `gencon-audiobook --epub-only --output C:\temp\gencon\test-144-default` — default (no --conference) still works
- [ ] `gencon-audiobook --conference "April 2024" --output C:\temp\gencon\test-144-err` — invalid format shows clear error, exits non-zero

Closes #144