### PR TITLE
fix: preserve EPUB footnotes from Church talk pages (#159)

### DIFF
--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -254,26 +254,44 @@ def _sanitize_transcript(
                 del tag.attrs[attr]
 
     # Preserve internal footnote links as EPUB 3 noterefs; unwrap everything else.
-    # Links whose href starts with "#note" connect superscript markers to footnote
-    # bodies on the same page. Adding epub:type="noteref" lets modern e-readers
-    # (Apple Books, Kobo, Thorium) display the footnote as a dismissible popup.
-    # All other <a> tags (scripture refs, cross-refs) point outside the EPUB
-    # container (RSC-033, RSC-026) and must be unwrapped.
+    # The Church site generates note-ref links with class="note-ref" and a full talk-page
+    # URL ending in "#noteN" (e.g. href="/study/general-conference/2024/04/31bowen?lang=eng#note1").
+    # These must be normalized to bare fragment refs ("#noteN") and marked epub:type="noteref"
+    # so e-readers (Apple Books, Kobo, Thorium) can display the footnote as a dismissible popup.
+    # Bare "#noteN" hrefs (from synthetic or pre-normalized content) are also accepted.
+    # All other <a> tags (scripture refs, cross-refs) point outside the EPUB container
+    # (RSC-033, RSC-026) and must be unwrapped.
+    _NOTE_FRAGMENT_RE = re.compile(r"#(note\d+)$")
     for a_tag in soup.find_all("a"):
         href = str(a_tag.get("href") or "")
-        if href.startswith("#note"):
-            # Strip all attrs except href; add EPUB 3 noteref semantics.
-            a_tag.attrs = {"href": href, "epub:type": "noteref"}
+        scroll_id = str(a_tag.get("data-scroll-id") or "")
+        note_id: str | None = None
+        if scroll_id and re.match(r"^note\d+$", scroll_id):
+            # Canonical case: Church note-ref link with data-scroll-id="noteN"
+            note_id = scroll_id
+        elif href.startswith("#note") and re.match(r"^#note\d+$", href):
+            # Pre-normalized bare fragment ref
+            note_id = href[1:]
+        else:
+            # Check for full URL ending in #noteN fragment
+            m = _NOTE_FRAGMENT_RE.search(href)
+            if m and "note-ref" in (a_tag.get("class") or []):
+                note_id = m.group(1)
+        if note_id:
+            a_tag.attrs = {"href": f"#{note_id}", "epub:type": "noteref"}
         else:
             a_tag.unwrap()
 
     # Wrap footnote body elements in <aside epub:type="footnote">.
-    # The Church site uses id="note1", id="note2", etc. on <p> or <div> elements
-    # for the footnote content. Moving the id to the wrapping <aside> satisfies
-    # EPUB 3 structure: the noteref href="#note1" links to the aside, which the
-    # reader renders as a popup.
+    # The Church site uses id="note1", id="note2", etc. on <li> elements inside
+    # footer.notes for the footnote content. Moving the id to the wrapping <aside>
+    # satisfies EPUB 3 structure: the noteref href="#note1" links to the aside, which
+    # the reader renders as a popup.
+    # Only match ids of exactly the form "note" + digits (e.g. "note1", "note12").
+    # Do NOT match "note_title1" (section headings) or "note1_p1" (child elements).
+    _FOOTNOTE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(
-        lambda t: isinstance(t.get("id"), str) and t["id"].startswith("note")
+        lambda t: isinstance(t.get("id"), str) and bool(_FOOTNOTE_ID_RE.match(t["id"]))
     ):
         note_id = str(tag["id"])
         del tag["id"]
@@ -291,14 +309,16 @@ def _sanitize_transcript(
 
     # Strip data-* attributes (React/JS rendering artifacts), random web IDs
     # (e.g., id="p_fvoG6"), and web CSS class names that have no corresponding
-    # rules in the EPUB stylesheet. Preserve id attributes beginning with "note"
-    # (footnote anchors). <img> class attrs are already cleared above.
+    # rules in the EPUB stylesheet. Preserve only footnote anchor ids of the
+    # form "noteN" (e.g., "note1") on <aside> elements. <img> class attrs are
+    # already cleared above.
+    _FOOTNOTE_ASIDE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(True):
         data_attrs = [attr for attr in tag.attrs if attr.startswith("data-")]
         for attr in data_attrs:
             del tag[attr]
         tag_id = tag.get("id")
-        if isinstance(tag_id, str) and not tag_id.startswith("note"):
+        if isinstance(tag_id, str) and not _FOOTNOTE_ASIDE_ID_RE.match(tag_id):
             del tag["id"]
         if "class" in tag.attrs:
             del tag["class"]

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -797,7 +797,17 @@ def parse_talk_page(html: str, talk_url: str) -> dict:
     # Transcript — primary: div.body-block
     body = soup.find("div", class_="body-block")
     if body:
-        result["transcript_html"] = str(body)
+        transcript_parts = [str(body)]
+        # The Church site places footnote bodies in <footer class="notes">, which is a
+        # sibling of div.body-block, not inside it. Append its HTML so the EPUB builder
+        # has the note bodies it needs to render footnotes. Guard against duplication:
+        # only append when the primary selector (not the article fallback) was used,
+        # since article fallbacks already capture the full article including the footer.
+        notes_footer = soup.find("footer", class_="notes")
+        if notes_footer:
+            transcript_parts.append(str(notes_footer))
+            logger.debug("transcript: appended footer.notes (%d chars)", len(str(notes_footer)))
+        result["transcript_html"] = "".join(transcript_parts)
         logger.debug("transcript (primary div.body-block): %d chars", len(result["transcript_html"] or ""))
 
     if not result["transcript_html"]:

--- a/tests/fixtures/talk_page_with_notes.html
+++ b/tests/fixtures/talk_page_with_notes.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"/><title>Test Talk With Notes</title></head>
+<body>
+<article data-content-type="general-conference">
+  <header>
+    <h1 class="title">Miracles, Angels, and Priesthood Power</h1>
+    <p class="author-name">By Elder Shayne M. Bowen</p>
+    <div class="lumen-tile__image">
+      <img src="https://www.churchofjesuschrist.org/imgs/spkr-bowen/full/320/0/default" alt="Shayne M. Bowen"/>
+    </div>
+  </header>
+  <div class="body-block">
+    <p data-aid="159162981" id="p1">Many today say that miracles no longer exist, that angels are fictional, and that the heavens are closed. I testify that miracles have not ceased, angels are among us, and the heavens are truly open.</p>
+    <p data-aid="159162987" id="p2">When our Savior, Jesus Christ, was on the earth, He gave priesthood keys to His chief Apostle, Peter.<a class="note-ref" data-scroll-id="note1" href="/study/general-conference/2024/04/31bowen?lang=eng#note1"><sup class="marker" data-value="1"></sup></a> Through these keys, Peter and the other Apostles led the Savior's Church.</p>
+    <p data-aid="159162993" id="p3">Peter, James, and John and other ancient prophets appeared as resurrected beings, bestowing upon the Prophet Joseph Smith what the Lord described as "the keys of my kingdom, and a dispensation of the gospel."<a class="note-ref" data-scroll-id="note2" href="/study/general-conference/2024/04/31bowen?lang=eng#note2"><sup class="marker" data-value="2"></sup></a></p>
+    <p data-aid="159163134" id="p26">I testify that the holy priesthood with its keys, authority, and power has been restored to the earth in our day. In the name of Jesus Christ, amen.</p>
+  </div>
+  <footer class="notes">
+    <p class="title" data-aid="159163161" id="note_title1">Notes</p>
+    <ol class="decimal" data-type="marker" start="1">
+      <li data-marker="1." id="note1" data-full-marker="1.">
+        <p data-aid="159163167" id="note1_p1">See <a class="scripture-ref" href="/study/scriptures/nt/matt/16?lang=eng&amp;id=p17-p19#p17">Matthew 16:17&#x2013;19</a>; <a class="scripture-ref" href="/study/scriptures/dc-testament/dc/128?lang=eng&amp;id=p18,21#p18">Doctrine and Covenants 128:18, 21</a>.</p>
+      </li>
+      <li data-marker="2." id="note2" data-full-marker="2.">
+        <p data-aid="159163174" id="note2_p1">See <a class="scripture-ref" href="/study/scriptures/dc-testament/dc/27?lang=eng&amp;id=p12-p13#p12">Doctrine and Covenants 27:12&#x2013;13</a>.</p>
+      </li>
+    </ol>
+  </footer>
+</article>
+<div class="player-component">
+  <video>
+    <source src="https://assets.churchofjesuschrist.org/31bowen-32k-en.mp3" type="audio/mpeg"/>
+  </video>
+</div>
+</body>
+</html>

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -185,6 +185,65 @@ def test_sanitize_transcript_noteref_link_preserved_with_epub_type() -> None:
     assert "<sup" in result, "Superscript inside noteref must be preserved"
 
 
+def test_sanitize_transcript_real_noteref_url_normalized() -> None:
+    """Church note-ref links use full talk-page URLs ending in #noteN, not bare fragments.
+
+    A link like href="/study/general-conference/2024/04/31bowen?lang=eng#note1" with
+    class="note-ref" and data-scroll-id="note1" must be normalized to href="#note1"
+    and marked as epub:type="noteref". The existing href-fragment check does not handle
+    this case — it only matches bare "#note" prefixes.
+    """
+    html = (
+        '<p>Priesthood keys.<a class="note-ref" '
+        'data-scroll-id="note1" '
+        'href="/study/general-conference/2024/04/31bowen?lang=eng#note1">'
+        '<sup class="marker" data-value="1"></sup></a></p>'
+    )
+    result = _sanitize_transcript(html)
+    assert 'href="#note1"' in result, (
+        f"Full URL note-ref must be normalized to bare fragment, got: {result!r}"
+    )
+    assert 'epub:type="noteref"' in result, (
+        f"epub:type noteref must be added to normalized note-ref, got: {result!r}"
+    )
+
+
+def test_sanitize_transcript_li_footnote_body_wrapped_in_aside() -> None:
+    """Real Church footnote bodies use <li id='noteN'>, not <p id='noteN'>.
+
+    The EPUB builder must wrap <li id="noteN"> in <aside epub:type="footnote"> just
+    as it does for <p id="noteN"> shapes, since the real site uses list items.
+    """
+    html = (
+        '<ol><li id="note1">'
+        '<p>See <a href="/study/scriptures/nt/matt/16">Matthew 16:17</a>.</p>'
+        '</li></ol>'
+    )
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote" id="note1">' in result, (
+        f"<li id='note1'> must become <aside epub:type='footnote' id='note1'>, got: {result!r}"
+    )
+    assert "Matthew 16:17" in result, "Footnote body text must survive wrapping"
+
+
+def test_sanitize_transcript_note_title_id_not_wrapped() -> None:
+    """id='note_title1' is a section heading, not a footnote body — must not be wrapped."""
+    html = '<p id="note_title1">Notes</p>'
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote"' not in result, (
+        f"note_title* id must not produce a footnote aside, got: {result!r}"
+    )
+
+
+def test_sanitize_transcript_child_note_id_not_wrapped() -> None:
+    """id='note1_p1' is a child element ID, not a footnote body — must not be wrapped."""
+    html = '<p id="note1_p1">Child paragraph text.</p>'
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote"' not in result, (
+        f"note1_p1 id must not produce a footnote aside, got: {result!r}"
+    )
+
+
 def test_sanitize_transcript_non_note_links_still_unwrapped() -> None:
     """Non-footnote <a> tags (scripture refs, cross-refs) must still be unwrapped."""
     html = '<p>See <a href="https://www.churchofjesuschrist.org/scripture/1ne/1.1">1 Ne. 1:1</a>.</p>'
