### PR TITLE
Release v0.2.0 video audio upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `--prefer-video-audio` flag: when a conference's 360p video audio is better than the MP3 source, the tool can extract the 96 kbps AAC track from video instead of downloading lower-quality MP3 audio. The default run warns before downloading, the opt-in path shows estimated download/audio-cache sizes, and newer conferences with better MP3 audio are protected from downgrade.
+- EPUB table-of-contents entries now include speaker names.
 
 ### Fixed
 - Scraper fetches now enforce robots.txt through the shared `_fetch()` path, matching the documented behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `--prefer-video-audio` flag: when a conference's 360p video audio is better than the MP3 source, the tool can extract the 96 kbps AAC track from video instead of downloading lower-quality MP3 audio. The default run warns before downloading, the opt-in path shows estimated download/audio-cache sizes, and newer conferences with better MP3 audio are protected from downgrade.
 - EPUB table-of-contents entries now include speaker names.
+- Completion reports now include session count and session names.
 
 ### Fixed
 - Scraper fetches now enforce robots.txt through the shared `_fetch()` path, matching the documented behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-29
+
 ### Added
 - `--prefer-video-audio` flag: when a conference's 360p video audio is better than the MP3 source, the tool can extract the 96 kbps AAC track from video instead of downloading lower-quality MP3 audio. The default run warns before downloading, the opt-in path shows estimated download/audio-cache sizes, and newer conferences with better MP3 audio are protected from downgrade.
 - EPUB table-of-contents entries now include speaker names.
@@ -132,7 +134,8 @@ Initial release.
 - Filename sanitization preventing path traversal and special characters in output paths.
 - Fixture-based unit tests for scraper, downloader, audio pipeline, EPUB builder, and utilities; weekly live smoke test workflow with automatic GitHub issue creation on failure.
 
