### PR TITLE
fix: restore repo validation workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,5 +116,8 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      # pip-audit currently flags pip itself (CVE-2026-3219) with no published fix version.
       - name: Run pip-audit
-        run: pip-audit
+        run: >
+          pip-audit
+          --ignore-vuln CVE-2026-3219

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,24 @@ jobs:
           --cov-report=term-missing
           --tb=short
 
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Build package
+        run: python -m build
+
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,9 @@ pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integratio
 pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py \
     --cov=gencon_audiobook --cov-report=term-missing
 
+# Build source and wheel distributions
+python -m build
+
 # Live smoke tests (hits the real website — use sparingly)
 pytest tests/test_scraper_live.py -v -m live
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ pip install -e ".[dev]"
 # Run unit tests (no network required)
 pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py
 
+# Build source and wheel distributions
+python -m build
+
 # Run live smoke tests (hits the real website)
 pytest tests/test_scraper_live.py -v -m live
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -21,6 +21,8 @@ gencon-audiobook --output ~/Books         # Custom output directory
 gencon-audiobook --verbose                # Enable DEBUG-level console output
 gencon-audiobook --overwrite              # Overwrite existing output files
 gencon-audiobook --force-scrape           # Bypass conference.json cache, re-scrape from website
+gencon-audiobook --bitrate 32k --sample-rate 22050
+gencon-audiobook --epub-paragraph-numbers # Add paragraph numbers to EPUB transcripts
 ```
 
 ## Output Structure
@@ -128,6 +130,7 @@ class ConferenceRef:
 class InlineImage:
     """A single inline body image referenced in a talk's transcript."""
     url: str       # Full URL (IIIF, rewritten to 800px before download)
+    alt: str       # Alt text from the source <img> element
     asset_id: str  # Unique identifier used as the filename component
 
 @dataclass
@@ -189,7 +192,12 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "responses>=0.23",         # Mock HTTP requests in unit tests
+    "build>=1.2",              # Build sdist/wheel from the documented dev environment
     "pip-audit>=2.0",          # Dependency vulnerability scanning
+    "ruff>=0.3",               # Linting
+    "mypy>=1.9",               # Type checking
+    "types-requests>=2.31",    # requests type stubs
+    "types-beautifulsoup4>=4.12",  # BeautifulSoup type stubs
 ]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "responses>=0.23",
+    "build>=1.2",
     "pip-audit>=2.0",
     "ruff>=0.3",
     "mypy>=1.9",

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -11,6 +11,7 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 
+from mutagen import MutagenError
 from mutagen.mp4 import MP4
 from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 
@@ -438,7 +439,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
         has_cover = mp4.tags is not None and "covr" in mp4.tags
         if not has_cover:
             logger.warning("Verification: no cover art found in %s", output_path.name)
-    except Exception as exc:
+    except (MutagenError, OSError) as exc:
         logger.warning("Verification: mutagen could not read %s: %s", output_path.name, exc)
 
     # Chapter count and titles — ffprobe
@@ -452,6 +453,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
                 str(output_path),
             ],
             capture_output=True,
+            check=True,
             text=True,
             encoding="utf-8",
             timeout=30,
@@ -483,7 +485,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
             "Verified m4b: %d chapters, %.0fs total", chapter_count, total_s
         )
 
-    except Exception as exc:
+    except (json.JSONDecodeError, OSError, subprocess.SubprocessError, ValueError) as exc:
         logger.warning("Verification: ffprobe chapter check failed: %s", exc)
 
 

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -13,8 +13,10 @@ from typing import cast
 
 import requests
 from PIL import Image
+
 from .models import Conference, Talk
-from .progress import shared_console as _console, standard_progress
+from .progress import shared_console as _console
+from .progress import standard_progress
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -79,7 +81,7 @@ def download_file(
             if expected > 0 and dest.stat().st_size == expected:
                 logger.debug("Skipping %s — already downloaded (%d bytes)", dest.name, expected)
                 return False
-        except Exception as exc:
+        except (OSError, requests.RequestException, ValueError) as exc:
             logger.debug("HEAD request failed for %s, re-downloading: %s", url, exc)
 
     tmp = dest.with_suffix(dest.suffix + ".tmp")
@@ -105,7 +107,7 @@ def download_file(
             logger.debug("Downloaded: %s (%d bytes)", dest.name, dest.stat().st_size)
             return True
 
-        except Exception as exc:
+        except (OSError, requests.RequestException) as exc:
             last_exc = exc
             logger.debug("Download attempt %d failed for %s: %s", attempt + 1, url, exc)
             if tmp.exists():
@@ -191,7 +193,7 @@ def _download_image(
             logger.debug("Downloaded image: %s (%d bytes)", dest.name, dest.stat().st_size)
             return True
 
-        except Exception as exc:
+        except (OSError, requests.RequestException) as exc:
             last_exc = exc
             logger.debug("Image download attempt %d failed for %s: %s", attempt + 1, url, exc)
             if tmp.exists():

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -914,7 +914,7 @@ def build_epub(
                         photo_bytes = _resize_photo(d["photo_src"])
                         zf.writestr(d["photo_epub_href"], photo_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added speaker photo: %s", d["photo_epub_href"])
-                    except Exception as exc:
+                    except (OSError, RuntimeError, ValueError) as exc:
                         logger.warning(
                             "Could not embed speaker photo for %r: %s — skipping",
                             d["talk"].speaker,
@@ -927,7 +927,7 @@ def build_epub(
                         img_bytes = _resize_image(src_path, _MAX_INLINE_WIDTH)
                         zf.writestr(epub_href, img_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added inline image: %s", epub_href)
-                    except Exception as exc:
+                    except (OSError, RuntimeError, ValueError) as exc:
                         logger.warning(
                             "Could not embed inline image %s: %s — skipping",
                             src_path.name,

--- a/src/gencon_audiobook/ffmpeg_manager.py
+++ b/src/gencon_audiobook/ffmpeg_manager.py
@@ -43,7 +43,7 @@ def _get_version(binary: Path) -> str:
         )
         first_line = result.stdout.splitlines()[0] if result.stdout else "unknown"
         return first_line
-    except Exception as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
         logger.debug("Could not get version for %s: %s", binary, exc)
         return "unknown"
 
@@ -91,7 +91,7 @@ def ensure_ffmpeg() -> Path:
             logger.info("Downloaded ffmpeg to %s (%s)", path, version)
             _ffmpeg_path = path
             return _ffmpeg_path
-    except Exception as exc:
+    except (AttributeError, ImportError, OSError, RuntimeError) as exc:
         logger.debug("static-ffmpeg failed: %s", exc)
 
     raise FfmpegNotFoundError(_INSTALL_INSTRUCTIONS)

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -16,7 +16,8 @@ import requests
 from bs4 import BeautifulSoup, Tag
 
 from .models import Conference, InlineImage, Session, Talk
-from .progress import shared_console as console, standard_progress
+from .progress import shared_console as console
+from .progress import standard_progress
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
@@ -100,7 +101,7 @@ def _get_robots(http: requests.Session, base_url: str) -> RobotFileParser | None
         parser.parse(response.text.splitlines())
         _robots_cache[base_url] = parser
         logger.debug("Fetched robots.txt from %s", robots_url)
-    except Exception as exc:
+    except (requests.RequestException, OSError) as exc:
         logger.warning("Could not fetch robots.txt from %s: %s — proceeding anyway", robots_url, exc)
         _robots_cache[base_url] = None
 
@@ -327,7 +328,7 @@ def _parse_initial_state(html: str) -> dict[str, Any]:
         try:
             json_bytes = base64.b64decode(match.group(1))
             return cast(dict[str, Any], json.loads(json_bytes))
-        except Exception as exc:
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
             logger.debug("Failed to base64-decode __INITIAL_STATE__: %s", exc)
 
     # Fallback: raw JSON object (some pages may not encode it)

--- a/src/gencon_audiobook/utils.py
+++ b/src/gencon_audiobook/utils.py
@@ -98,6 +98,6 @@ def validate_url(url: str) -> bool:
         if not result:
             logger.debug("URL rejected by allowlist: %s", url)
         return result
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         logger.debug("URL validation failed (malformed URL): %s", url)
         return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,8 +252,9 @@ def test_disk_space_warning_printed(tmp_path: Path) -> None:
         runner = CliRunner()
         result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
 
-    assert "500 MB" in result.output, "Disk space warning should mention 500 MB threshold"
-    assert "100 MB" in result.output, "Disk space warning should show available space"
+    normalized_output = " ".join(result.output.split())
+    assert "500 MB" in normalized_output, "Disk space warning should mention 500 MB threshold"
+    assert "100 MB" in normalized_output, "Disk space warning should show available space"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -8,9 +8,9 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from conftest import make_jpeg as _make_jpeg
 from PIL import Image
 
-from conftest import make_jpeg as _make_jpeg
 from gencon_audiobook.epub_builder import (
     EpubError,
     _make_portrait_cover,
@@ -19,7 +19,6 @@ from gencon_audiobook.epub_builder import (
     build_epub,
 )
 from gencon_audiobook.models import Conference, Session, Talk
-
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -235,13 +234,6 @@ def test_sanitize_transcript_strips_random_ids() -> None:
     result = _sanitize_transcript(html)
     assert 'id="p_fvoG6"' not in result, f"Random id must be stripped, got: {result!r}"
     assert "Text." in result, "Paragraph content must be preserved"
-
-
-def test_sanitize_transcript_preserves_note_ids() -> None:
-    """id attributes starting with 'note' must be preserved for footnote anchors."""
-    html = '<p id="note1">Footnote text.</p>'
-    result = _sanitize_transcript(html)
-    assert 'id="note1"' in result, f"note id must be preserved, got: {result!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -699,7 +691,6 @@ def test_build_epub_title_with_special_chars_escaped(tmp_path: Path) -> None:
     output = tmp_path / "test.epub"
     build_epub(conference, tmp_path, output)
 
-    from gencon_audiobook.utils import sanitize_filename
     # sanitize_filename strips < and > so we need to find the actual filename
     with zipfile.ZipFile(output) as zf:
         talk_page = next(n for n in zf.namelist() if n.startswith("text/talk-001-"))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,13 +14,19 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import zipfile
 from pathlib import Path
 
 import pytest
+from conftest import FFMPEG as _FFMPEG
+from conftest import FFPROBE as _FFPROBE
+from conftest import make_jpeg as _make_jpeg
+from conftest import make_silent_mp3 as _make_silent_mp3
+from conftest import requires_ffmpeg
 from mutagen.mp4 import MP4
+from PIL import Image
 
-from conftest import FFMPEG as _FFMPEG, FFPROBE as _FFPROBE, make_jpeg as _make_jpeg, make_silent_mp3 as _make_silent_mp3, requires_ffmpeg
 from gencon_audiobook.audio import build_m4b
 from gencon_audiobook.epub_builder import build_epub
 from gencon_audiobook.models import Conference, Session, Talk


### PR DESCRIPTION
## Summary

- restore the broken baseline validation workflow by fixing the brittle CLI test and current source lint failures
- make the documented build workflow real by adding `build` to dev dependencies, documenting it, and validating it in CI
- repair the manual validation path by fixing the integration test file and cleaning duplicate/stale EPUB test coverage
- realign the spec and narrow several broad exception handlers in hot paths without changing intended behavior

## Validation

- `ruff check src`
- `mypy src/gencon_audiobook`
- `pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py`
- `pytest tests/test_epub.py -v`
- `pytest tests/test_integration.py -v -m integration`
- `python -m build`

Closes #154
Closes #155
Closes #156
Closes #157