@@ -339,6 +398,71 @@ def test_build_epub_session_headers_are_links(tmp_path: Path) -> None:
         "Session header must not use <span>"
     assert f">{session_name}</a>" in nav, \
         "Session header must use <a> linking to first talk"
+
+
+# ---------------------------------------------------------------------------
+# build_epub — footnote end-to-end (ZIP-level assertions)
+# ---------------------------------------------------------------------------
+
+
+def _make_conference_with_notes() -> Conference:
+    """Return a one-talk Conference whose transcript contains realistic Church note markup."""
+    # Note refs use full talk-page URLs (as the Church site generates them), not bare fragments.
+    # Note bodies come from footer.notes as <li id="noteN"> elements (already appended to
+    # transcript_html by the scraper — this simulates a post-fix scrape result).
+    transcript = (
+        '<div class="body-block">'
+        '<p>Priesthood keys.'
+        '<a class="note-ref" data-scroll-id="note1" '
+        'href="/study/general-conference/2024/04/31bowen?lang=eng#note1">'
+        '<sup class="marker" data-value="1"></sup></a></p>'
+        '</div>'
+        '<footer class="notes">'
+        '<ol class="decimal">'
+        '<li id="note1"><p>See Matthew 16:17&#x2013;19.</p></li>'
+        '</ol>'
+        '</footer>'
+    )
+    talk = Talk(
+        title="Miracles, Angels, and Priesthood Power",
+        speaker="Elder Shayne M. Bowen",
+        talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/31bowen?lang=eng",
+        talk_index=1,
+        transcript_html=transcript,
+    )
+    session = Session(name="Saturday Morning Session", number=1, talks=[talk])
+    return Conference(
+        title="April 2024 General Conference",
+        year=2024,
+        month=4,
+        cover_image_url=None,
+        sessions=[session],
+        conference_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04",
+    )
+
+
+def test_build_epub_footnotes_noteref_in_output(tmp_path: Path) -> None:
+    """A talk with Church-style note refs must produce epub:type="noteref" in the EPUB ZIP.
+
+    This is a build-level regression test: it verifies that the entire pipeline from
+    transcript_html through _sanitize_transcript() and into the final EPUB file preserves
+    footnote markup — not just that the sanitizer function returns the right string.
+    """
+    conference = _make_conference_with_notes()
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    talk_files = [n for n in _epub_names(output) if n.startswith("text/talk-")]
+    assert talk_files, "Expected at least one talk XHTML file in the EPUB"
+    talk_content = _epub_read(output, talk_files[0]).decode("utf-8")
+    assert 'epub:type="noteref"' in talk_content, (
+        f"epub:type='noteref' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
+    assert 'epub:type="footnote"' in talk_content, (
+        f"epub:type='footnote' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
+    assert 'href="#note1"' in talk_content, (
+        f"Normalized note href '#note1' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -268,6 +268,28 @@ def test_parse_talk_page_deduplicates_inline_images():
     assert len(data["inline_images"]) == 1, "Duplicate asset_id should be deduplicated"
 
 
+def test_parse_talk_page_captures_footnote_bodies_from_footer():
+    """footer.notes content must appear in transcript_html so the EPUB builder can render it.
+
+    The Church site places footnote bodies in <footer class="notes"> as a sibling of
+    <div class="body-block">, not inside it. parse_talk_page() must capture both
+    so the EPUB builder has the note bodies it needs.
+    """
+    html = _load("talk_page_with_notes.html")
+    data = parse_talk_page(html, "https://www.churchofjesuschrist.org/study/general-conference/2024/04/31bowen?lang=eng")
+    transcript = data["transcript_html"] or ""
+    assert 'id="note1"' in transcript, (
+        "Footnote body id='note1' must be present in transcript_html"
+    )
+    assert 'id="note2"' in transcript, (
+        "Footnote body id='note2' must be present in transcript_html"
+    )
+    # Verify note content survived
+    assert "Matthew 16" in transcript, (
+        "Footnote body text must be present in transcript_html"
+    )
+
+
 # ---------------------------------------------------------------------------
 # robots.txt (#23)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes EPUB footnotes end-to-end. Footnotes were silently dropped from all EPUBs because:
1. The scraper only captured \div.body-block\ — footnote bodies live in \ooter.notes\, a sibling, not a child
2. The EPUB builder only recognized bare \#noteN\ hrefs, but live Church note-ref links use full talk-page URLs ending in \#note1\
3. The footnote-body regex matched \
ote_title1\ and \
ote1_p1\ as footnote anchors (wrong)

## Changes

- **scraper.py**: Append \ooter.notes\ HTML to \	ranscript_html\ alongside \div.body-block\
- **epub_builder.py**: Normalize full Church note-ref URLs to bare \#noteN\ fragments using \class='note-ref'\ + \data-scroll-id\ as the signal; tighten footnote-body wrapping to \^note\d+\$\ only
- **tests**: 6 new tests including a fixture with realistic Church HTML and a ZIP-level assertion

## Testing

- 252 unit tests pass (246 before + 6 new)
- \uff check src\ — clean
- \mypy src/gencon_audiobook\ — clean

Closes #159