### PR TITLE
release: EPUB footnotes fix + repo quality gates

### DIFF
--- a/.claude/rules/epub-style.md
+++ b/.claude/rules/epub-style.md
@@ -12,7 +12,7 @@ high contrast, accessibility modes). This is achieved by deferring ALL visual st
 - `color` (including `currentColor` in color properties)
 - `background-color`
 - `font-family`
-- Absolute font sizes: `px`, `pt`, `cm`, `mm`, `in`, `pc`
+- `font-size` (any unit — `px`, `pt`, `em`, `%`, `rem`, `vw`, etc. — defer text sizing to the reader)
 
 **Only allowed:**
 - Structural layout: `margin`, `padding`, `text-align`, `line-height` in `em` or `%`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read
@@ -83,6 +83,24 @@ jobs:
           --cov-report=term-missing
           --tb=short
 
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Build package
+        run: python -m build
+
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest
@@ -98,5 +116,8 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      # pip-audit currently flags pip itself (CVE-2026-3219) with no published fix version.
       - name: Run pip-audit
-        run: pip-audit
+        run: >
+          pip-audit
+          --ignore-vuln CVE-2026-3219

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,9 @@ pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integratio
 pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py \
     --cov=gencon_audiobook --cov-report=term-missing
 
+# Build source and wheel distributions
+python -m build
+
 # Live smoke tests (hits the real website — use sparingly)
 pytest tests/test_scraper_live.py -v -m live
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ New to the terminal or Python? See the [User Guide](https://github.com/XeroIP/ge
 gencon-audiobook
 
 # Select a specific conference
-gencon-audiobook --conference "April 2024"
+gencon-audiobook --conference 2024-04
 
 # Audiobook only (skip epub)
 gencon-audiobook --audiobook-only

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ pip install -e ".[dev]"
 # Run unit tests (no network required)
 pytest tests/ --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py
 
+# Build source and wheel distributions
+python -m build
+
 # Run live smoke tests (hits the real website)
 pytest tests/test_scraper_live.py -v -m live
 

--- a/docs/phases/phase-1-scraper-audiobook.md
+++ b/docs/phases/phase-1-scraper-audiobook.md
@@ -599,7 +599,7 @@ Implement a minimal but functional CLI. Full error handling and polish comes in 
 @click.option("--output", default="~/gencon-audiobook", show_default=True,
               help="Directory to save output files.")
 @click.option("--conference", default=None,
-              help="Conference to download (e.g., 'April 2024'). Defaults to most recent.")
+              help="Conference date as YYYY-MM (e.g., '2024-04'). Defaults to most recent.")
 @click.option("--audiobook-only", is_flag=True, default=False,
               help="Produce only the m4b audiobook, skip epub.")
 @click.option("--epub-only", is_flag=True, default=False,
@@ -682,7 +682,7 @@ gencon-audiobook --audiobook-only --output ./test_output
 
 # 7. Resume behavior
 # Delete one MP3 from test_output, re-run:
-gencon-audiobook --audiobook-only --output ./test_output --conference "April 2024"
+gencon-audiobook --audiobook-only --output ./test_output --conference 2024-04
 # Expected: only the deleted file re-downloads; all others skipped
 
 # 8. ffmpeg fallback (on clean venv without system ffmpeg)

--- a/docs/phases/phase-3-cli-polish.md
+++ b/docs/phases/phase-3-cli-polish.md
@@ -189,8 +189,8 @@ Handle gracefully (no traceback):
 - **Conference already downloaded**: If output files already exist and `--overwrite` is not set,
   print a message and exit with code 0. Never prompt interactively — the tool must be
   scriptable. `--overwrite` was declared in Phase 1 and is wired up here.
-- **Conference selection**: If `--conference` value doesn't match any available conference,
-  print the list of available conferences and exit with a helpful message
+- **Conference selection**: If `--conference` value is not in YYYY-MM format,
+  print a clear error and exit with a helpful message
 
 ---
 
@@ -220,9 +220,9 @@ ls -la ./test_output/<conference>/gencon-audiobook.log
 gencon-audiobook --output ./test_output  # second run
 # Expected: "Output files already exist. Use --overwrite to replace them."
 
-# 6. Invalid conference name
-gencon-audiobook --conference "Fake Conference 9999"
-# Expected: lists available conferences, clean error message
+# 6. Invalid conference format
+gencon-audiobook --conference "April 2024"
+# Expected: "Invalid conference format" error message, exit non-zero
 
 # 7. Disk space warning
 # (Hard to test without filling disk — verify the logic in code review)

--- a/docs/phases/phase-5-documentation.md
+++ b/docs/phases/phase-5-documentation.md
@@ -50,7 +50,7 @@ contribute.
 6. **Usage**
    ```bash
    gencon-audiobook                               # Most recent conference
-   gencon-audiobook --conference "April 2024"     # Specific conference
+   gencon-audiobook --conference 2024-04          # Specific conference
    gencon-audiobook --audiobook-only              # m4b only
    gencon-audiobook --epub-only                   # epub only
    gencon-audiobook --output ~/Books              # Custom output directory

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -42,7 +42,7 @@ The epub-only pass covers scraping, image downloading, HTML sanitization, and EP
 without needing ffmpeg or a 200 MB MP3 download. Run this first.
 
 ```bash
-gencon-audiobook --epub-only --conference "April 2024" --output ~/gc-test
+gencon-audiobook --epub-only --conference 2024-04 --output ~/gc-test
 ```
 
 **What to check:**
@@ -65,7 +65,7 @@ gencon-audiobook --epub-only --conference "April 2024" --output ~/gc-test
 ## Step 3: Full run — audiobook + epub (~30–60 min)
 
 ```bash
-gencon-audiobook --conference "April 2024" --output ~/gc-test --overwrite
+gencon-audiobook --conference 2024-04 --output ~/gc-test --overwrite
 ```
 
 **What to check in the completion report:**

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -14,7 +14,7 @@ and speaker photos.
 pip install gencon-audiobook
 
 gencon-audiobook                          # List available conferences, default to most recent
-gencon-audiobook --conference "April 2024"  # Select a specific conference
+gencon-audiobook --conference 2024-04       # Select a specific conference
 gencon-audiobook --audiobook-only         # Produce only the m4b
 gencon-audiobook --epub-only              # Produce only the epub
 gencon-audiobook --output ~/Books         # Custom output directory

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -21,6 +21,8 @@ gencon-audiobook --output ~/Books         # Custom output directory
 gencon-audiobook --verbose                # Enable DEBUG-level console output
 gencon-audiobook --overwrite              # Overwrite existing output files
 gencon-audiobook --force-scrape           # Bypass conference.json cache, re-scrape from website
+gencon-audiobook --bitrate 32k --sample-rate 22050
+gencon-audiobook --epub-paragraph-numbers # Add paragraph numbers to EPUB transcripts
 ```
 
 ## Output Structure
@@ -128,6 +130,7 @@ class ConferenceRef:
 class InlineImage:
     """A single inline body image referenced in a talk's transcript."""
     url: str       # Full URL (IIIF, rewritten to 800px before download)
+    alt: str       # Alt text from the source <img> element
     asset_id: str  # Unique identifier used as the filename component
 
 @dataclass
@@ -189,7 +192,12 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "responses>=0.23",         # Mock HTTP requests in unit tests
+    "build>=1.2",              # Build sdist/wheel from the documented dev environment
     "pip-audit>=2.0",          # Dependency vulnerability scanning
+    "ruff>=0.3",               # Linting
+    "mypy>=1.9",               # Type checking
+    "types-requests>=2.31",    # requests type stubs
+    "types-beautifulsoup4>=4.12",  # BeautifulSoup type stubs
 ]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "responses>=0.23",