-[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/XeroIP/gencon-audiobook/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.8...v0.2.0
 [0.1.8]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/XeroIP/gencon-audiobook/compare/v0.1.5...v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--prefer-video-audio` flag: when a conference's 360p video audio is better than the MP3 source, the tool can extract the 96 kbps AAC track from video instead of downloading lower-quality MP3 audio. The default run warns before downloading, the opt-in path shows estimated download/audio-cache sizes, and newer conferences with better MP3 audio are protected from downgrade.
+
+### Fixed
+- Scraper fetches now enforce robots.txt through the shared `_fetch()` path, matching the documented behavior.
+
 ## [0.1.7] - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ gencon-audiobook --force-scrape
 # Reduce file size (lower bitrate and sample rate)
 gencon-audiobook --bitrate 32k --sample-rate 22050
 
+# Use higher-quality video audio when older MP3 audio is worse
+gencon-audiobook --conference 2024-04 --prefer-video-audio
+
 # Show detailed progress in the terminal
 gencon-audiobook --verbose
 
@@ -84,6 +87,8 @@ For the full options reference, file size guide, and platform compatibility note
 ```
 
 Running the tool a second time skips files that already exist and loads conference metadata from `conference.json` instead of re-scraping the Church website. Use `--overwrite` to rebuild output files. Use `--force-scrape` to bypass the metadata cache and fetch fresh data from the Church website.
+
+For older conferences, the tool checks whether the 360p video has better audio than the MP3 source. If it does, the default run warns you before downloading. Re-run with `--prefer-video-audio` to extract the higher-quality AAC track from video files. This takes significantly longer and requires much more disk space, so the tool shows estimated download and audio-cache sizes before starting.
 
 ---
 

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -24,7 +24,7 @@ test-release\Scripts\activate
 # Mac/Linux:
 source test-release/bin/activate
 
-pip install gencon-audiobook==0.1.8   # replace with the version being tested
+pip install gencon-audiobook==0.2.0   # replace with the version being tested
 ```
 
 Verify the entry point and version:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -180,9 +180,9 @@ requires-python = ">=3.10"
 dependencies = [
     "click>=8.0",              # CLI framework
     "requests>=2.28",          # HTTP client
-    "beautifulsoup4>=4.11",    # HTML parsing (uses html.parser — NOT lxml)
+    "beautifulsoup4>=4.12",    # HTML parsing (uses html.parser — NOT lxml)
     "mutagen>=1.47",           # Audio metadata verification only (NOT for chapter writing)
-    "Pillow>=9.1",             # Image processing (resize/convert speaker photos to JPEG)
+    "Pillow>=10.0",            # Image processing (resize/convert speaker photos to JPEG)
     "rich>=13.0",              # Progress bars and terminal output
     "static-ffmpeg>=2.7",      # Fallback ffmpeg download if not on system PATH
 ]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -23,6 +23,7 @@ gencon-audiobook --overwrite              # Overwrite existing output files
 gencon-audiobook --force-scrape           # Bypass conference.json cache, re-scrape from website
 gencon-audiobook --bitrate 32k --sample-rate 22050
 gencon-audiobook --epub-paragraph-numbers # Add paragraph numbers to EPUB transcripts
+gencon-audiobook --prefer-video-audio     # Extract better AAC audio from video when MP3 is worse
 ```
 
 ## Output Structure
@@ -35,7 +36,7 @@ gencon-audiobook --epub-paragraph-numbers # Add paragraph numbers to EPUB transc
   conference.json                       # Cached conference metadata (skip re-scraping on rerun)
   audio/                                # Downloaded and converted audio
     001-sanitized-title.mp3             # Zero-padded talk_index, sanitized title
-    001-sanitized-title.m4a             # Intermediate AAC (deleted after m4b is built)
+    001-sanitized-title.m4a             # Extracted video AAC cache, or temporary converted AAC
     ...
   speakers/                             # Speaker photos (for reference and epub)
     001-speaker-name.jpg                # Zero-padded talk_index, sanitized speaker name
@@ -62,6 +63,7 @@ that both `downloader.py` and `audio.py` can compute independently from the Talk
 | ffmpeg sourcing | System PATH first, then `static-ffmpeg` fallback | Users with ffmpeg already installed (most Linux/macOS users) get zero overhead. New users get automatic download. |
 | m4b chapters | ffmpeg FFMETADATA1 format | Only reliable method for writing MP4 chapter atoms. Mutagen used for post-creation verification only — mutagen cannot write chapters. |
 | m4b audio | AAC-LC, source-matched bitrate/sample-rate, mono | Maximum compatibility across iOS and Android. HE-AAC has spotty Android support. Mono is correct for speech. Source quality is preserved by default; `--bitrate` and `--sample-rate` flags override. |
+| Video audio upgrade | Opt-in `--prefer-video-audio` after measured ffprobe comparison | Older MP3s can be 32-64 kbps while 360p video carries 96 kbps AAC. The default run warns and exits before slow downloads; the opt-in path shows size estimates and refuses to downgrade 128 kbps MP3 conferences. |
 | m4b cover | Book-level JPEG only | Per-chapter images not reliably rendered by any player. |
 | m4b chapters | `"Talk Title -- Speaker Name"` | MP4 chapter spec has no author field; speaker name embedded in title with em-dash separator. |
 | EPUB generation | Manual ZIP of XHTML | `ebooklib` is unmaintained (last release 2022), has 100+ open bugs, and produces non-compliant EPUB 3 output. Manual generation gives full control and reliable epubcheck compliance. |
@@ -95,6 +97,7 @@ churchofjesuschrist.org
   downloader.py  ----------------------------->  output_dir/
   (images: parallel via ThreadPoolExecutor)       |-- audio/*.mp3
   (audio: sequential, 0.5s delay)                 |-- cover.jpg
+  (optional video audio extraction)               |-- audio/*.m4a
   (.tmp + rename, resume, retry/backoff)          |-- speakers/*.jpg
   (JPEG conversion via Pillow)                    +-- inline/*.jpg
   (IIIF URLs rewritten to 800px resolution)
@@ -139,6 +142,7 @@ class Talk:
     speaker: str
     talk_url: str
     mp3_url: str | None = None
+    video_url: str | None = None
     transcript_html: str | None = None
     speaker_image_url: str | None = None
     inline_images: list[InlineImage] = field(default_factory=list)  # body images from transcript

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gencon-audiobook"
-version = "0.1.7"
+version = "0.2.0"
 description = "Download General Conference talks as a complete audiobook (m4b) and epub with full transcripts"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "requests>=2.28",
-    "beautifulsoup4>=4.11",
+    "beautifulsoup4>=4.12",
     "mutagen>=1.47",
-    "Pillow>=9.1",
+    "Pillow>=10.0",
     "rich>=13.0",
     "static-ffmpeg>=2.7",
 ]

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -626,18 +626,22 @@ def build_m4b(
     source_sample_rate: int | None = None
 
     # Step 1: Auto-detect source quality unless the caller explicitly overrode it.
-    # Probe the first available MP3 — all talks in a conference come from the same
+    # Probe the first available audio file — all talks in a conference come from the same
     # source pipeline and share the same bitrate/sample_rate.
-    first_mp3 = next(
+    first_audio = next(
         (
-            audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.mp3"
+            path
             for t in talks
-            if (audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.mp3").exists()
+            for path in (
+                audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.m4a",
+                audio_dir / f"{t.talk_index:03d}-{sanitize_filename(t.title)}.mp3",
+            )
+            if path.exists()
         ),
         None,
     )
-    if first_mp3 is not None:
-        detected_bitrate, detected_sample_rate = _probe_source_quality(first_mp3, ffprobe_path)
+    if first_audio is not None:
+        detected_bitrate, detected_sample_rate = _probe_source_quality(first_audio, ffprobe_path)
         source_bitrate = detected_bitrate
         source_sample_rate = detected_sample_rate
         if bitrate is None:
@@ -652,8 +656,9 @@ def build_m4b(
     source_bitrate = source_bitrate or bitrate
     source_sample_rate = source_sample_rate or sample_rate
 
-    # Step 2: Convert MP3 → AAC, populate duration_seconds
+    # Step 2: Convert MP3 -> AAC or reuse extracted AAC, populate duration_seconds
     logger.info("Converting %d talks to AAC...", len(talks))
+    delete_after_build: list[Path] = []
     conv_progress = standard_progress()
     with conv_progress:
         outer_task = conv_progress.add_task("Converting to AAC", total=len(talks))
@@ -661,8 +666,23 @@ def build_m4b(
         for talk in talks:
             conv_progress.update(outer_task, description=talk.title[:60])
             mp3_path = audio_dir / f"{talk.talk_index:03d}-{sanitize_filename(talk.title)}.mp3"
+            m4a_path = mp3_path.with_suffix(".m4a")
+            if m4a_path.exists():
+                try:
+                    duration = _get_duration_ffprobe(m4a_path, ffprobe_path)
+                    talk.duration_seconds = duration
+                    aac_paths.append(m4a_path)
+                    successful_talks.append(talk)
+                    logger.debug("Using existing AAC %s (%.1fs)", m4a_path.name, duration)
+                except AudioError as exc:
+                    logger.error("AAC probe failed for %r: %s — skipping", talk.title, exc)
+                    skipped.append(talk.title)
+                finally:
+                    conv_progress.advance(outer_task)
+                continue
+
             if not mp3_path.exists():
-                logger.warning("MP3 not found for talk %r (%s) — skipping", talk.title, mp3_path)
+                logger.warning("Audio not found for talk %r (%s) — skipping", talk.title, mp3_path)
                 skipped.append(talk.title)
                 conv_progress.advance(outer_task)
                 continue
@@ -691,6 +711,7 @@ def build_m4b(
                 )
                 talk.duration_seconds = duration
                 aac_paths.append(aac_path)
+                delete_after_build.append(aac_path)
                 successful_talks.append(talk)
                 logger.debug("Converted %s (%.1fs)", mp3_path.name, duration)
             except AudioError as exc:
@@ -772,8 +793,9 @@ def build_m4b(
             _spinner_progress.add_task(f"Muxing m4b: {output_path.name}")
             _run(mux_cmd, label="m4b mux")
 
-    # Step 6: Delete individual AAC files (intermediate cleaned by TemporaryDirectory)
-    for aac_path in aac_paths:
+    # Step 6: Delete only AAC files created from MP3 conversion. Extracted video
+    # audio is a reusable source cache and must remain for resume/rebuild.
+    for aac_path in delete_after_build:
         try:
             aac_path.unlink()
             logger.debug("Deleted intermediate AAC: %s", aac_path.name)

--- a/src/gencon_audiobook/cache.py
+++ b/src/gencon_audiobook/cache.py
@@ -133,6 +133,7 @@ def _talk_from_dict(d: dict[str, Any]) -> Talk:
         speaker=d["speaker"],
         talk_url=d["talk_url"],
         mp3_url=d.get("mp3_url"),
+        video_url=d.get("video_url"),
         transcript_html=d.get("transcript_html"),
         speaker_image_url=d.get("speaker_image_url"),
         inline_images=inline_images,

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -311,7 +311,7 @@ def _format_duration(seconds: float) -> str:
 
 
 def _print_completion_report(
-    conf_title: str,
+    conference: Conference,
     conf_output_dir: Path,
     m4b_path: Path,
     epub_path: Path,
@@ -322,7 +322,7 @@ def _print_completion_report(
     """Print a structured completion report to the console.
 
     Args:
-        conf_title: Human-readable conference title.
+        conference: Conference metadata used for output names and session details.
         conf_output_dir: Conference output directory.
         m4b_path: Path to the built m4b file (may not exist if epub-only).
         epub_path: Path to the built epub file (may not exist if audiobook-only).
@@ -332,7 +332,10 @@ def _print_completion_report(
     """
     console.print("")
     console.print("--- Completion Report ---")
-    console.print(f"  Conference:    {conf_title}")
+    console.print(f"  Conference:    {conference.title}")
+    console.print(f"  Sessions:      {len(conference.sessions)}")
+    for session in conference.sessions:
+        console.print(f"    - {session.name}")
 
     if stats is not None:
         console.print(f"  Duration:      {_format_duration(stats.duration_seconds)}")
@@ -626,7 +629,7 @@ def _run(
             phase_times["epub"] = time.monotonic() - t0
 
     _print_completion_report(
-        conf_title=conf_obj.title,
+        conference=conf_obj,
         conf_output_dir=conf_output_dir,
         m4b_path=m4b_path,
         epub_path=epub_path,

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -17,10 +17,16 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
 from .cache import CACHE_FILENAME, load_cache, save_cache
-from .downloader import DownloadError, DownloadResult, download_conference
+from .downloader import (
+    AudioProbe,
+    DownloadError,
+    DownloadResult,
+    _probe_audio_info,
+    download_conference,
+)
 from .epub_builder import EpubError, build_epub
 from .ffmpeg_manager import FfmpegNotFoundError, ensure_ffmpeg, ensure_ffprobe
-from .models import Talk
+from .models import Conference, Talk
 from .progress import shared_console
 from .scraper import ScraperError, fetch_available_conferences, scrape_conference
 
@@ -243,6 +249,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
     default=False,
     help="Add left-margin paragraph numbers to each talk transcript in the EPUB.",
 )
+@click.option(
+    "--prefer-video-audio",
+    is_flag=True,
+    default=False,
+    help="Use higher-quality audio extracted from 360p video when it beats the MP3 source.",
+)
 @click.version_option(version=__version__, prog_name="gencon-audiobook")
 def main(
     output: str,
@@ -255,6 +267,7 @@ def main(
     bitrate: str | None,
     sample_rate: int | None,
     epub_paragraph_numbers: bool,
+    prefer_video_audio: bool,
 ) -> None:
     """Download General Conference talks as a chaptered m4b audiobook and epub companion."""
     _check_python_version()
@@ -271,6 +284,7 @@ def main(
             bitrate=bitrate,
             sample_rate=sample_rate,
             epub_paragraph_numbers=epub_paragraph_numbers,
+            prefer_video_audio=prefer_video_audio,
         )
     except KeyboardInterrupt:
         console.print(
@@ -353,6 +367,108 @@ def _print_completion_report(
     console.print(f"  Log:    {conf_output_dir / _LOG_FILENAME}")
 
 
+def _format_bytes(size_bytes: float) -> str:
+    """Format a byte count as MB or GB for terminal display."""
+    if size_bytes >= 1024 ** 3:
+        return f"~{size_bytes / (1024 ** 3):.1f} GB"
+    return f"~{size_bytes / (1024 ** 2):.0f} MB"
+
+
+def _find_probe_talk(talks: list[Talk]) -> Talk | None:
+    """Return the first talk with both MP3 and video URLs."""
+    return next((talk for talk in talks if talk.mp3_url and talk.video_url), None)
+
+
+def _probe_conference_quality(conf_obj: Conference, ffprobe: Path) -> tuple[AudioProbe, AudioProbe] | None:
+    """Probe representative MP3 and video audio quality for a conference."""
+    probe_talk = _find_probe_talk(conf_obj.talks)
+    if probe_talk is None or probe_talk.mp3_url is None or probe_talk.video_url is None:
+        return None
+    try:
+        return (
+            _probe_audio_info(probe_talk.mp3_url, ffprobe),
+            _probe_audio_info(probe_talk.video_url, ffprobe),
+        )
+    except (OSError, ValueError, DownloadError) as exc:
+        logger.warning("Could not probe audio quality: %s", exc)
+        return None
+
+
+def _kbps(bit_rate: int | None) -> int:
+    return round((bit_rate or 0) / 1000)
+
+
+def _video_estimates(conf_obj: Conference, mp3_probe: AudioProbe, video_probe: AudioProbe) -> tuple[str, str, str, int, int]:
+    """Return display estimates for --prefer-video-audio confirmation."""
+    video_count = sum(1 for talk in conf_obj.talks if talk.video_url)
+    total_count = len(conf_obj.talks)
+    fallback_count = total_count - video_count
+    avg_duration = video_probe.duration_seconds or mp3_probe.duration_seconds or 0
+    video_download_bytes = ((video_probe.total_bitrate_bps or video_probe.audio_bitrate_bps or 0) * avg_duration * video_count) / 8
+    audio_cache_bytes = ((video_probe.audio_bitrate_bps or 0) * avg_duration * video_count) / 8
+    mp3_bytes = ((mp3_probe.audio_bitrate_bps or 0) * avg_duration * total_count) / 8
+    return (
+        _format_bytes(video_download_bytes),
+        _format_bytes(audio_cache_bytes),
+        _format_bytes(mp3_bytes),
+        video_count,
+        fallback_count,
+    )
+
+
+def _confirm_audio_choice(
+    conf_obj: Conference,
+    mp3_probe: AudioProbe,
+    video_probe: AudioProbe,
+    prefer_video_audio: bool,
+) -> bool:
+    """Return True when download_conference should extract video audio."""
+    mp3_bitrate = mp3_probe.audio_bitrate_bps
+    video_bitrate = video_probe.audio_bitrate_bps
+    if not mp3_bitrate or not video_bitrate:
+        return False
+
+    if video_bitrate <= mp3_bitrate:
+        if prefer_video_audio:
+            console.print(
+                "\n--prefer-video-audio was requested, but the MP3 source is already "
+                "equal or better for this conference."
+            )
+            console.print(f"\n  Source MP3:  {_kbps(mp3_bitrate)} kbps")
+            console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
+            if not click.confirm("\nContinue with standard MP3 audio?", default=True):
+                sys.exit(0)
+        return False
+
+    if not prefer_video_audio:
+        console.print("\nHigher quality audio is available for this conference.\n")
+        console.print(f"  Source MP3:  {_kbps(mp3_bitrate)} kbps")
+        console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
+        console.print(
+            "\nRe-run with --prefer-video-audio to download higher quality audio.\n"
+            "Note: video audio extraction takes significantly longer and requires\n"
+            "much more disk space than standard MP3 download."
+        )
+        if not click.confirm("\nContinue with lower quality?", default=False):
+            sys.exit(0)
+        return False
+
+    download_size, audio_cache_size, mp3_size, video_count, fallback_count = _video_estimates(
+        conf_obj, mp3_probe, video_probe
+    )
+    console.print("\n--prefer-video-audio is active.\n")
+    console.print(
+        f"  Talks to process:      {len(conf_obj.talks)}  "
+        f"({video_count} via video, {fallback_count} fallback to MP3)"
+    )
+    console.print(f"  Estimated download:    {download_size}  (vs {mp3_size} for MP3 only)")
+    console.print(f"  Estimated audio cache: {audio_cache_size}")
+    console.print("\nDownload time will be significantly longer than a standard run.")
+    if not click.confirm("\nProceed?", default=False):
+        sys.exit(0)
+    return True
+
+
 def _run(
     output: str,
     conference: str | None,
@@ -363,6 +479,7 @@ def _run(
     bitrate: str | None,
     sample_rate: int | None,
     epub_paragraph_numbers: bool = False,
+    prefer_video_audio: bool = False,
 ) -> None:
     """Inner implementation of main() — separated so KeyboardInterrupt is handled cleanly."""
     output_dir = Path(output).expanduser().resolve()
@@ -409,6 +526,23 @@ def _run(
         )
         sys.exit(1)
 
+    ffmpeg: Path | None = None
+    ffprobe: Path | None = None
+    use_video_audio = False
+    if not epub_only:
+        try:
+            ffmpeg = ensure_ffmpeg()
+            ffprobe = ensure_ffprobe()
+        except FfmpegNotFoundError as exc:
+            click.echo(f"Error: ffmpeg not available.\n{exc}", err=True)
+            sys.exit(1)
+        quality = _probe_conference_quality(conf_obj, ffprobe)
+        if quality is not None:
+            mp3_probe, video_probe = quality
+            use_video_audio = _confirm_audio_choice(
+                conf_obj, mp3_probe, video_probe, prefer_video_audio
+            )
+
     # Warn if disk space is low before starting downloads.
     _check_disk_space(conf_output_dir)
 
@@ -418,7 +552,11 @@ def _run(
     t0 = time.monotonic()
     try:
         dl_result: DownloadResult = download_conference(
-            conf_obj, conf_output_dir, skip_audio=epub_only
+            conf_obj,
+            conf_output_dir,
+            skip_audio=epub_only,
+            prefer_video_audio=use_video_audio,
+            ffmpeg_path=ffmpeg,
         )
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
@@ -433,12 +571,8 @@ def _run(
     # Build m4b audiobook
     if not epub_only:
         console.print("Building audiobook...")
-        try:
-            ffmpeg = ensure_ffmpeg()
-            ffprobe = ensure_ffprobe()
-        except FfmpegNotFoundError as exc:
-            click.echo(f"Error: ffmpeg not available.\n{exc}", err=True)
-            sys.exit(1)
+        assert ffmpeg is not None
+        assert ffprobe is not None
 
         audio_dir = conf_output_dir / "audio"
         cover_path = conf_output_dir / "cover.jpg"

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import subprocess
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -24,6 +26,7 @@ logger = logging.getLogger(__name__)
 _DOWNLOAD_CHUNK_SIZE = 65_536  # 64 KB chunks for streaming downloads
 _JPEG_QUALITY = 85              # JPEG quality for converted images
 _IMAGE_WORKERS = 8              # concurrent image download threads
+_VIDEO_EXTRACT_TIMEOUT = 60 * 60 * 2
 
 # Thread-local storage so each worker gets its own requests.Session.
 # requests.Session is NOT thread-safe; sharing one across threads causes
@@ -42,6 +45,73 @@ class DownloadResult:
     failed_talks: list[Talk] = field(default_factory=list)
     downloaded: int = 0
     skipped: int = 0
+
+
+@dataclass(frozen=True)
+class AudioProbe:
+    """Remote media probe details needed for quality comparison and estimates."""
+
+    audio_bitrate_bps: int | None
+    duration_seconds: float | None
+    total_bitrate_bps: int | None
+
+
+def _probe_audio_info(url: str, ffprobe_path: Path) -> AudioProbe:
+    """Probe a remote media URL with ffprobe.
+
+    ffprobe uses HTTP range requests for MP3/MP4 metadata, so this does not
+    download the full file.
+    """
+    if not validate_url(url):
+        raise ValueError(f"URL not on allowlist: {url!r}")
+
+    try:
+        result = subprocess.run(
+            [
+                str(ffprobe_path),
+                "-v", "quiet",
+                "-print_format", "json",
+                "-show_streams",
+                "-show_format",
+                "-select_streams", "a:0",
+                url,
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        data = json.loads(result.stdout)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        raise DownloadError(f"ffprobe failed for {url!r}: {exc}") from exc
+    streams = data.get("streams", [])
+    audio_stream = streams[0] if streams else {}
+    fmt = data.get("format", {})
+
+    audio_bitrate = _parse_int(audio_stream.get("bit_rate"))
+    duration = _parse_float(audio_stream.get("duration")) or _parse_float(fmt.get("duration"))
+    total_bitrate = _parse_int(fmt.get("bit_rate")) or audio_bitrate
+    return AudioProbe(audio_bitrate, duration, total_bitrate)
+
+
+def _parse_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _parse_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
 
 
 def download_file(
@@ -247,6 +317,56 @@ def _audio_path(output_dir: Path, talk: Talk) -> Path:
     return output_dir / "audio" / f"{talk.talk_index:03d}-{name}.mp3"
 
 
+def _video_audio_path(output_dir: Path, talk: Talk) -> Path:
+    """Return the destination path for extracted video audio."""
+    return _audio_path(output_dir, talk).with_suffix(".m4a")
+
+
+def _extract_video_audio(video_url: str, dest: Path, ffmpeg_path: Path) -> bool:
+    """Extract AAC audio from a remote MP4 video URL into dest."""
+    if not validate_url(video_url):
+        raise ValueError(f"URL not on allowlist: {video_url!r}")
+    if dest.exists():
+        logger.debug("Skipping video audio %s — already extracted", dest.name)
+        return False
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    cmd = [
+        str(ffmpeg_path),
+        "-nostdin",
+        "-i", video_url,
+        "-vn",
+        "-acodec", "copy",
+        "-y",
+        str(tmp),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_VIDEO_EXTRACT_TIMEOUT,
+        )
+        if result.returncode != 0:
+            raise DownloadError(
+                f"ffmpeg video audio extraction failed for {video_url!r}: "
+                f"{result.stderr[-2000:]}"
+            )
+        tmp.replace(dest)
+        return True
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise DownloadError(f"Failed to extract video audio from {video_url!r}: {exc}") from exc
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
 def _speaker_path(output_dir: Path, talk: Talk) -> Path:
     """Return the destination path for a talk's speaker photo."""
     name = sanitize_filename(talk.speaker)
@@ -264,6 +384,8 @@ def download_conference(
     output_dir: Path,
     delay: float = 0.5,
     skip_audio: bool = False,
+    prefer_video_audio: bool = False,
+    ffmpeg_path: Path | None = None,
 ) -> DownloadResult:
     """Download all MP3s, cover image, and speaker photos for a conference.
 
@@ -277,12 +399,16 @@ def download_conference(
         output_dir: Directory to download into. Created if it doesn't exist.
         delay: Seconds to wait between audio HTTP requests.
         skip_audio: If True, skip MP3 downloads (for --epub-only mode).
+        prefer_video_audio: If True, extract audio from talk.video_url when present.
+        ffmpeg_path: Required when prefer_video_audio is True.
 
     Returns:
         DownloadResult with counts of downloaded/skipped files and any failed talks.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     cleanup_tmp_files(output_dir)
+    if prefer_video_audio and ffmpeg_path is None:
+        raise ValueError("ffmpeg_path is required when prefer_video_audio=True")
 
     session = _make_session()
     talks = conference.talks
@@ -293,7 +419,10 @@ def download_conference(
 
     if not skip_audio:
         for talk in talks:
-            if talk.mp3_url:
+            if prefer_video_audio and talk.video_url:
+                dest = _video_audio_path(output_dir, talk)
+                queue.append((talk.video_url, dest, f"[video audio] {talk.title[:50]}", False, talk))
+            elif talk.mp3_url:
                 dest = _audio_path(output_dir, talk)
                 queue.append((talk.mp3_url, dest, f"[audio] {talk.title[:50]}", False, talk))
             else:
@@ -390,7 +519,11 @@ def download_conference(
         for url, dest, label, queue_talk in audio_queue:
             overall_progress.update(overall_task, description=label)
             try:
-                was_downloaded = download_file(url, dest, session, retries=3)
+                if dest.suffix == ".m4a":
+                    assert ffmpeg_path is not None
+                    was_downloaded = _extract_video_audio(url, dest, ffmpeg_path)
+                else:
+                    was_downloaded = download_file(url, dest, session, retries=3)
                 if was_downloaded:
                     downloaded += 1
                     time.sleep(delay)

--- a/src/gencon_audiobook/epub_builder.py
+++ b/src/gencon_audiobook/epub_builder.py
@@ -607,7 +607,8 @@ def _nav_xhtml(
         toc.append('      <ol>')
         for talk in session.talks:
             href = talk_hrefs[talk.talk_index]
-            toc.append(f'        <li><a href="{href}">{escape(talk.title)}</a></li>')
+            label = f"{talk.title} -- {talk.speaker}" if talk.speaker else talk.title
+            toc.append(f'        <li><a href="{href}">{escape(label)}</a></li>')
         toc.append('      </ol>')
         toc.append('    </li>')
     toc += ['  </ol>', '</nav>']

--- a/src/gencon_audiobook/models.py
+++ b/src/gencon_audiobook/models.py
@@ -29,6 +29,7 @@ class Talk:
         speaker: Speaker's full name.
         talk_url: URL of the talk page on churchofjesuschrist.org.
         mp3_url: URL of the MP3 audio file, if available.
+        video_url: URL of the 360p MP4 video file, if available.
         transcript_html: Raw HTML transcript, if available.
         speaker_image_url: URL of the speaker photo, if available.
         session_name: Name of the session this talk belongs to.
@@ -42,6 +43,7 @@ class Talk:
     speaker: str
     talk_url: str
     mp3_url: str | None = None
+    video_url: str | None = None
     transcript_html: str | None = None
     speaker_image_url: str | None = None
     inline_images: list[InlineImage] = field(default_factory=list)

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -238,6 +238,7 @@ def _fetch(http: requests.Session, url: str, delay: float = _REQUEST_DELAY) -> s
     """
     if not validate_url(url):
         raise ScraperError(f"URL not on allowlist: {url}")
+    _check_robots(http, url)
 
     last_exc: Exception | None = None
     for attempt in range(_MAX_RETRIES + 1):

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -67,6 +67,10 @@ _CONF_URL_RE = re.compile(
     r"/study/general-conference/\d{4}/\d{2}/[a-z0-9][-a-z0-9]*(?:\?|$)",
     re.IGNORECASE,
 )
+_VIDEO_360P_RE = re.compile(
+    r"https://assets\.churchofjesuschrist\.org/[a-z0-9]+-360p-en\.mp4",
+    re.IGNORECASE,
+)
 
 
 # Cache of parsed RobotFileParser objects, keyed by scheme+host (e.g. "https://www.churchofjesuschrist.org")
@@ -345,6 +349,16 @@ def _parse_initial_state(html: str) -> dict[str, Any]:
             logger.debug("Failed to parse __INITIAL_STATE__ as raw JSON: %s", exc)
 
     return {}
+
+
+def _find_video_url(state: dict[str, Any]) -> str | None:
+    """Find a 360p MP4 URL anywhere in decoded page state."""
+    state_text = json.dumps(state, ensure_ascii=False)
+    match = _VIDEO_360P_RE.search(state_text)
+    if not match:
+        return None
+    video_url = match.group(0)
+    return video_url if validate_url(video_url) else None
 
 
 # ---------------------------------------------------------------------------
@@ -740,20 +754,21 @@ def _sessions_from_html(html: str) -> list[Session]:
 
 
 def parse_talk_page(html: str, talk_url: str) -> dict:
-    """Extract mp3_url, transcript_html, speaker_image_url, speaker, and inline_images from a talk page.
+    """Extract media, transcript, speaker, and inline images from a talk page.
 
     Args:
         html: HTML content of the individual talk page.
         talk_url: URL of this talk page (used only for logging).
 
     Returns:
-        Dict with keys: mp3_url, transcript_html, speaker_image_url, speaker,
-        inline_images. String values may be None if not found; inline_images
-        is always a list (possibly empty).
+        Dict with keys: mp3_url, video_url, transcript_html, speaker_image_url,
+        speaker, inline_images. String values may be None if not found;
+        inline_images is always a list (possibly empty).
     """
     soup = BeautifulSoup(html, "html.parser")
     result: dict = {
         "mp3_url": None,
+        "video_url": None,
         "transcript_html": None,
         "speaker_image_url": None,
         "speaker": None,
@@ -763,6 +778,10 @@ def parse_talk_page(html: str, talk_url: str) -> dict:
     # MP3 URL — primary: reader.contentStore[*].meta.audio[0].mediaUrl in __INITIAL_STATE__
     # The Church website embeds the audio URL in JS state; the HTML player is rendered client-side.
     state = _parse_initial_state(html)
+    result["video_url"] = _find_video_url(state)
+    if result["video_url"]:
+        logger.debug("video_url (state scan): %s", result["video_url"])
+
     content_store = state.get("reader", {}).get("contentStore", {})
     for _key, entry in content_store.items():
         audio_list = entry.get("meta", {}).get("audio", [])
@@ -1001,6 +1020,7 @@ def scrape_conference(conference_url: str) -> Conference:
                     talk.speaker = data["speaker"]
 
                 talk.mp3_url = data["mp3_url"]
+                talk.video_url = data["video_url"]
                 talk.transcript_html = data["transcript_html"]
                 talk.speaker_image_url = data["speaker_image_url"]
                 talk.inline_images = data["inline_images"]

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -250,6 +250,33 @@ def test_build_m4b_skips_missing_mp3(tmp_path: Path) -> None:
     )
 
 
+@requires_ffmpeg
+def test_build_m4b_skips_talk_when_conversion_fails(tmp_path: Path) -> None:
+    """A mid-build conversion failure must not create a ghost chapter."""
+    from unittest.mock import patch
+
+    import gencon_audiobook.audio as audio_module
+
+    conference = _make_conference(tmp_path, n_talks=2)
+    audio_dir = tmp_path / "audio"
+    output = tmp_path / "output.m4b"
+    original_convert = audio_module.convert_mp3_to_aac
+
+    def convert_or_fail(*args, **kwargs):
+        mp3_path = args[0]
+        if mp3_path.name.startswith("002-"):
+            raise AudioError("simulated conversion failure")
+        return original_convert(*args, **kwargs)
+
+    with patch("gencon_audiobook.audio.convert_mp3_to_aac", side_effect=convert_or_fail):
+        stats = build_m4b(conference, audio_dir, output, None, _FFMPEG, _FFPROBE)
+
+    assert output.exists(), "m4b should still be produced when one conversion fails"
+    assert stats.chapter_count == 1, "Failed talk must not appear as a ghost chapter"
+    assert conference.talks[0].duration_seconds > 0
+    assert conference.talks[1].duration_seconds == 0.0
+
+
 # ---------------------------------------------------------------------------
 # _ffmeta_escape — pure function tests
 # ---------------------------------------------------------------------------

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -277,6 +277,24 @@ def test_build_m4b_skips_talk_when_conversion_fails(tmp_path: Path) -> None:
     assert conference.talks[1].duration_seconds == 0.0
 
 
+@requires_ffmpeg
+def test_build_m4b_uses_existing_m4a_without_deleting_it(tmp_path: Path) -> None:
+    conference = _make_conference(tmp_path, n_talks=1)
+    audio_dir = tmp_path / "audio"
+    mp3_path = audio_dir / "001-Talk-1.mp3"
+    m4a_path = mp3_path.with_suffix(".m4a")
+    output = tmp_path / "output.m4b"
+
+    convert_mp3_to_aac(mp3_path, m4a_path, _FFMPEG, _FFPROBE)
+    mp3_path.unlink()
+
+    stats = build_m4b(conference, audio_dir, output, None, _FFMPEG, _FFPROBE)
+
+    assert output.exists(), "m4b should be produced from existing .m4a source"
+    assert m4a_path.exists(), "Extracted video audio cache must not be deleted"
+    assert stats.chapter_count == 1
+
+
 # ---------------------------------------------------------------------------
 # _ffmeta_escape — pure function tests
 # ---------------------------------------------------------------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -32,6 +32,7 @@ def _make_conference() -> Conference:
         speaker="President Henry B. Eyring",
         talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/talk1",
         mp3_url="https://assets.churchofjesuschrist.org/audio/talk1.mp3",
+        video_url="https://assets.churchofjesuschrist.org/video/talk1-360p-en.mp4",
         transcript_html="<p>Welcome.</p>",
         speaker_image_url="https://assets.churchofjesuschrist.org/photo1.jpg",
         inline_images=[inline],
@@ -46,6 +47,7 @@ def _make_conference() -> Conference:
         speaker="Elder Test Speaker",
         talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/talk2",
         mp3_url=None,
+        video_url=None,
         transcript_html=None,
         speaker_image_url=None,
         inline_images=[],
@@ -95,6 +97,7 @@ def test_save_load_round_trip(tmp_path: "pytest.TempPathFactory") -> None:
     assert loaded_talk.speaker == orig_talk.speaker
     assert loaded_talk.talk_url == orig_talk.talk_url
     assert loaded_talk.mp3_url == orig_talk.mp3_url
+    assert loaded_talk.video_url == orig_talk.video_url
     assert loaded_talk.transcript_html == orig_talk.transcript_html
     assert loaded_talk.speaker_image_url == orig_talk.speaker_image_url
     assert loaded_talk.session_name == orig_talk.session_name

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -138,6 +138,24 @@ def test_load_cache_corrupt_json(tmp_path: "pytest.TempPathFactory") -> None:
     assert result is None, "Expected None for corrupt JSON"
 
 
+def test_load_cache_malformed_conference_data(tmp_path: "pytest.TempPathFactory") -> None:
+    """Valid JSON with an invalid conference shape must fall back to re-scraping."""
+    expected_url = "https://www.churchofjesuschrist.org/study/general-conference/2024/04"
+    malformed = {
+        "cache_version": CACHE_VERSION,
+        "conference": {
+            "conference_url": expected_url,
+            "title": "April 2024 General Conference",
+            # Missing sessions/year/month/cover_image_url.
+        },
+    }
+    (tmp_path / CACHE_FILENAME).write_text(json.dumps(malformed), encoding="utf-8")
+
+    result = load_cache(tmp_path, expected_url=expected_url)
+
+    assert result is None, "Expected None for malformed conference cache data"
+
+
 def test_load_cache_version_mismatch(tmp_path: "pytest.TempPathFactory") -> None:
     """load_cache returns None when cache_version does not match CACHE_VERSION."""
     conf = _make_conference()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 
 from gencon_audiobook.audio import AudioError
 from gencon_audiobook.cli import main, _LOG_FILENAME
-from gencon_audiobook.downloader import DownloadError
+from gencon_audiobook.downloader import AudioProbe, DownloadError, DownloadResult
 from gencon_audiobook.models import Conference, Session, Talk
 from gencon_audiobook.scraper import ConferenceRef, ScraperError
 
@@ -30,12 +30,13 @@ def _make_ref(title: str = "April 2024 General Conference", year: int = 2024, mo
     )
 
 
-def _make_conference(title: str = "April 2024 General Conference") -> Conference:
+def _make_conference(title: str = "April 2024 General Conference", *, video_url: str | None = None) -> Conference:
     talk = Talk(
         title="Opening Remarks",
         speaker="President Eyring",
         talk_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04/01",
         mp3_url="https://assets.churchofjesuschrist.org/test.mp3",
+        video_url=video_url,
         talk_index=1,
         duration_seconds=120.0,
     )
@@ -601,3 +602,98 @@ def test_explicit_bitrate_passed_to_build_m4b(tmp_path: Path) -> None:
         f"Expected bitrate='48k', got {kwargs.get('bitrate')!r}"
     assert kwargs.get("sample_rate") == 22050, \
         f"Expected sample_rate=22050, got {kwargs.get('sample_rate')!r}"
+
+
+def test_quality_banner_exits_by_default_when_video_audio_is_better(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=32_000, duration_seconds=600.0, total_bitrate_bps=32_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference") as mock_download,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["--output", str(tmp_path), "--audiobook-only", "--conference", "2024-04"],
+            input="\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Higher quality audio is available" in result.output
+    mock_download.assert_not_called()
+
+
+def test_prefer_video_audio_prompts_with_estimates_and_enables_extraction(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=32_000, duration_seconds=600.0, total_bitrate_bps=32_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference", return_value=DownloadResult()) as mock_download,
+        patch("gencon_audiobook.cli.build_m4b"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--output", str(tmp_path),
+                "--audiobook-only",
+                "--conference", "2024-04",
+                "--prefer-video-audio",
+            ],
+            input="y\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "--prefer-video-audio is active" in result.output
+    assert "Estimated download" in result.output
+    assert mock_download.call_args.kwargs["prefer_video_audio"] is True
+
+
+def test_prefer_video_audio_does_not_downgrade_better_mp3(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=128_000, duration_seconds=600.0, total_bitrate_bps=128_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference", return_value=DownloadResult()) as mock_download,
+        patch("gencon_audiobook.cli.build_m4b"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--output", str(tmp_path),
+                "--audiobook-only",
+                "--conference", "2024-04",
+                "--prefer-video-audio",
+            ],
+            input="\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "MP3 source is already equal" in result.output
+    assert "better for this conference" in result.output
+    assert mock_download.call_args.kwargs["prefer_video_audio"] is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -354,6 +354,8 @@ def test_completion_summary_printed(tmp_path: Path) -> None:
         result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
 
     assert "Completion Report" in result.output, result.output
+    assert "Sessions:" in result.output, result.output
+    assert "Saturday Morning Session" in result.output, result.output
     assert "Audiobook:" in result.output, result.output
 
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -14,7 +15,9 @@ from gencon_audiobook.downloader import (
     DownloadError,
     DownloadResult,
     _audio_path,
+    _probe_audio_info,
     _speaker_path,
+    _video_audio_path,
     cleanup_tmp_files,
     download_conference,
     download_file,
@@ -23,6 +26,7 @@ from gencon_audiobook.models import Conference, Session, Talk
 
 _ALLOWED_URL = "https://assets.churchofjesuschrist.org/test.mp3"
 _ALLOWED_IMG = "https://assets.churchofjesuschrist.org/test.jpg"
+_ALLOWED_VIDEO = "https://assets.churchofjesuschrist.org/testslug-360p-en.mp4"
 _BLOCKED_URL = "https://evil.example.com/test.mp3"
 
 
@@ -267,6 +271,35 @@ def test_speaker_path_format(tmp_path: Path) -> None:
     assert path.parent == tmp_path / "speakers"
 
 
+def test_video_audio_path_format(tmp_path: Path) -> None:
+    talk = Talk(
+        title="Welcome to Conference",
+        speaker="John Smith",
+        talk_url="https://www.churchofjesuschrist.org/t",
+        talk_index=7,
+    )
+    path = _video_audio_path(tmp_path, talk)
+    assert path.name == "007-Welcome-to-Conference.m4a", f"Unexpected name: {path.name!r}"
+    assert path.parent == tmp_path / "audio"
+
+
+def test_probe_audio_info_parses_ffprobe_json() -> None:
+    result = MagicMock()
+    result.stdout = """
+    {
+      "streams": [{"bit_rate": "96000", "duration": "600.0"}],
+      "format": {"bit_rate": "600000", "duration": "600.0"}
+    }
+    """
+
+    with patch("gencon_audiobook.downloader.subprocess.run", return_value=result):
+        probe = _probe_audio_info(_ALLOWED_VIDEO, Path("ffprobe"))
+
+    assert probe.audio_bitrate_bps == 96_000
+    assert probe.duration_seconds == 600.0
+    assert probe.total_bitrate_bps == 600_000
+
+
 # ---------------------------------------------------------------------------
 # download_conference — integration of the full download queue
 # ---------------------------------------------------------------------------
@@ -295,6 +328,41 @@ def _make_single_talk_conference() -> Conference:
         sessions=[session],
         conference_url="https://www.churchofjesuschrist.org/study/general-conference/2024/04",
     )
+
+
+def test_download_conference_extracts_video_audio_when_preferred(tmp_path: Path) -> None:
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    with patch("gencon_audiobook.downloader._extract_video_audio", return_value=True) as mock_extract:
+        result = download_conference(
+            conference,
+            tmp_path,
+            delay=0,
+            prefer_video_audio=True,
+            ffmpeg_path=Path("ffmpeg"),
+        )
+
+    expected_dest = tmp_path / "audio" / "001-Test-Talk.m4a"
+    mock_extract.assert_called_once_with(_ALLOWED_VIDEO, expected_dest, Path("ffmpeg"))
+    assert result.downloaded == 1
+
+
+@rsps_lib.activate
+def test_download_conference_prefers_mp3_when_video_missing(tmp_path: Path) -> None:
+    rsps_lib.add(rsps_lib.GET, _MP3_URL, body=_small_mp3(), status=200)
+    conference = _make_single_talk_conference()
+
+    result = download_conference(
+        conference,
+        tmp_path,
+        delay=0,
+        prefer_video_audio=True,
+        ffmpeg_path=Path("ffmpeg"),
+    )
+
+    assert (tmp_path / "audio" / "001-Test-Talk.mp3").exists()
+    assert result.downloaded == 1
 
 
 @rsps_lib.activate

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -376,6 +376,16 @@ def test_build_epub_talk_titles_in_nav(tmp_path: Path) -> None:
         assert talk.title in nav, f"Talk title {talk.title!r} not found in nav.xhtml"
 
 
+def test_build_epub_talk_speakers_in_nav(tmp_path: Path) -> None:
+    conference = _make_conference(n_talks=3)
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+    nav = _epub_read(output, "nav.xhtml").decode("utf-8")
+    for talk in conference.talks:
+        expected = f"{talk.title} -- {talk.speaker}"
+        assert expected in nav, f"TOC entry {expected!r} not found in nav.xhtml"
+
+
 def test_build_epub_sessions_in_nav(tmp_path: Path) -> None:
     conference = _make_conference(n_talks=4)
     output = tmp_path / "test.epub"
@@ -823,6 +833,19 @@ def test_build_epub_title_with_special_chars_escaped(tmp_path: Path) -> None:
     assert "&amp;" in page, "Ampersand in title must be HTML-escaped as &amp;"
     assert "<Elder" not in page, "Unescaped angle bracket in speaker name must not appear"
     assert "<Test>" not in page, "Unescaped angle brackets must not appear in XHTML"
+
+
+def test_build_epub_nav_speaker_label_escaped(tmp_path: Path) -> None:
+    conference = _make_conference(n_talks=1)
+    conference.talks[0].title = "Faith & Works"
+    conference.talks[0].speaker = "Elder A. <Test>"
+
+    output = tmp_path / "test.epub"
+    build_epub(conference, tmp_path, output)
+
+    nav = _epub_read(output, "nav.xhtml").decode("utf-8")
+    assert "Faith &amp; Works -- Elder A. &lt;Test&gt;" in nav
+    assert "<Test>" not in nav, "TOC speaker label must be escaped"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -307,6 +307,17 @@ def _make_http_session(robots_text: str, status: int = 200) -> MagicMock:
     return session
 
 
+def _add_robots_response(body: str = "User-agent: *\nDisallow:\n") -> None:
+    """Register an allow-all robots.txt response for _fetch tests."""
+    reset_robots_cache()
+    responses_lib.add(
+        responses_lib.GET,
+        "https://www.churchofjesuschrist.org/robots.txt",
+        status=200,
+        body=body,
+    )
+
+
 def test_check_robots_allows_permitted_url() -> None:
     """A URL permitted by robots.txt must not raise."""
     robots_text = "User-agent: *\nDisallow: /private/\n"
@@ -385,6 +396,7 @@ def test_fetch_retries_on_429_then_succeeds() -> None:
     url = "https://www.churchofjesuschrist.org/study/general-conference"
     minimal_html = "<html><body>" + "x" * 1200 + "</body></html>"
 
+    _add_robots_response()
     responses_lib.add(responses_lib.GET, url, status=429, body="Too Many Requests")
     responses_lib.add(responses_lib.GET, url, status=200, body=minimal_html)
 
@@ -402,6 +414,7 @@ def test_fetch_403_raises_immediately_without_retry() -> None:
     from gencon_audiobook.scraper import _fetch
 
     url = "https://www.churchofjesuschrist.org/study/general-conference"
+    _add_robots_response()
     responses_lib.add(responses_lib.GET, url, status=403, body="Forbidden")
     # Only one response registered — if retry occurs, responses_lib raises ConnectionError
 
@@ -410,9 +423,28 @@ def test_fetch_403_raises_immediately_without_retry() -> None:
         with pytest.raises(ScraperError, match="403"):
             _fetch(session, url)
 
-    assert len(responses_lib.calls) == 1, (
-        f"403 must not be retried — expected 1 request, got {len(responses_lib.calls)}"
+    assert len(responses_lib.calls) == 2, (
+        f"403 must not be retried — expected robots + 1 request, got {len(responses_lib.calls)}"
     )
+
+
+@responses_lib.activate
+def test_fetch_enforces_robots_txt_before_request() -> None:
+    """_fetch must enforce robots.txt, not just direct _check_robots() calls."""
+    from gencon_audiobook.scraper import _fetch
+
+    url = "https://www.churchofjesuschrist.org/study/general-conference/2024/04"
+    _add_robots_response("User-agent: *\nDisallow: /study/general-conference/\n")
+    responses_lib.add(responses_lib.GET, url, status=200, body="x" * 1200)
+
+    session = _scraper_make_session()
+    with pytest.raises(ScraperError, match="disallowed by robots.txt"):
+        _fetch(session, url)
+
+    assert len(responses_lib.calls) == 1, (
+        "_fetch should stop after robots.txt and never request a disallowed page"
+    )
+    assert responses_lib.calls[0].request.url.endswith("/robots.txt")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -6,6 +6,8 @@ or after the Church website structure changes.
 
 from __future__ import annotations
 
+import base64
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -155,6 +157,39 @@ def test_parse_talk_page_mp3_url_passes_validate_url():
     assert data["mp3_url"] is not None
     assert validate_url(data["mp3_url"]), \
         f"mp3_url should pass validate_url(), got {data['mp3_url']!r}"
+
+
+def test_parse_talk_page_extracts_video_url_from_decoded_state():
+    video_url = "https://assets.churchofjesuschrist.org/utshiqnoy1y8xchu1tdwi860yku3zl2jw56xcbbx-360p-en.mp4"
+    state = {
+        "reader": {
+            "contentStore": {
+                "talk": {
+                    "meta": {
+                        "audio": [{"mediaUrl": "https://assets.churchofjesuschrist.org/audio-32k-en.mp3"}],
+                        "video": [{"mediaUrl": video_url}],
+                    }
+                }
+            }
+        }
+    }
+    encoded = base64.b64encode(json.dumps(state).encode("utf-8")).decode("ascii")
+    html = f'<html><body><script>window.__INITIAL_STATE__ = "{encoded}"</script></body></html>'
+
+    data = parse_talk_page(html, "https://www.churchofjesuschrist.org/test")
+
+    assert data["video_url"] == video_url
+
+
+def test_parse_talk_page_video_url_regex_accepts_uppercase_hash():
+    video_url = "https://assets.churchofjesuschrist.org/59C8428CEF2EDDFAB2352EF6F3011D57B4772C28-360p-en.mp4"
+    state = {"video": {"url": video_url}}
+    encoded = base64.b64encode(json.dumps(state).encode("utf-8")).decode("ascii")
+    html = f'<html><body><script>window.__INITIAL_STATE__ = "{encoded}"</script></body></html>'
+
+    data = parse_talk_page(html, "https://www.churchofjesuschrist.org/test")
+
+    assert data["video_url"] == video_url
 
 
 def test_parse_talk_page_extracts_transcript():


### PR DESCRIPTION
## Summary

- Bumps the package to v0.2.0 for the video-audio upgrade release.
- Adds `--prefer-video-audio` with quality probing, downgrade protection, confirmation prompts, and size estimates.
- Adds video URL scraping/cache support and m4a audio-cache handling.
- Bumps dependency floors, expands edge-case coverage, adds speaker names to EPUB TOC entries, and expands the completion report with session details.

## Validation

- `pytest tests\ -v --ignore=tests\test_scraper_live.py --ignore=tests\test_integration.py`
- `mypy src\gencon_audiobook`
- `ruff check src`
- `python -m build`
- `gencon-audiobook --version` -> `0.2.0`

Closes #141
Closes #140
Closes #167
Closes #165
Closes #153