+    "build>=1.2",
     "pip-audit>=2.0",
     "ruff>=0.3",
     "mypy>=1.9",

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -12,18 +12,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from mutagen.mp4 import MP4
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TaskID,
-    TaskProgressColumn,
-    TextColumn,
-)
+from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 
 from .models import Conference, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import standard_progress
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -645,14 +637,7 @@ def build_m4b(
 
     # Step 2: Convert MP3 → AAC, populate duration_seconds
     logger.info("Converting %d talks to AAC...", len(talks))
-    conv_progress = Progress(
-        SpinnerColumn(),
-        MofNCompleteColumn(),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeRemainingWithLabel(compact=True),
-        TextColumn("[progress.description]{task.description}"),
-    )
+    conv_progress = standard_progress()
     with conv_progress:
         outer_task = conv_progress.add_task("Converting to AAC", total=len(talks))
         inner_task = conv_progress.add_task("", total=1.0, visible=False)

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from mutagen.mp4 import MP4
 from rich.progress import (
     BarColumn,
-    MofNCompleteColumn,
     Progress,
     SpinnerColumn,
     TaskID,
@@ -23,7 +22,7 @@ from rich.progress import (
 )
 
 from .models import Conference, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import ConditionalMofNColumn, TimeRemainingWithLabel
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -647,7 +646,7 @@ def build_m4b(
     logger.info("Converting %d talks to AAC...", len(talks))
     conv_progress = Progress(
         SpinnerColumn(),
-        MofNCompleteColumn(),
+        ConditionalMofNColumn(),
         BarColumn(),
         TaskProgressColumn(),
         TimeRemainingWithLabel(compact=True),
@@ -655,7 +654,7 @@ def build_m4b(
     )
     with conv_progress:
         outer_task = conv_progress.add_task("Converting to AAC", total=len(talks))
-        inner_task = conv_progress.add_task("", total=1.0, visible=False)
+        inner_task = conv_progress.add_task("", total=1.0, visible=False, show_count=False)
         for talk in talks:
             conv_progress.update(outer_task, description=talk.title[:60])
             mp3_path = audio_dir / f"{talk.talk_index:03d}-{sanitize_filename(talk.title)}.mp3"

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -11,6 +11,7 @@ import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 
+from mutagen import MutagenError
 from mutagen.mp4 import MP4
 from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 
@@ -438,7 +439,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
         has_cover = mp4.tags is not None and "covr" in mp4.tags
         if not has_cover:
             logger.warning("Verification: no cover art found in %s", output_path.name)
-    except Exception as exc:
+    except (MutagenError, OSError) as exc:
         logger.warning("Verification: mutagen could not read %s: %s", output_path.name, exc)
 
     # Chapter count and titles — ffprobe
@@ -452,6 +453,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
                 str(output_path),
             ],
             capture_output=True,
+            check=True,
             text=True,
             encoding="utf-8",
             timeout=30,
@@ -483,7 +485,7 @@ def _verify_m4b(output_path: Path, conference: Conference, ffprobe_path: Path) -
             "Verified m4b: %d chapters, %.0fs total", chapter_count, total_s
         )
 
-    except Exception as exc:
+    except (json.JSONDecodeError, OSError, subprocess.SubprocessError, ValueError) as exc:
         logger.warning("Verification: ffprobe chapter check failed: %s", exc)
 
 

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -110,7 +110,8 @@ def _ffmeta_escape(value: str) -> str:
     return value
 
 
-_SUBPROCESS_TIMEOUT = 600   # 10 minutes — generous for large conference builds
+_SUBPROCESS_TIMEOUT = 600   # 10 minutes — for concat/mux of full conference
+_CONVERT_TIMEOUT = 120      # 2 minutes — per-file AAC conversion
 _FALLBACK_BITRATE = "64k"   # used when ffprobe quality probe fails
 _FALLBACK_SAMPLE_RATE = 44100  # used when ffprobe quality probe fails
 
@@ -163,7 +164,11 @@ def _run_ffmpeg_with_progress(
 
     The command must already include `-progress pipe:1 -nostats` so ffmpeg writes
     key=value progress lines to stdout. A watchdog timer kills the process if it
-    exceeds _SUBPROCESS_TIMEOUT seconds without finishing.
+    exceeds _CONVERT_TIMEOUT seconds without finishing.
+
+    stderr is drained in a background thread to prevent pipe deadlock: if ffmpeg
+    writes more than the OS pipe buffer (4KB on Windows) to stderr while Python
+    is blocked reading stdout, both processes stall indefinitely.
 
     Args:
         cmd: Complete ffmpeg command including -progress pipe:1 -nostats flags.
@@ -185,6 +190,17 @@ def _run_ffmpeg_with_progress(
         errors="replace",
     )
 
+    # Drain stderr in a background thread to prevent pipe buffer deadlock.
+    stderr_lines: list[str] = []
+
+    def _drain_stderr() -> None:
+        assert proc.stderr is not None
+        for line in proc.stderr:
+            stderr_lines.append(line)
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
     killed_by_watchdog = False
 
     def _watchdog() -> None:
@@ -193,7 +209,7 @@ def _run_ffmpeg_with_progress(
             killed_by_watchdog = True
             proc.kill()
 
-    timer = threading.Timer(_SUBPROCESS_TIMEOUT, _watchdog)
+    timer = threading.Timer(_CONVERT_TIMEOUT, _watchdog)
     timer.start()
     try:
         assert proc.stdout is not None  # guaranteed by stdout=PIPE
@@ -212,17 +228,16 @@ def _run_ffmpeg_with_progress(
         timer.cancel()
 
     proc.wait()
+    stderr_thread.join(timeout=5)
 
     if killed_by_watchdog:
         raise AudioError(
-            f"{label} timed out after {_SUBPROCESS_TIMEOUT}s. "
-            "The ffmpeg process was killed. Try with fewer talks or check for corrupt MP3 files."
+            f"{label} timed out after {_CONVERT_TIMEOUT}s. "
+            "The ffmpeg process was killed. Check for corrupt or unsupported MP3 files."
         )
 
     if proc.returncode != 0:
-        stderr = ""
-        if proc.stderr:
-            stderr = proc.stderr.read()
+        stderr = "".join(stderr_lines)
         raise AudioError(
             f"{label} failed (exit {proc.returncode}).\n"
             f"Command: {' '.join(cmd)}\n"

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import calendar
 import logging
+import re
 import shutil
 import sys
 import time
@@ -30,6 +32,9 @@ _DISK_WARN_MB = 500
 
 # Module-level console so helpers can print without threading a Console argument.
 console = Console()
+
+_CONF_BASE = "https://www.churchofjesuschrist.org/study/general-conference"
+_CONFERENCE_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
 
 
 # ---------------------------------------------------------------------------
@@ -124,18 +129,34 @@ def _check_disk_space(path: Path) -> None:
 def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     """Resolve the conference to download.
 
-    If conference_filter is given, find the first match (case-insensitive).
-    Otherwise print a numbered menu and default to the most recent.
+    If conference_filter is given as YYYY-MM, construct the URL directly — no
+    listing fetch needed. Otherwise fetch the listing and default to the most recent.
 
     Args:
-        conference_filter: Partial conference name to match, or None.
+        conference_filter: Conference date as YYYY-MM (e.g., '2024-04'), or None.
 
     Returns:
         (title, url) of the selected conference.
 
     Raises:
-        SystemExit: if the filter matches nothing or the list cannot be fetched.
+        SystemExit: if the format is invalid or the listing cannot be fetched.
     """
+    if conference_filter:
+        m = _CONFERENCE_RE.match(conference_filter)
+        if not m:
+            click.echo(
+                f"Error: Invalid conference format {conference_filter!r}.\n"
+                "Expected YYYY-MM (e.g., '2024-04' or '1999-10').",
+                err=True,
+            )
+            sys.exit(1)
+        year, month = int(m.group(1)), int(m.group(2))
+        title = f"{calendar.month_name[month]} {year} General Conference"
+        url = f"{_CONF_BASE}/{year}/{month:02d}"
+        console.print(f"Selected: {title}")
+        return title, url
+
+    # No filter — fetch listing, default to most recent.
     try:
         with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
             sp.add_task("Fetching available conferences...")
@@ -152,23 +173,6 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
         )
         sys.exit(1)
 
-    if conference_filter:
-        needle = conference_filter.lower()
-        matches = [r for r in refs if needle in r.title.lower()]
-        if not matches:
-            click.echo(
-                f"Error: No conference matching {conference_filter!r}.\n\n"
-                "Available conferences:",
-                err=True,
-            )
-            for i, r in enumerate(refs[:10], 1):
-                click.echo(f"  {i}. {r.title}", err=True)
-            sys.exit(1)
-        selected = matches[0]
-        console.print(f"Selected: {selected.title}")
-        return selected.title, selected.url
-
-    # Default: most recent (first in list)
     console.print(f"Found {len(refs)} conferences. Using: {refs[0].title}")
     return refs[0].title, refs[0].url
 
@@ -188,7 +192,7 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 @click.option(
     "--conference",
     default=None,
-    help="Conference to download (e.g., 'April 2024'). Defaults to most recent.",
+    help="Conference date as YYYY-MM (e.g., '2024-04'). Defaults to most recent.",
 )
 @click.option(
     "--audiobook-only",

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -11,7 +11,6 @@ import time
 from pathlib import Path
 
 import click
-from rich.console import Console
 from rich.logging import RichHandler
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
@@ -22,6 +21,7 @@ from .downloader import DownloadError, DownloadResult, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
 from .models import Talk
+from .progress import shared_console
 from .scraper import ScraperError, fetch_available_conferences, scrape_conference
 
 logger = logging.getLogger(__name__)
@@ -30,8 +30,10 @@ _LOG_FILENAME = "gencon-audiobook.log"
 _MIN_PYTHON = (3, 10)
 _DISK_WARN_MB = 500
 
-# Module-level console so helpers can print without threading a Console argument.
-console = Console()
+# Use the shared console from progress.py so RichHandler and all Progress bars
+# write through the same Console — Rich then interleaves log messages correctly
+# above the live progress bar instead of clobbering the same terminal line.
+console = shared_console
 
 _CONF_BASE = "https://www.churchofjesuschrist.org/study/general-conference"
 _CONFERENCE_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
@@ -158,7 +160,7 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 
     # No filter — fetch listing, default to most recent.
     try:
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
+        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console) as sp:
             sp.add_task("Fetching available conferences...")
             refs = fetch_available_conferences()
     except ScraperError as exc:
@@ -475,6 +477,7 @@ def _run(
                 with Progress(
                     SpinnerColumn(),
                     TextColumn("[progress.description]{task.description}"),
+                    console=console,
                 ) as sp:
                     sp.add_task(f"Building EPUB: {conf_obj.title}")
                     build_epub(

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -16,7 +16,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
 from .cache import CACHE_FILENAME, load_cache, save_cache
-from .downloader import DownloadError, download_conference
+from .downloader import DownloadError, DownloadResult, download_conference
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
 from .models import Talk
@@ -407,16 +407,18 @@ def _run(
     _check_disk_space(conf_output_dir)
 
     # Download audio (skipped for --epub-only) and images.
-    console.print(f"Downloading files for {len(conf_obj.talks)} talks...")
+    # download_conference() prints its own contextual message and skips silently
+    # if all files are already present.
     t0 = time.monotonic()
     try:
-        failed_talks: list[Talk] = download_conference(
+        dl_result: DownloadResult = download_conference(
             conf_obj, conf_output_dir, skip_audio=epub_only
         )
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
         sys.exit(1)
     phase_times["download"] = time.monotonic() - t0
+    failed_talks = dl_result.failed_talks
 
     m4b_path = conf_output_dir / f"{conf_obj.title}.m4b"
     epub_path = conf_output_dir / f"{conf_obj.title}.epub"

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -12,17 +12,8 @@ from typing import cast
 
 import requests
 from PIL import Image
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TaskProgressColumn,
-    TextColumn,
-)
-
 from .models import Conference, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import standard_progress
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -316,14 +307,7 @@ def download_conference(
         len(image_queue),
     )
 
-    overall_progress = Progress(
-        SpinnerColumn(),
-        MofNCompleteColumn(),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeRemainingWithLabel(compact=True),
-        TextColumn("[progress.description]{task.description}"),
-    )
+    overall_progress = standard_progress()
 
     failed: list[str] = []
     failed_talks: list[Talk] = []

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -13,10 +13,8 @@ from typing import cast
 
 import requests
 from PIL import Image
-from rich.console import Console
-
 from .models import Conference, Talk
-from .progress import standard_progress
+from .progress import shared_console as _console, standard_progress
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -29,8 +27,6 @@ _IMAGE_WORKERS = 8              # concurrent image download threads
 # requests.Session is NOT thread-safe; sharing one across threads causes
 # intermittent connection errors and garbled responses.
 _thread_locals: threading.local = threading.local()
-
-_console = Console()
 
 
 class DownloadError(Exception):

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -6,12 +6,14 @@ import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
 from typing import cast
 
 import requests
 from PIL import Image
+from rich.console import Console
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -36,9 +38,20 @@ _IMAGE_WORKERS = 8              # concurrent image download threads
 # intermittent connection errors and garbled responses.
 _thread_locals: threading.local = threading.local()
 
+_console = Console()
+
 
 class DownloadError(Exception):
     """Raised when a file download fails after all retries."""
+
+
+@dataclass
+class DownloadResult:
+    """Results returned by download_conference()."""
+
+    failed_talks: list[Talk] = field(default_factory=list)
+    downloaded: int = 0
+    skipped: int = 0
 
 
 def download_file(
@@ -47,7 +60,7 @@ def download_file(
     session: requests.Session,
     timeout: tuple[int, int] = (30, 120),
     retries: int = 3,
-) -> None:
+) -> bool:
     """Download a single file to dest, using .tmp + rename for atomicity.
 
     Skips download if dest already exists with expected size (from Content-Length).
@@ -59,6 +72,9 @@ def download_file(
         session: requests.Session to use.
         timeout: (connect_timeout, read_timeout) in seconds.
         retries: Number of retry attempts with exponential backoff.
+
+    Returns:
+        True if the file was downloaded, False if it was skipped (already present).
 
     Raises:
         DownloadError: if download fails after all retries.
@@ -74,7 +90,7 @@ def download_file(
             expected = int(head.headers.get("Content-Length", -1))
             if expected > 0 and dest.stat().st_size == expected:
                 logger.debug("Skipping %s — already downloaded (%d bytes)", dest.name, expected)
-                return
+                return False
         except Exception as exc:
             logger.debug("HEAD request failed for %s, re-downloading: %s", url, exc)
 
@@ -99,7 +115,7 @@ def download_file(
 
             tmp.replace(dest)
             logger.debug("Downloaded: %s (%d bytes)", dest.name, dest.stat().st_size)
-            return
+            return True
 
         except Exception as exc:
             last_exc = exc
@@ -140,7 +156,7 @@ def _download_image(
     session: requests.Session,
     timeout: tuple[int, int] = (30, 120),
     retries: int = 3,
-) -> None:
+) -> bool:
     """Download an image, convert to JPEG, and save to dest.
 
     Skips if dest already exists (images don't resume by size — content-identical
@@ -153,6 +169,9 @@ def _download_image(
         timeout: (connect_timeout, read_timeout) in seconds.
         retries: Number of retry attempts.
 
+    Returns:
+        True if the image was downloaded, False if it was skipped (already present).
+
     Raises:
         DownloadError: if download or conversion fails after all retries.
         ValueError: if url fails validate_url().
@@ -162,7 +181,7 @@ def _download_image(
 
     if dest.exists():
         logger.debug("Skipping image %s — already exists", dest.name)
-        return
+        return False
 
     tmp = dest.with_suffix(dest.suffix + ".tmp")
     last_exc: Exception | None = None
@@ -182,7 +201,7 @@ def _download_image(
             tmp.write_bytes(jpeg_bytes)
             tmp.replace(dest)
             logger.debug("Downloaded image: %s (%d bytes)", dest.name, dest.stat().st_size)
-            return
+            return True
 
         except Exception as exc:
             last_exc = exc
@@ -255,21 +274,22 @@ def download_conference(
     output_dir: Path,
     delay: float = 0.5,
     skip_audio: bool = False,
-) -> list[Talk]:
+) -> DownloadResult:
     """Download all MP3s, cover image, and speaker photos for a conference.
 
     Files are downloaded to .tmp first, renamed on success. Existing files of
     the correct size are skipped (resume behavior). Speaker photos are converted
-    to JPEG. Progress is shown via rich progress bars.
+    to JPEG. Progress is shown via rich progress bars only when files actually
+    need downloading.
 
     Args:
         conference: Fully populated Conference object with mp3_urls set.
         output_dir: Directory to download into. Created if it doesn't exist.
-        delay: Seconds to wait between HTTP requests.
+        delay: Seconds to wait between audio HTTP requests.
         skip_audio: If True, skip MP3 downloads (for --epub-only mode).
 
     Returns:
-        List of Talk objects whose audio download failed (empty if all succeeded).
+        DownloadResult with counts of downloaded/skipped files and any failed talks.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     cleanup_tmp_files(output_dir)
@@ -305,7 +325,25 @@ def download_conference(
 
     if not queue:
         logger.info("Nothing to download.")
-        return []
+        return DownloadResult()
+
+    # Pre-scan: count locally present files without making HEAD requests.
+    # This is an approximation — audio files are further verified by Content-Length
+    # inside download_file, but the pre-scan is cheap and accurate enough for UX.
+    pre_exists = sum(1 for _, dest, _, _, _ in queue if dest.exists())
+    needs_download = len(queue) - pre_exists
+
+    if needs_download == 0:
+        logger.debug("All %d files already present — skipping download phase.", len(queue))
+        return DownloadResult(skipped=len(queue))
+
+    if pre_exists > 0:
+        _console.print(
+            f"Downloading {needs_download} of {len(queue)} files "
+            f"({pre_exists} already present)..."
+        )
+    else:
+        _console.print(f"Downloading {len(queue)} files...")
 
     image_queue = [(url, dest, label) for url, dest, label, is_image, _ in queue if is_image]
     audio_queue = [(url, dest, label, talk) for url, dest, label, is_image, talk in queue if not is_image]
@@ -327,6 +365,8 @@ def download_conference(
 
     failed: list[str] = []
     failed_talks: list[Talk] = []
+    downloaded = 0
+    skipped = 0
 
     with overall_progress:
         overall_task = overall_progress.add_task("Downloading files", total=len(queue))
@@ -336,15 +376,15 @@ def download_conference(
         # requests.Session is not thread-safe.
         if image_queue:
 
-            def _download_one_image(args: tuple[str, Path, str]) -> str | None:
-                """Worker: download one image. Returns label on failure, None on success."""
+            def _download_one_image(args: tuple[str, Path, str]) -> tuple[bool, str | None]:
+                """Worker: download one image. Returns (was_downloaded, label_on_failure)."""
                 url, dest, label = args
                 try:
-                    _download_image(url, dest, _get_thread_session(), retries=3)
-                    return None
+                    was_downloaded = _download_image(url, dest, _get_thread_session(), retries=3)
+                    return was_downloaded, None
                 except (DownloadError, ValueError) as exc:
                     logger.error("Failed to download %s: %s", label, exc)
-                    return label
+                    return False, label
                 finally:
                     overall_progress.advance(overall_task)
 
@@ -352,9 +392,13 @@ def download_conference(
             with ThreadPoolExecutor(max_workers=workers) as executor:
                 futures = {executor.submit(_download_one_image, item): item for item in image_queue}
                 for future in as_completed(futures):
-                    result = future.result()
-                    if result is not None:
-                        failed.append(result)
+                    was_downloaded, error_label = future.result()
+                    if error_label is not None:
+                        failed.append(error_label)
+                    elif was_downloaded:
+                        downloaded += 1
+                    else:
+                        skipped += 1
 
         # Audio: sequential with courtesy delay between requests.
         # MP3s are large; parallel streaming of many large files simultaneously
@@ -363,8 +407,12 @@ def download_conference(
         for url, dest, label, queue_talk in audio_queue:
             overall_progress.update(overall_task, description=label)
             try:
-                download_file(url, dest, session, retries=3)
-                time.sleep(delay)
+                was_downloaded = download_file(url, dest, session, retries=3)
+                if was_downloaded:
+                    downloaded += 1
+                    time.sleep(delay)
+                else:
+                    skipped += 1
             except (DownloadError, ValueError) as exc:
                 logger.error("Failed to download %s: %s", label, exc)
                 failed.append(label)
@@ -380,4 +428,4 @@ def download_conference(
             ", ".join(failed),
         )
 
-    return failed_talks
+    return DownloadResult(failed_talks=failed_talks, downloaded=downloaded, skipped=skipped)

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -13,8 +13,10 @@ from typing import cast
 
 import requests
 from PIL import Image
+
 from .models import Conference, Talk
-from .progress import shared_console as _console, standard_progress
+from .progress import shared_console as _console
+from .progress import standard_progress
 from .utils import USER_AGENT, sanitize_filename, validate_url
 
 logger = logging.getLogger(__name__)
@@ -79,7 +81,7 @@ def download_file(
             if expected > 0 and dest.stat().st_size == expected:
                 logger.debug("Skipping %s — already downloaded (%d bytes)", dest.name, expected)
                 return False
-        except Exception as exc:
+        except (OSError, requests.RequestException, ValueError) as exc:
             logger.debug("HEAD request failed for %s, re-downloading: %s", url, exc)
 
     tmp = dest.with_suffix(dest.suffix + ".tmp")
@@ -105,7 +107,7 @@ def download_file(
             logger.debug("Downloaded: %s (%d bytes)", dest.name, dest.stat().st_size)
             return True
 
-        except Exception as exc:
+        except (OSError, requests.RequestException) as exc:
             last_exc = exc
             logger.debug("Download attempt %d failed for %s: %s", attempt + 1, url, exc)
             if tmp.exists():
@@ -191,7 +193,7 @@ def _download_image(
             logger.debug("Downloaded image: %s (%d bytes)", dest.name, dest.stat().st_size)
             return True
 
-        except Exception as exc:
+        except (OSError, requests.RequestException) as exc:
             last_exc = exc
             logger.debug("Image download attempt %d failed for %s: %s", attempt + 1, url, exc)
             if tmp.exists():

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -254,26 +254,44 @@ def _sanitize_transcript(
                 del tag.attrs[attr]
 
     # Preserve internal footnote links as EPUB 3 noterefs; unwrap everything else.
-    # Links whose href starts with "#note" connect superscript markers to footnote
-    # bodies on the same page. Adding epub:type="noteref" lets modern e-readers
-    # (Apple Books, Kobo, Thorium) display the footnote as a dismissible popup.
-    # All other <a> tags (scripture refs, cross-refs) point outside the EPUB
-    # container (RSC-033, RSC-026) and must be unwrapped.
+    # The Church site generates note-ref links with class="note-ref" and a full talk-page
+    # URL ending in "#noteN" (e.g. href="/study/general-conference/2024/04/31bowen?lang=eng#note1").
+    # These must be normalized to bare fragment refs ("#noteN") and marked epub:type="noteref"
+    # so e-readers (Apple Books, Kobo, Thorium) can display the footnote as a dismissible popup.
+    # Bare "#noteN" hrefs (from synthetic or pre-normalized content) are also accepted.
+    # All other <a> tags (scripture refs, cross-refs) point outside the EPUB container
+    # (RSC-033, RSC-026) and must be unwrapped.
+    _NOTE_FRAGMENT_RE = re.compile(r"#(note\d+)$")
     for a_tag in soup.find_all("a"):
         href = str(a_tag.get("href") or "")
-        if href.startswith("#note"):
-            # Strip all attrs except href; add EPUB 3 noteref semantics.
-            a_tag.attrs = {"href": href, "epub:type": "noteref"}
+        scroll_id = str(a_tag.get("data-scroll-id") or "")
+        note_id: str | None = None
+        if scroll_id and re.match(r"^note\d+$", scroll_id):
+            # Canonical case: Church note-ref link with data-scroll-id="noteN"
+            note_id = scroll_id
+        elif href.startswith("#note") and re.match(r"^#note\d+$", href):
+            # Pre-normalized bare fragment ref
+            note_id = href[1:]
+        else:
+            # Check for full URL ending in #noteN fragment
+            m = _NOTE_FRAGMENT_RE.search(href)
+            if m and "note-ref" in (a_tag.get("class") or []):
+                note_id = m.group(1)
+        if note_id:
+            a_tag.attrs = {"href": f"#{note_id}", "epub:type": "noteref"}
         else:
             a_tag.unwrap()
 
     # Wrap footnote body elements in <aside epub:type="footnote">.
-    # The Church site uses id="note1", id="note2", etc. on <p> or <div> elements
-    # for the footnote content. Moving the id to the wrapping <aside> satisfies
-    # EPUB 3 structure: the noteref href="#note1" links to the aside, which the
-    # reader renders as a popup.
+    # The Church site uses id="note1", id="note2", etc. on <li> elements inside
+    # footer.notes for the footnote content. Moving the id to the wrapping <aside>
+    # satisfies EPUB 3 structure: the noteref href="#note1" links to the aside, which
+    # the reader renders as a popup.
+    # Only match ids of exactly the form "note" + digits (e.g. "note1", "note12").
+    # Do NOT match "note_title1" (section headings) or "note1_p1" (child elements).
+    _FOOTNOTE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(
-        lambda t: isinstance(t.get("id"), str) and t["id"].startswith("note")
+        lambda t: isinstance(t.get("id"), str) and bool(_FOOTNOTE_ID_RE.match(t["id"]))
     ):
         note_id = str(tag["id"])
         del tag["id"]
@@ -291,14 +309,16 @@ def _sanitize_transcript(
 
     # Strip data-* attributes (React/JS rendering artifacts), random web IDs
     # (e.g., id="p_fvoG6"), and web CSS class names that have no corresponding
-    # rules in the EPUB stylesheet. Preserve id attributes beginning with "note"
-    # (footnote anchors). <img> class attrs are already cleared above.
+    # rules in the EPUB stylesheet. Preserve only footnote anchor ids of the
+    # form "noteN" (e.g., "note1") on <aside> elements. <img> class attrs are
+    # already cleared above.
+    _FOOTNOTE_ASIDE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(True):
         data_attrs = [attr for attr in tag.attrs if attr.startswith("data-")]
         for attr in data_attrs:
             del tag[attr]
         tag_id = tag.get("id")
-        if isinstance(tag_id, str) and not tag_id.startswith("note"):
+        if isinstance(tag_id, str) and not _FOOTNOTE_ASIDE_ID_RE.match(tag_id):
             del tag["id"]
         if "class" in tag.attrs:
             del tag["class"]

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -914,7 +914,7 @@ def build_epub(
                         photo_bytes = _resize_photo(d["photo_src"])
                         zf.writestr(d["photo_epub_href"], photo_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added speaker photo: %s", d["photo_epub_href"])
-                    except Exception as exc:
+                    except (OSError, RuntimeError, ValueError) as exc:
                         logger.warning(
                             "Could not embed speaker photo for %r: %s — skipping",
                             d["talk"].speaker,
@@ -927,7 +927,7 @@ def build_epub(
                         img_bytes = _resize_image(src_path, _MAX_INLINE_WIDTH)
                         zf.writestr(epub_href, img_bytes, compress_type=zipfile.ZIP_STORED)
                         logger.debug("Added inline image: %s", epub_href)
-                    except Exception as exc:
+                    except (OSError, RuntimeError, ValueError) as exc:
                         logger.warning(
                             "Could not embed inline image %s: %s — skipping",
                             src_path.name,

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -18,6 +18,13 @@ from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
 
+# Footnote regex constants — compiled once at module load to avoid per-call overhead.
+# Match the "noteN" fragment at the end of any URL (used to normalize full Church URLs).
+_NOTE_FRAGMENT_RE = re.compile(r"#(note\d+)$")
+# Match a valid footnote anchor id: exactly "note" followed by one or more digits.
+# Excludes "note_title1" (section headings) and "note1_p1" (child paragraph IDs).
+_FOOTNOTE_ID_RE = re.compile(r"^note\d+$")
+
 _COPYRIGHT = (
     "Copyright {year} Intellectual Reserve, Inc. "
     "All rights reserved. For personal, noncommercial use only."
@@ -261,15 +268,14 @@ def _sanitize_transcript(
     # Bare "#noteN" hrefs (from synthetic or pre-normalized content) are also accepted.
     # All other <a> tags (scripture refs, cross-refs) point outside the EPUB container
     # (RSC-033, RSC-026) and must be unwrapped.
-    _NOTE_FRAGMENT_RE = re.compile(r"#(note\d+)$")
     for a_tag in soup.find_all("a"):
         href = str(a_tag.get("href") or "")
         scroll_id = str(a_tag.get("data-scroll-id") or "")
         note_id: str | None = None
-        if scroll_id and re.match(r"^note\d+$", scroll_id):
+        if scroll_id and _FOOTNOTE_ID_RE.match(scroll_id):
             # Canonical case: Church note-ref link with data-scroll-id="noteN"
             note_id = scroll_id
-        elif href.startswith("#note") and re.match(r"^#note\d+$", href):
+        elif href.startswith("#note") and _FOOTNOTE_ID_RE.match(href[1:]):
             # Pre-normalized bare fragment ref
             note_id = href[1:]
         else:
@@ -289,7 +295,6 @@ def _sanitize_transcript(
     # the reader renders as a popup.
     # Only match ids of exactly the form "note" + digits (e.g. "note1", "note12").
     # Do NOT match "note_title1" (section headings) or "note1_p1" (child elements).
-    _FOOTNOTE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(
         lambda t: isinstance(t.get("id"), str) and bool(_FOOTNOTE_ID_RE.match(t["id"]))
     ):
@@ -312,13 +317,12 @@ def _sanitize_transcript(
     # rules in the EPUB stylesheet. Preserve only footnote anchor ids of the
     # form "noteN" (e.g., "note1") on <aside> elements. <img> class attrs are
     # already cleared above.
-    _FOOTNOTE_ASIDE_ID_RE = re.compile(r"^note\d+$")
     for tag in soup.find_all(True):
         data_attrs = [attr for attr in tag.attrs if attr.startswith("data-")]
         for attr in data_attrs:
             del tag[attr]
         tag_id = tag.get("id")
-        if isinstance(tag_id, str) and not _FOOTNOTE_ASIDE_ID_RE.match(tag_id):
+        if isinstance(tag_id, str) and not _FOOTNOTE_ID_RE.match(tag_id):
             del tag["id"]
         if "class" in tag.attrs:
             del tag["class"]

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -126,7 +126,6 @@ nav li {
 aside {
   margin: 1.5em 0 0.5em;
   padding-left: 1em;
-  font-size: 0.85em;
 }
 
 .transcript.numbered {
@@ -138,7 +137,6 @@ aside {
   width: 2em;
   margin-left: -2.5em;
   text-align: right;
-  font-size: 0.8em;
   line-height: inherit;
 }
 """

--- a/src/gencon_audiobook/ffmpeg_manager.py
+++ b/src/gencon_audiobook/ffmpeg_manager.py
@@ -43,7 +43,7 @@ def _get_version(binary: Path) -> str:
         )
         first_line = result.stdout.splitlines()[0] if result.stdout else "unknown"
         return first_line
-    except Exception as exc:
+    except (OSError, subprocess.SubprocessError) as exc:
         logger.debug("Could not get version for %s: %s", binary, exc)
         return "unknown"
 
@@ -91,7 +91,7 @@ def ensure_ffmpeg() -> Path:
             logger.info("Downloaded ffmpeg to %s (%s)", path, version)
             _ffmpeg_path = path
             return _ffmpeg_path
-    except Exception as exc:
+    except (AttributeError, ImportError, OSError, RuntimeError) as exc:
         logger.debug("static-ffmpeg failed: %s", exc)
 
     raise FfmpegNotFoundError(_INSTALL_INSTRUCTIONS)

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from rich.progress import Task, TimeRemainingColumn
+from rich.progress import MofNCompleteColumn, Task, TimeRemainingColumn
 from rich.text import Text
 
 
@@ -14,3 +14,19 @@ class TimeRemainingWithLabel(TimeRemainingColumn):
         if text.plain.strip() and text.plain.strip() not in ("--:--", "-:--:--"):
             text.append(" remaining")
         return text
+
+
+class ConditionalMofNColumn(MofNCompleteColumn):
+    """MofNCompleteColumn that can be hidden per-task via a task field.
+
+    If the task's ``show_count`` field is False, renders blank padding of the
+    same width so columns remain aligned across tasks.
+    """
+
+    def render(self, task: Task) -> Text:
+        if not task.fields.get("show_count", True):
+            total = int(task.total) if task.total is not None else 1
+            total_width = len(str(total))
+            # Width matches f"{completed:{total_width}d}/{total}": 2*total_width + 1
+            return Text(" " * (2 * total_width + 1))
+        return super().render(task)

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -1,8 +1,17 @@
-"""Shared Rich progress column customizations."""
+"""Shared Rich progress column customizations and progress bar factory."""
 
 from __future__ import annotations
 
-from rich.progress import Task, TimeRemainingColumn
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    Task,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
 from rich.text import Text
 
 
@@ -14,3 +23,37 @@ class TimeRemainingWithLabel(TimeRemainingColumn):
         if text.plain.strip() and text.plain.strip() not in ("--:--", "-:--:--"):
             text.append(" remaining")
         return text
+
+
+class ConditionalMofNColumn(MofNCompleteColumn):
+    """MofNCompleteColumn that can be hidden per-task via a task field.
+
+    If the task's ``show_count`` field is False, renders blank padding of the
+    same width so columns remain aligned across tasks.
+    """
+
+    def render(self, task: Task) -> Text:
+        if not task.fields.get("show_count", True):
+            total = int(task.total) if task.total is not None else 1
+            total_width = len(str(total))
+            # Width matches f"{completed:{total_width}d}/{total}": 2*total_width + 1
+            return Text(" " * (2 * total_width + 1))
+        return super().render(task)
+
+
+def standard_progress() -> Progress:
+    """Return a Progress bar with the standard project column layout.
+
+    All full-width progress bars (scrape, download, convert) use this factory
+    so their columns are identical and visually aligned.
+
+    Column order: spinner | N/M count | bar | percent | time remaining | description
+    """
+    return Progress(
+        SpinnerColumn(),
+        ConditionalMofNColumn(),
+        BarColumn(),
+        TaskProgressColumn(),
+        TimeRemainingWithLabel(compact=True),
+        TextColumn("[progress.description]{task.description}"),
+    )

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from rich.console import Console
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -13,6 +14,11 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 from rich.text import Text
+
+# Single shared console used by all progress bars AND the RichHandler in cli.py.
+# When Progress and RichHandler share the same Console, Rich correctly interleaves
+# log messages above the live progress bar instead of clobbering the same line.
+shared_console = Console()
 
 
 class TimeRemainingWithLabel(TimeRemainingColumn):
@@ -56,4 +62,5 @@ def standard_progress() -> Progress:
         TaskProgressColumn(),
         TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
+        console=shared_console,
     )

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -538,9 +538,17 @@ def parse_conference_listing(html: str) -> list[Session]:
 
 
 def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
-    """Extract sessions from __INITIAL_STATE__ for the conference listing page."""
+    """Extract sessions from __INITIAL_STATE__ for the conference listing page.
+
+    Older conferences (pre-2020) have duplicate sections in the JSON: the real
+    sessions appear first, then a second set of unnamed sections that repeat the
+    same talks with a session landing page prepended. We deduplicate by tracking
+    seen talk URLs — any entry whose URL was already claimed by an earlier session
+    is skipped, and sections that produce zero new talks are dropped entirely.
+    """
     library = state.get("library", {})
     sessions: list[Session] = []
+    seen_urls: set[str] = set()
 
     # Find the library key that matches a conference listing URL
     for key, value in library.items():
@@ -555,10 +563,13 @@ def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
                 # Skip entries that don't look like conference sub-pages
                 if not _CONF_URL_RE.search(uri):
                     continue
+                talk_url = urljoin(_BASE_URL, uri.split("?")[0])
+                if talk_url in seen_urls:
+                    continue
                 title = entry.get("title", "")
                 speaker = entry.get("subtitle", "") or entry.get("author", "")
-                talk_url = urljoin(_BASE_URL, uri.split("?")[0])
                 if title:
+                    seen_urls.add(talk_url)
                     talks.append(Talk(title=title, speaker=speaker, talk_url=talk_url))
             if talks:
                 sessions.append(Session(name=name, number=i, talks=talks))

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -660,6 +660,14 @@ def _sessions_from_html(html: str) -> list[Session]:
         if isinstance(sub_ul, Tag) and sub_ul.find("a", href=_CONF_URL_RE):
             session_lis.append(li)
 
+    # Track session LIs by object identity so we can skip nested ones when
+    # iterating talks. Older conferences have 3-level nesting: an outer grouping
+    # <li> whose sub-<ul> contains session <li>s, each of which has a sub-<ul>
+    # of actual talks. Without this guard, the outer grouping treats each inner
+    # session <li>'s heading link as a "talk", producing bogus Talk objects for
+    # session landing pages.
+    session_li_ids: set[int] = {id(li) for li in session_lis}
+
     sessions: list[Session] = []
     session_number = 0
 
@@ -685,6 +693,9 @@ def _sessions_from_html(html: str) -> list[Session]:
 
             talks: list[Talk] = []
             for talk_li in sub_ul.find_all("li", recursive=False):
+                # Skip nested session LIs — they are processed in their own iteration.
+                if id(talk_li) in session_li_ids:
+                    continue
                 talk_a = talk_li.find("a", href=_CONF_URL_RE)
                 if not talk_a:
                     continue

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -15,17 +15,9 @@ from urllib.robotparser import RobotFileParser
 import requests
 from bs4 import BeautifulSoup, Tag
 from rich.console import Console
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TaskProgressColumn,
-    TextColumn,
-)
 
 from .models import Conference, InlineImage, Session, Talk
-from .progress import TimeRemainingWithLabel
+from .progress import standard_progress
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
@@ -953,14 +945,7 @@ def scrape_conference(conference_url: str) -> Conference:
     skipped: list[Talk] = []
 
     console.print(f"Scraping: {title}")
-    scrape_progress = Progress(
-        SpinnerColumn(),
-        MofNCompleteColumn(),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeRemainingWithLabel(compact=True),
-        TextColumn("[progress.description]{task.description}"),
-    )
+    scrape_progress = standard_progress()
     with scrape_progress:
         task = scrape_progress.add_task("Scraping talks", total=len(all_talks))
         for i, talk in enumerate(all_talks, start=1):

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -16,7 +16,8 @@ import requests
 from bs4 import BeautifulSoup, Tag
 
 from .models import Conference, InlineImage, Session, Talk
-from .progress import shared_console as console, standard_progress
+from .progress import shared_console as console
+from .progress import standard_progress
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
@@ -100,7 +101,7 @@ def _get_robots(http: requests.Session, base_url: str) -> RobotFileParser | None
         parser.parse(response.text.splitlines())
         _robots_cache[base_url] = parser
         logger.debug("Fetched robots.txt from %s", robots_url)
-    except Exception as exc:
+    except (requests.RequestException, OSError) as exc:
         logger.warning("Could not fetch robots.txt from %s: %s — proceeding anyway", robots_url, exc)
         _robots_cache[base_url] = None
 
@@ -327,7 +328,7 @@ def _parse_initial_state(html: str) -> dict[str, Any]:
         try:
             json_bytes = base64.b64decode(match.group(1))
             return cast(dict[str, Any], json.loads(json_bytes))
-        except Exception as exc:
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
             logger.debug("Failed to base64-decode __INITIAL_STATE__: %s", exc)
 
     # Fallback: raw JSON object (some pages may not encode it)

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -68,12 +68,14 @@ def _upgrade_iiif(url: str) -> str:
     url = re.sub(r"/full/!\d+,/", "/full/!800,/", url)
     return url
 
-# Matches /study/general-conference/YYYY/MM/talk-id (individual talk URL).
-# Modern talk slugs use a numeric-prefix + speaker-name format with no hyphens
-# (e.g., "11oaks", "12christofferson"). Session-level links DO contain hyphens
-# (e.g., "saturday-morning-session") and must be excluded — [a-z0-9]+ achieves
-# this. Verified against fixture data; the weekly live test monitors for changes.
-_TALK_URL_RE = re.compile(r"/study/general-conference/\d{4}/\d{2}/[a-z0-9]+(?:\?|$)", re.IGNORECASE)
+# Matches any /study/general-conference/YYYY/MM/slug URL — talk and session links
+# alike. The character class [a-z0-9][-a-z0-9]* covers modern unhyphenated slugs
+# ("11oaks") and older hyphenated ones ("the-work-moves-forward"). Talk vs.
+# session is determined by DOM position in _sessions_from_html, not URL pattern.
+_CONF_URL_RE = re.compile(
+    r"/study/general-conference/\d{4}/\d{2}/[a-z0-9][-a-z0-9]*(?:\?|$)",
+    re.IGNORECASE,
+)
 
 
 # Cache of parsed RobotFileParser objects, keyed by scheme+host (e.g. "https://www.churchofjesuschrist.org")
@@ -558,8 +560,8 @@ def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
             talks: list[Talk] = []
             for entry in section.get("entries", []):
                 uri = entry.get("uri", "")
-                # Skip non-talk entries (e.g., session-level links)
-                if not _TALK_URL_RE.search(uri):
+                # Skip entries that don't look like conference sub-pages
+                if not _CONF_URL_RE.search(uri):
                     continue
                 title = entry.get("title", "")
                 speaker = entry.get("subtitle", "") or entry.get("author", "")
@@ -649,12 +651,12 @@ def _sessions_from_html(html: str) -> list[Session]:
     """
     soup = BeautifulSoup(html, "html.parser")
 
-    talk_links = soup.find_all("a", href=_TALK_URL_RE)
-    if not talk_links:
+    conf_links = soup.find_all("a", href=_CONF_URL_RE)
+    if not conf_links:
         return []
 
-    # Walk up: talk_a -> talk_li -> inner_ul -> session_li -> outer_ul
-    inner_ul = talk_links[0].find_parent("ul")
+    # Walk up: conf_a -> talk_li -> inner_ul -> session_li -> outer_ul
+    inner_ul = conf_links[0].find_parent("ul")
     if not inner_ul:
         return []
     session_li = inner_ul.parent
@@ -670,19 +672,23 @@ def _sessions_from_html(html: str) -> list[Session]:
                 # "Contents" or other non-session entry — skip
                 continue
 
-            # Session name: first <a> that is NOT a talk link
+            # Session name: direct-child <a> of the session <li> (the session heading link).
+            # URL matching is not used — all conf URLs look alike; DOM position distinguishes
+            # session <li> from talk <li>. Fall back to <h4> for older HTML that uses headings.
             session_name: str | None = None
             for a in li.find_all("a", recursive=False):
-                if not _TALK_URL_RE.search(a.get("href", "")):
-                    session_name = a.get_text(strip=True)
-                    break
-
+                session_name = a.get_text(strip=True)
+                break
+            if not session_name:
+                h4 = li.find("h4", recursive=False)
+                if isinstance(h4, Tag):
+                    session_name = h4.get_text(strip=True)
             if not session_name:
                 session_name = f"Session {session_number + 1}"
 
             talks: list[Talk] = []
             for talk_li in sub_ul.find_all("li", recursive=False):
-                talk_a = talk_li.find("a", href=_TALK_URL_RE)
+                talk_a = talk_li.find("a", href=_CONF_URL_RE)
                 if not talk_a:
                     continue
                 title = _extract_talk_title(talk_a)
@@ -699,7 +705,7 @@ def _sessions_from_html(html: str) -> list[Session]:
     if not sessions:
         logger.warning("No session structure detected; grouping all talks under one session")
         all_talks: list[Talk] = []
-        for a in talk_links:
+        for a in conf_links:
             title = _extract_talk_title(a)
             speaker = _extract_talk_speaker(a)
             if title:

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -529,7 +529,7 @@ def parse_conference_listing(html: str) -> list[Session]:
 
     # Fallback: HTML traversal
     if not sessions:
-        logger.warning("Listing JSON selector found nothing; falling back to HTML traversal")
+        logger.debug("Listing JSON selector found nothing; falling back to HTML traversal")
         sessions = _sessions_from_html(html)
         if sessions:
             logger.debug("Listing HTML fallback: %d sessions", len(sessions))

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -797,7 +797,17 @@ def parse_talk_page(html: str, talk_url: str) -> dict:
     # Transcript — primary: div.body-block
     body = soup.find("div", class_="body-block")
     if body:
-        result["transcript_html"] = str(body)
+        transcript_parts = [str(body)]
+        # The Church site places footnote bodies in <footer class="notes">, which is a
+        # sibling of div.body-block, not inside it. Append its HTML so the EPUB builder
+        # has the note bodies it needs to render footnotes. Guard against duplication:
+        # only append when the primary selector (not the article fallback) was used,
+        # since article fallbacks already capture the full article including the footer.
+        notes_footer = soup.find("footer", class_="notes")
+        if notes_footer:
+            transcript_parts.append(str(notes_footer))
+            logger.debug("transcript: appended footer.notes (%d chars)", len(str(notes_footer)))
+        result["transcript_html"] = "".join(transcript_parts)
         logger.debug("transcript (primary div.body-block): %d chars", len(result["transcript_html"] or ""))
 
     if not result["transcript_html"]:

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -14,14 +14,12 @@ from urllib.robotparser import RobotFileParser
 
 import requests
 from bs4 import BeautifulSoup, Tag
-from rich.console import Console
 
 from .models import Conference, InlineImage, Session, Talk
-from .progress import standard_progress
+from .progress import shared_console as console, standard_progress
 from .utils import USER_AGENT, validate_url
 
 logger = logging.getLogger(__name__)
-console = Console()
 
 _BASE_URL = "https://www.churchofjesuschrist.org"
 _ARCHIVE_PATH = "/study/general-conference"
@@ -677,14 +675,6 @@ def _sessions_from_html(html: str) -> list[Session]:
         if isinstance(sub_ul, Tag) and sub_ul.find("a", href=_CONF_URL_RE):
             session_lis.append(li)
 
-    # Track session LIs by object identity so we can skip nested ones when
-    # iterating talks. Older conferences have 3-level nesting: an outer grouping
-    # <li> whose sub-<ul> contains session <li>s, each of which has a sub-<ul>
-    # of actual talks. Without this guard, the outer grouping treats each inner
-    # session <li>'s heading link as a "talk", producing bogus Talk objects for
-    # session landing pages.
-    session_li_ids: set[int] = {id(li) for li in session_lis}
-
     sessions: list[Session] = []
     session_number = 0
 
@@ -706,13 +696,13 @@ def _sessions_from_html(html: str) -> list[Session]:
                 if isinstance(h4, Tag):
                     session_name = h4.get_text(strip=True)
             if not session_name:
-                session_name = f"Session {session_number + 1}"
+                # Unnamed session LIs are duplicates — the site renders each session twice:
+                # once with a direct-child <a> holding the name, once with a <div> and no name.
+                # Skip the unnamed copies.
+                continue
 
             talks: list[Talk] = []
             for talk_li in sub_ul.find_all("li", recursive=False):
-                # Skip nested session LIs — they are processed in their own iteration.
-                if id(talk_li) in session_li_ids:
-                    continue
                 talk_a = talk_li.find("a", href=_CONF_URL_RE)
                 if not talk_a:
                     continue

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -556,7 +556,13 @@ def _sessions_from_state(state: dict[str, Any]) -> list[Session]:
             continue
         raw_sections = value.get("sections", [])
         for i, section in enumerate(raw_sections, start=1):
-            name = section.get("title", f"Session {i}")
+            name = section.get("title")
+            if not name:
+                # Older conferences have unnamed duplicate sections that repeat
+                # every talk from a named session plus a session landing page.
+                # Skip them — real sessions always have titles in the JSON.
+                logger.debug("Skipping unnamed JSON section %d (likely duplicate)", i)
+                continue
             talks: list[Talk] = []
             for entry in section.get("entries", []):
                 uri = entry.get("uri", "")

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -622,24 +622,24 @@ def _sessions_from_html(html: str) -> list[Session]:
 
     Observed structure on the Church website (CSS-module class names may change):
 
-        outer_ul
-          <li>Contents link (no sub-ul, skip)</li>
-          <li>                                     <- session LI
-            <a class="sectionTitle-*">Saturday Morning Session</a>
-            inner_ul                               <- talks for this session
-              <li>
-                <a href="/study/general-conference/YYYY/MM/talk-id">
-                  <div class="itemTitle-*">
-                    <p>Talk Title</p>
-                    <p class="subtitle-*">Speaker Name</p>
-                  </div>
-                </a>
-              </li>
-              ...
-          </li>
-          ...
+        <li>                                     <- session LI
+          <a class="sectionTitle-*">Saturday Morning Session</a>
+          <ul>                                   <- talks for this session
+            <li>
+              <a href="/study/general-conference/YYYY/MM/talk-id">
+                <div class="itemTitle-*">
+                  <p>Talk Title</p>
+                  <p class="subtitle-*">Speaker Name</p>
+                </div>
+              </a>
+            </li>
+            ...
+          </ul>
+        </li>
 
-    Navigate to the outer UL by walking up from the first talk link.
+    Session <li> elements are identified by having a direct-child <ul> that contains
+    at least one conference link. This approach works across conference eras without
+    needing to bootstrap a walk from a specific link position.
     """
     soup = BeautifulSoup(html, "html.parser")
 
@@ -647,21 +647,26 @@ def _sessions_from_html(html: str) -> list[Session]:
     if not conf_links:
         return []
 
-    # Walk up: conf_a -> talk_li -> inner_ul -> session_li -> outer_ul
-    inner_ul = conf_links[0].find_parent("ul")
-    if not inner_ul:
-        return []
-    session_li = inner_ul.parent
-    outer_ul = session_li.parent if session_li and session_li.name == "li" else None
+    # Find session <li> elements directly: a <li> is a session if it has a
+    # direct-child <ul> that contains at least one conference link.
+    # Bootstrapping from conf_links[0] fails for older conferences where the
+    # first link in document order is a session landing page (in the outer UL),
+    # not a talk (in the inner UL).
+    session_lis: list[Tag] = []
+    for li in soup.find_all("li"):
+        if not isinstance(li, Tag):
+            continue
+        sub_ul = li.find("ul", recursive=False)
+        if isinstance(sub_ul, Tag) and sub_ul.find("a", href=_CONF_URL_RE):
+            session_lis.append(li)
 
     sessions: list[Session] = []
     session_number = 0
 
-    if outer_ul and outer_ul.name in ("ul", "ol"):
-        for li in outer_ul.find_all("li", recursive=False):
-            sub_ul = li.find("ul")
-            if not sub_ul:
-                # "Contents" or other non-session entry — skip
+    if session_lis:
+        for li in session_lis:
+            sub_ul = li.find("ul", recursive=False)
+            if not isinstance(sub_ul, Tag):
                 continue
 
             # Session name: direct-child <a> of the session <li> (the session heading link).
@@ -980,7 +985,7 @@ def scrape_conference(conference_url: str) -> Conference:
                     missing.append("mp3_url")
 
                 if missing:
-                    logger.error(
+                    logger.warning(
                         "Talk at %s missing required fields: %s — skipping",
                         talk.talk_url,
                         ", ".join(missing),

--- a/src/gencon_audiobook/utils.py
+++ b/src/gencon_audiobook/utils.py
@@ -98,6 +98,6 @@ def validate_url(url: str) -> bool:
         if not result:
             logger.debug("URL rejected by allowlist: %s", url)
         return result
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         logger.debug("URL validation failed (malformed URL): %s", url)
         return False

--- a/tests/fixtures/talk_page_with_notes.html
+++ b/tests/fixtures/talk_page_with_notes.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"/><title>Test Talk With Notes</title></head>
+<body>
+<article data-content-type="general-conference">
+  <header>
+    <h1 class="title">Miracles, Angels, and Priesthood Power</h1>
+    <p class="author-name">By Elder Shayne M. Bowen</p>
+    <div class="lumen-tile__image">
+      <img src="https://www.churchofjesuschrist.org/imgs/spkr-bowen/full/320/0/default" alt="Shayne M. Bowen"/>
+    </div>
+  </header>
+  <div class="body-block">
+    <p data-aid="159162981" id="p1">Many today say that miracles no longer exist, that angels are fictional, and that the heavens are closed. I testify that miracles have not ceased, angels are among us, and the heavens are truly open.</p>
+    <p data-aid="159162987" id="p2">When our Savior, Jesus Christ, was on the earth, He gave priesthood keys to His chief Apostle, Peter.<a class="note-ref" data-scroll-id="note1" href="/study/general-conference/2024/04/31bowen?lang=eng#note1"><sup class="marker" data-value="1"></sup></a> Through these keys, Peter and the other Apostles led the Savior's Church.</p>
+    <p data-aid="159162993" id="p3">Peter, James, and John and other ancient prophets appeared as resurrected beings, bestowing upon the Prophet Joseph Smith what the Lord described as "the keys of my kingdom, and a dispensation of the gospel."<a class="note-ref" data-scroll-id="note2" href="/study/general-conference/2024/04/31bowen?lang=eng#note2"><sup class="marker" data-value="2"></sup></a></p>
+    <p data-aid="159163134" id="p26">I testify that the holy priesthood with its keys, authority, and power has been restored to the earth in our day. In the name of Jesus Christ, amen.</p>
+  </div>
+  <footer class="notes">
+    <p class="title" data-aid="159163161" id="note_title1">Notes</p>
+    <ol class="decimal" data-type="marker" start="1">
+      <li data-marker="1." id="note1" data-full-marker="1.">
+        <p data-aid="159163167" id="note1_p1">See <a class="scripture-ref" href="/study/scriptures/nt/matt/16?lang=eng&amp;id=p17-p19#p17">Matthew 16:17&#x2013;19</a>; <a class="scripture-ref" href="/study/scriptures/dc-testament/dc/128?lang=eng&amp;id=p18,21#p18">Doctrine and Covenants 128:18, 21</a>.</p>
+      </li>
+      <li data-marker="2." id="note2" data-full-marker="2.">
+        <p data-aid="159163174" id="note2_p1">See <a class="scripture-ref" href="/study/scriptures/dc-testament/dc/27?lang=eng&amp;id=p12-p13#p12">Doctrine and Covenants 27:12&#x2013;13</a>.</p>
+      </li>
+    </ol>
+  </footer>
+</article>
+<div class="player-component">
+  <video>
+    <source src="https://assets.churchofjesuschrist.org/31bowen-32k-en.mp3" type="audio/mpeg"/>
+  </video>
+</div>
+</body>
+</html>

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -534,8 +534,7 @@ def test_run_ffmpeg_with_progress_parses_out_time() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter(stdout_lines)
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = ""
+    mock_proc.stderr = iter([])  # iterable — drained by stderr thread
     mock_proc.returncode = 0
     mock_proc.poll.return_value = 0
 
@@ -564,8 +563,7 @@ def test_run_ffmpeg_with_progress_nonzero_exit() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter(["progress=end\n"])
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = "some ffmpeg error"
+    mock_proc.stderr = iter(["some ffmpeg error\n"])  # iterable — drained by stderr thread
     mock_proc.returncode = 1
     mock_proc.poll.return_value = 1
 
@@ -587,8 +585,7 @@ def test_run_ffmpeg_with_progress_watchdog_kills_hung_process() -> None:
 
     mock_proc = MagicMock()
     mock_proc.stdout = iter([])  # EOF immediately so the readline loop exits
-    mock_proc.stderr = MagicMock()
-    mock_proc.stderr.read.return_value = ""
+    mock_proc.stderr = iter([])  # iterable — drained by stderr thread
     mock_proc.returncode = -9
     mock_proc.poll.return_value = None  # process appears still running when watchdog fires
 
@@ -613,3 +610,32 @@ def test_run_ffmpeg_with_progress_watchdog_kills_hung_process() -> None:
                 progress=progress,
                 task_id=0,  # type: ignore[arg-type]
             )
+
+
+def test_run_ffmpeg_with_progress_noisy_stderr_does_not_deadlock() -> None:
+    """ffmpeg writing large amounts of stderr should not deadlock.
+
+    Previously, stderr was piped but never read, causing the OS pipe buffer
+    (4KB on Windows) to fill and deadlock both processes.
+    """
+    from unittest.mock import MagicMock, patch
+
+    # Simulate lots of stderr output (well beyond OS pipe buffer)
+    noisy_stderr = ["WARNING: something suspicious\n"] * 500
+
+    mock_proc = MagicMock()
+    mock_proc.stdout = iter(["out_time_us=1000000\n", "progress=end\n"])
+    mock_proc.stderr = iter(noisy_stderr)
+    mock_proc.returncode = 0
+    mock_proc.poll.return_value = 0
+
+    progress = MagicMock()
+    with patch("subprocess.Popen", return_value=mock_proc):
+        # Should complete without hanging
+        _run_ffmpeg_with_progress(
+            ["ffmpeg", "-i", "in.mp3", "out.m4a"],
+            label="test",
+            source_duration_s=5.0,
+            progress=progress,
+            task_id=0,  # type: ignore[arg-type]
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,8 +252,9 @@ def test_disk_space_warning_printed(tmp_path: Path) -> None:
         runner = CliRunner()
         result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
 
-    assert "500 MB" in result.output, "Disk space warning should mention 500 MB threshold"
-    assert "100 MB" in result.output, "Disk space warning should show available space"
+    normalized_output = " ".join(result.output.split())
+    assert "500 MB" in normalized_output, "Disk space warning should mention 500 MB threshold"
+    assert "100 MB" in normalized_output, "Disk space warning should show available space"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,14 +163,11 @@ def test_defaults_to_most_recent_conference(tmp_path: Path) -> None:
 
 
 def test_conference_filter_selects_matching(tmp_path: Path) -> None:
-    refs = [
-        _make_ref("April 2024 General Conference", 2024, 4),
-        _make_ref("October 2023 General Conference", 2023, 10),
-    ]
+    """YYYY-MM format constructs the URL directly without fetching the listing."""
     conference = _make_conference("October 2023 General Conference")
 
     with (
-        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
+        patch("gencon_audiobook.cli.fetch_available_conferences") as mock_listing,
         patch("gencon_audiobook.cli.scrape_conference", return_value=conference) as mock_scrape,
         patch("gencon_audiobook.cli.download_conference"),
         patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
@@ -179,24 +176,53 @@ def test_conference_filter_selects_matching(tmp_path: Path) -> None:
     ):
         runner = CliRunner()
         result = runner.invoke(
-            main, ["--output", str(tmp_path), "--audiobook-only", "--conference", "October 2023"]
+            main, ["--output", str(tmp_path), "--audiobook-only", "--conference", "2023-10"]
         )
 
     assert result.exit_code == 0, result.output
+    mock_listing.assert_not_called()
     called_url = mock_scrape.call_args[0][0]
-    assert "2023/10" in called_url
+    assert "2023/10" in called_url, f"Expected 2023/10 in URL, got: {called_url}"
 
 
 def test_conference_filter_no_match_exits_nonzero(tmp_path: Path) -> None:
-    refs = [_make_ref("April 2024 General Conference")]
-
-    with patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs):
-        runner = CliRunner()
-        result = runner.invoke(
-            main, ["--output", str(tmp_path), "--conference", "Nonexistent 1800"]
-        )
+    """Invalid YYYY-MM format exits with a non-zero code."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--output", str(tmp_path), "--conference", "Nonexistent 1800"]
+    )
 
     assert result.exit_code != 0
+
+
+def test_conference_filter_invalid_format_exits_nonzero(tmp_path: Path) -> None:
+    """Month-first or free-text format is rejected with a clear error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main, ["--output", str(tmp_path), "--conference", "april-2024"]
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid conference format" in result.output, result.output
+
+
+def test_conference_direct_url_skips_listing_fetch(tmp_path: Path) -> None:
+    """When --conference YYYY-MM is given, fetch_available_conferences is never called."""
+    conference = _make_conference("April 2024 General Conference")
+
+    with (
+        patch("gencon_audiobook.cli.fetch_available_conferences") as mock_listing,
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.download_conference"),
+        patch("gencon_audiobook.cli.build_epub"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["--output", str(tmp_path), "--epub-only", "--conference", "2024-04"]
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_listing.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -485,28 +511,6 @@ def test_epub_summary_line_printed(tmp_path: Path) -> None:
     assert ".epub" in result.output, \
         f"EPUB filename should appear in the completion summary: {result.output!r}"
 
-
-def test_conference_filter_is_case_insensitive(tmp_path: Path) -> None:
-    """The --conference filter must match case-insensitively.
-
-    Users will naturally type 'april 2024' instead of 'April 2024'.
-    """
-    refs = [_make_ref("April 2024 General Conference", 2024, 4)]
-    conference = _make_conference()
-
-    with (
-        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
-        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
-        patch("gencon_audiobook.cli.download_conference"),
-        patch("gencon_audiobook.cli.build_epub"),
-    ):
-        runner = CliRunner()
-        result = runner.invoke(
-            main, ["--output", str(tmp_path), "--epub-only", "--conference", "april 2024"]
-        )
-
-    assert result.exit_code == 0, \
-        f"Lowercase --conference filter should match; got exit {result.exit_code}: {result.output}"
 
 
 def test_log_file_created_in_output_dir(tmp_path: Path) -> None:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 from gencon_audiobook.downloader import (
     DownloadError,
+    DownloadResult,
     _audio_path,
     _speaker_path,
     cleanup_tmp_files,
@@ -61,8 +62,9 @@ def test_download_file_success(tmp_path: Path) -> None:
     rsps_lib.add(rsps_lib.GET, _ALLOWED_URL, body=content, status=200)
 
     dest = tmp_path / "audio" / "001-test.mp3"
-    download_file(_ALLOWED_URL, dest, _make_session())
+    result = download_file(_ALLOWED_URL, dest, _make_session())
 
+    assert result is True, "download_file should return True when file is downloaded"
     assert dest.exists(), "Destination file should exist after download"
     assert dest.read_bytes() == content, "Destination content should match server response"
     assert not dest.with_suffix(dest.suffix + ".tmp").exists(), ".tmp file should be cleaned up"
@@ -91,8 +93,9 @@ def test_download_file_skips_existing(tmp_path: Path) -> None:
     dest = tmp_path / "001-test.mp3"
     dest.write_bytes(content)  # pre-existing correct file
 
-    download_file(_ALLOWED_URL, dest, _make_session())
+    result = download_file(_ALLOWED_URL, dest, _make_session())
 
+    assert result is False, "download_file should return False when file is skipped"
     get_calls = [c for c in rsps_lib.calls if c.request.method == "GET"]
     assert len(get_calls) == 0, "GET should not be issued when file is already complete"
 
@@ -335,6 +338,43 @@ def test_download_conference_audio_downloaded_by_default(tmp_path: Path) -> None
     mp3 = tmp_path / "audio" / "001-Test-Talk.mp3"
     assert mp3.exists(), \
         f"MP3 should be downloaded by default (skip_audio=False); expected {mp3}"
+
+
+@rsps_lib.activate
+def test_download_conference_returns_download_result(tmp_path: Path) -> None:
+    """download_conference() returns a DownloadResult with accurate counts."""
+    rsps_lib.add(rsps_lib.GET, _COVER_URL, body=_jpeg_bytes(), status=200)
+    rsps_lib.add(rsps_lib.GET, _PHOTO_URL, body=_jpeg_bytes(), status=200)
+    rsps_lib.add(rsps_lib.GET, _MP3_URL, body=_small_mp3(), status=200)
+
+    conference = _make_single_talk_conference()
+    result = download_conference(conference, tmp_path, delay=0, skip_audio=False)
+
+    assert isinstance(result, DownloadResult), "download_conference must return a DownloadResult"
+    assert result.failed_talks == [], "No talks should fail when all downloads succeed"
+    assert result.downloaded == 3, f"Expected 3 downloaded, got {result.downloaded}"
+    assert result.skipped == 0, f"Expected 0 skipped, got {result.skipped}"
+
+
+@rsps_lib.activate
+def test_download_conference_skips_silently_when_all_exist(tmp_path: Path) -> None:
+    """When all destination files already exist, no HTTP requests are made and no progress bar shown."""
+    conference = _make_single_talk_conference()
+
+    # Pre-create all destination files so the pre-scan short-circuits
+    (tmp_path / "cover.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "speakers").mkdir()
+    (tmp_path / "speakers" / "001-Test-Speaker.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "audio").mkdir()
+    (tmp_path / "audio" / "001-Test-Talk.mp3").write_bytes(_small_mp3())
+
+    result = download_conference(conference, tmp_path, delay=0, skip_audio=False)
+
+    assert result.downloaded == 0, "No files should be downloaded when all already exist"
+    assert result.skipped == 3, f"Expected 3 skipped, got {result.skipped}"
+    assert result.failed_talks == [], "No talks should fail on a fully-cached run"
+    # No HTTP calls — the pre-scan returns early before touching the network
+    assert len(rsps_lib.calls) == 0, "No HTTP requests should be made when all files exist"
 
 
 @rsps_lib.activate

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -569,15 +569,15 @@ def test_build_epub_css_has_no_font_family(tmp_path: Path) -> None:
         "CSS must not contain font-family declarations"
 
 
-def test_build_epub_css_has_no_absolute_font_sizes(tmp_path: Path) -> None:
+def test_build_epub_css_has_no_font_size_declarations(tmp_path: Path) -> None:
     conference = _make_conference(n_talks=2)
     output = tmp_path / "test.epub"
     build_epub(conference, tmp_path, output)
     css = _epub_read(output, "style.css").decode("utf-8")
     css_no_comments = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
-    # Absolute units: px, pt, cm, mm, in, pc
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", css_no_comments), \
-        "CSS must not use absolute font-size units (px, pt, cm, mm, in, pc)"
+    # font-size of any unit is banned — defer text sizing entirely to the reader
+    assert not re.search(r"\bfont-size\s*:", css_no_comments), \
+        "CSS must not contain any font-size declarations (any unit)"
 
 
 # ---------------------------------------------------------------------------
@@ -1135,5 +1135,5 @@ def test_build_epub_css_para_num_theme_safe(tmp_path: Path) -> None:
     assert not re.search(r"\bcolor\s*:", block), ".para-num must not set color"
     assert not re.search(r"\bbackground(-color)?\s*:", block), ".para-num must not set background"
     assert not re.search(r"\bfont-family\s*:", block), ".para-num must not set font-family"
-    assert not re.search(r"\bfont-size\s*:[^;]*\d(px|pt|cm|mm|in|pc)\b", block), \
-        ".para-num must not use absolute font-size units"
+    assert not re.search(r"\bfont-size\s*:", block), \
+        ".para-num must not contain any font-size declaration (any unit)"

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -185,6 +185,65 @@ def test_sanitize_transcript_noteref_link_preserved_with_epub_type() -> None:
     assert "<sup" in result, "Superscript inside noteref must be preserved"
 
 
+def test_sanitize_transcript_real_noteref_url_normalized() -> None:
+    """Church note-ref links use full talk-page URLs ending in #noteN, not bare fragments.
+
+    A link like href="/study/general-conference/2024/04/31bowen?lang=eng#note1" with
+    class="note-ref" and data-scroll-id="note1" must be normalized to href="#note1"
+    and marked as epub:type="noteref". The existing href-fragment check does not handle
+    this case — it only matches bare "#note" prefixes.
+    """
+    html = (
+        '<p>Priesthood keys.<a class="note-ref" '
+        'data-scroll-id="note1" '
+        'href="/study/general-conference/2024/04/31bowen?lang=eng#note1">'
+        '<sup class="marker" data-value="1"></sup></a></p>'
+    )
+    result = _sanitize_transcript(html)
+    assert 'href="#note1"' in result, (
+        f"Full URL note-ref must be normalized to bare fragment, got: {result!r}"
+    )
+    assert 'epub:type="noteref"' in result, (
+        f"epub:type noteref must be added to normalized note-ref, got: {result!r}"
+    )
+
+
+def test_sanitize_transcript_li_footnote_body_wrapped_in_aside() -> None:
+    """Real Church footnote bodies use <li id='noteN'>, not <p id='noteN'>.
+
+    The EPUB builder must wrap <li id="noteN"> in <aside epub:type="footnote"> just
+    as it does for <p id="noteN"> shapes, since the real site uses list items.
+    """
+    html = (
+        '<ol><li id="note1">'
+        '<p>See <a href="/study/scriptures/nt/matt/16">Matthew 16:17</a>.</p>'
+        '</li></ol>'
+    )
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote" id="note1">' in result, (
+        f"<li id='note1'> must become <aside epub:type='footnote' id='note1'>, got: {result!r}"
+    )
+    assert "Matthew 16:17" in result, "Footnote body text must survive wrapping"
+
+
+def test_sanitize_transcript_note_title_id_not_wrapped() -> None:
+    """id='note_title1' is a section heading, not a footnote body — must not be wrapped."""
+    html = '<p id="note_title1">Notes</p>'
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote"' not in result, (
+        f"note_title* id must not produce a footnote aside, got: {result!r}"
+    )
+
+
+def test_sanitize_transcript_child_note_id_not_wrapped() -> None:
+    """id='note1_p1' is a child element ID, not a footnote body — must not be wrapped."""
+    html = '<p id="note1_p1">Child paragraph text.</p>'
+    result = _sanitize_transcript(html)
+    assert '<aside epub:type="footnote"' not in result, (
+        f"note1_p1 id must not produce a footnote aside, got: {result!r}"
+    )
+
+
 def test_sanitize_transcript_non_note_links_still_unwrapped() -> None:
     """Non-footnote <a> tags (scripture refs, cross-refs) must still be unwrapped."""
     html = '<p>See <a href="https://www.churchofjesuschrist.org/scripture/1ne/1.1">1 Ne. 1:1</a>.</p>'
@@ -339,6 +398,71 @@ def test_build_epub_session_headers_are_links(tmp_path: Path) -> None:
         "Session header must not use <span>"
     assert f">{session_name}</a>" in nav, \
         "Session header must use <a> linking to first talk"
+
+
+# ---------------------------------------------------------------------------
+# build_epub — footnote end-to-end (ZIP-level assertions)
+# ---------------------------------------------------------------------------
+
+
+def _make_conference_with_notes() -> Conference:
+    """Return a one-talk Conference whose transcript contains realistic Church note markup."""
+    # Note refs use full talk-page URLs (as the Church site generates them), not bare fragments.
+    # Note bodies come from footer.notes as <li id="noteN"> elements (already appended to
+    # transcript_html by the scraper — this simulates a post-fix scrape result).
+    transcript = (
+        '<div class="body-block">'
+        '<p>Priesthood keys.'
+        '<a class="note-ref" data-scroll-id="note1" '
+        'href="/study/general-conference/2024/04/31bowen?lang=eng#note1">'
+        '<sup class="marker" data-value="1"></sup></a></p>'
+        '</div>'
+        '<footer class="notes">'
+        '<ol class="decimal">'
+        '<li id="note1"><p>See Matthew 16:17&#x2013;19.</p></li>'
+        '</ol>'
+        '</footer>'
+    )
+    talk = Talk(
+        title="Miracles, Angels, and Priesthood Power",
+        speaker="Elder Shayne M. Bowen",
+        talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/31bowen?lang=eng",
+        talk_index=1,
+        transcript_html=transcript,
+    )
+    session = Session(name="Saturday Morning Session", number=1, talks=[talk])
+    return Conference(
+        title="April 2024 General Conference",
+        year=2024,
+        month=4,
+        cover_image_url=None,
+        sessions=[session],
+        conference_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04",
+    )
+
+
+def test_build_epub_footnotes_noteref_in_output(tmp_path: Path) -> None:
+    """A talk with Church-style note refs must produce epub:type="noteref" in the EPUB ZIP.
+
+    This is a build-level regression test: it verifies that the entire pipeline from
+    transcript_html through _sanitize_transcript() and into the final EPUB file preserves
+    footnote markup — not just that the sanitizer function returns the right string.
+    """
+    conference = _make_conference_with_notes()
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    talk_files = [n for n in _epub_names(output) if n.startswith("text/talk-")]
+    assert talk_files, "Expected at least one talk XHTML file in the EPUB"
+    talk_content = _epub_read(output, talk_files[0]).decode("utf-8")
+    assert 'epub:type="noteref"' in talk_content, (
+        f"epub:type='noteref' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
+    assert 'epub:type="footnote"' in talk_content, (
+        f"epub:type='footnote' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
+    assert 'href="#note1"' in talk_content, (
+        f"Normalized note href '#note1' must appear in the talk XHTML; got:\n{talk_content[:2000]}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -8,9 +8,9 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from conftest import make_jpeg as _make_jpeg
 from PIL import Image
 
-from conftest import make_jpeg as _make_jpeg
 from gencon_audiobook.epub_builder import (
     EpubError,
     _make_portrait_cover,
@@ -19,7 +19,6 @@ from gencon_audiobook.epub_builder import (
     build_epub,
 )
 from gencon_audiobook.models import Conference, Session, Talk
-
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -235,13 +234,6 @@ def test_sanitize_transcript_strips_random_ids() -> None:
     result = _sanitize_transcript(html)
     assert 'id="p_fvoG6"' not in result, f"Random id must be stripped, got: {result!r}"
     assert "Text." in result, "Paragraph content must be preserved"
-
-
-def test_sanitize_transcript_preserves_note_ids() -> None:
-    """id attributes starting with 'note' must be preserved for footnote anchors."""
-    html = '<p id="note1">Footnote text.</p>'
-    result = _sanitize_transcript(html)
-    assert 'id="note1"' in result, f"note id must be preserved, got: {result!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -699,7 +691,6 @@ def test_build_epub_title_with_special_chars_escaped(tmp_path: Path) -> None:
     output = tmp_path / "test.epub"
     build_epub(conference, tmp_path, output)
 
-    from gencon_audiobook.utils import sanitize_filename
     # sanitize_filename strips < and > so we need to find the actual filename
     with zipfile.ZipFile(output) as zf:
         talk_page = next(n for n in zf.namelist() if n.startswith("text/talk-001-"))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,13 +14,19 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import zipfile
 from pathlib import Path
 
 import pytest
+from conftest import FFMPEG as _FFMPEG
+from conftest import FFPROBE as _FFPROBE
+from conftest import make_jpeg as _make_jpeg
+from conftest import make_silent_mp3 as _make_silent_mp3
+from conftest import requires_ffmpeg
 from mutagen.mp4 import MP4
+from PIL import Image
 
-from conftest import FFMPEG as _FFMPEG, FFPROBE as _FFPROBE, make_jpeg as _make_jpeg, make_silent_mp3 as _make_silent_mp3, requires_ffmpeg
 from gencon_audiobook.audio import build_m4b
 from gencon_audiobook.epub_builder import build_epub
 from gencon_audiobook.models import Conference, Session, Talk

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -485,3 +485,40 @@ def test_upgrade_iiif_leaves_non_iiif_url_unchanged() -> None:
     assert _upgrade_iiif(url) == url, (
         f"Non-IIIF URL must pass through unchanged, got: {_upgrade_iiif(url)!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _CONF_URL_RE
+# ---------------------------------------------------------------------------
+
+
+def test_conf_url_re_matches_modern_slug() -> None:
+    """_CONF_URL_RE must match modern (no-hyphen) talk slugs."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04/11oaks"
+    assert _CONF_URL_RE.search(url), f"Expected match for modern slug: {url!r}"
+
+
+def test_conf_url_re_matches_hyphenated_slug() -> None:
+    """_CONF_URL_RE must match pre-2020 hyphenated talk slugs (the old bug)."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/1999/04/the-work-moves-forward"
+    assert _CONF_URL_RE.search(url), f"Expected match for hyphenated slug: {url!r}"
+
+
+def test_conf_url_re_matches_session_slug() -> None:
+    """Session slugs also match _CONF_URL_RE — DOM position distinguishes sessions from talks."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04/saturday-morning-session"
+    assert _CONF_URL_RE.search(url), f"Expected match for session slug: {url!r}"
+
+
+def test_conf_url_re_rejects_archive_url() -> None:
+    """_CONF_URL_RE must not match the top-level archive URL (no talk slug)."""
+    from gencon_audiobook.scraper import _CONF_URL_RE
+
+    url = "/study/general-conference/2024/04"
+    assert not _CONF_URL_RE.search(url), f"Should not match bare conference URL: {url!r}"

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -268,6 +268,28 @@ def test_parse_talk_page_deduplicates_inline_images():
     assert len(data["inline_images"]) == 1, "Duplicate asset_id should be deduplicated"
 
 
+def test_parse_talk_page_captures_footnote_bodies_from_footer():
+    """footer.notes content must appear in transcript_html so the EPUB builder can render it.
+
+    The Church site places footnote bodies in <footer class="notes"> as a sibling of
+    <div class="body-block">, not inside it. parse_talk_page() must capture both
+    so the EPUB builder has the note bodies it needs.
+    """
+    html = _load("talk_page_with_notes.html")
+    data = parse_talk_page(html, "https://www.churchofjesuschrist.org/study/general-conference/2024/04/31bowen?lang=eng")
+    transcript = data["transcript_html"] or ""
+    assert 'id="note1"' in transcript, (
+        "Footnote body id='note1' must be present in transcript_html"
+    )
+    assert 'id="note2"' in transcript, (
+        "Footnote body id='note2' must be present in transcript_html"
+    )
+    # Verify note content survived
+    assert "Matthew 16" in transcript, (
+        "Footnote body text must be present in transcript_html"
+    )
+
+
 # ---------------------------------------------------------------------------
 # robots.txt (#23)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Merges all work from this release cycle into main.

### Changes included

**PR #158 — fix: restore repo validation workflows**
- CI: build job, dual-branch triggers (main + dev), pip-audit CVE ignore
- \pyproject.toml\: added \uild>=1.2\ to dev extras
- Docs: README, CONTRIBUTING, spec.md updated for current CLI surface
- Tests: fixed brittle disk-space test, removed duplicate, fixed broken imports
- Source: hardened broad exception handling across scraper, downloader, audio, epub_builder, utils, ffmpeg_manager

**PR #160 — fix: preserve EPUB footnotes from Church talk pages (#159)**
- \scraper.py\: append \ooter.notes\ to transcript so note bodies reach the EPUB builder
- \pub_builder.py\: normalize full Church note-ref URLs to bare \#noteN\ fragments; tighten footnote-body wrapping to \^note\d+\$\ only
- 6 new tests including ZIP-level assertion
- UAT confirmed: 32/37 talks in April 2026 conference have correct \pub:type='noteref'\ + \pub:type='footnote'\ markup

### UAT results
- 252 unit tests pass
- 10 live scraper smoke tests pass
- Full EPUB generation against April 2026 conference: clean, footnotes present

Closes #159