### PR TITLE
fix: resolve v0.2.0rc1 UAT findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Progress indicators now show elapsed time on long-running progress bars and spinner phases.
+- Download status messages now show audio/image count breakdowns.
+
+### Fixed
+- `--prefer-video-audio` extraction now writes `.m4a.tmp` files with an explicit ffmpeg muxer, fixing Windows extraction failures where ffmpeg could not infer the output format.
+- `--prefer-video-audio` now falls back to the MP3 URL for an individual talk if video-audio extraction fails.
+- Fully cached `--prefer-video-audio` reruns skip the heavy download confirmation and avoid misleading no-op timing output.
+- `--audiobook-only` and `--epub-only` are now rejected as mutually exclusive flags before scraping or downloading.
+- Missing `--output` values now produce a direct option-value error instead of an unrelated extra-argument error.
+- Missing direct conference URLs now report the requested conference as unavailable instead of retrying and blaming internet connectivity.
+- If every talk audio download fails, the CLI now stops before audiobook build with a clear error and log path.
+
+### Changed
+- Video-audio decision banners are styled so important warning/active states stand out without coloring the full prompt body.
+
 ## [0.2.0rc1] - 2026-04-29
 
 ### Added

--- a/src/gencon_audiobook/audio.py
+++ b/src/gencon_audiobook/audio.py
@@ -13,10 +13,10 @@ from pathlib import Path
 
 from mutagen import MutagenError
 from mutagen.mp4 import MP4
-from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
+from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn, TimeElapsedColumn
 
 from .models import Conference, Talk
-from .progress import standard_progress
+from .progress import shared_console, standard_progress
 from .utils import sanitize_filename
 
 logger = logging.getLogger(__name__)
@@ -745,6 +745,8 @@ def build_m4b(
         _spinner_progress = Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            console=shared_console,
         )
         with _spinner_progress:
             _spinner_progress.add_task(f"Concatenating {len(aac_paths)} AAC files...")
@@ -788,6 +790,8 @@ def build_m4b(
         _spinner_progress = Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            console=shared_console,
         )
         with _spinner_progress:
             _spinner_progress.add_task(f"Muxing m4b: {output_path.name}")
@@ -803,7 +807,12 @@ def build_m4b(
             logger.warning("Could not delete %s: %s", aac_path, exc)
 
     # Step 7: Verify
-    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}")) as sp:
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=shared_console,
+    ) as sp:
         sp.add_task(f"Verifying m4b: {output_path.name}")
         _verify_m4b(output_path, conference, ffprobe_path)
     logger.info("Built: %s (%.1f MB)", output_path.name, output_path.stat().st_size / 1_048_576)

--- a/src/gencon_audiobook/cli.py
+++ b/src/gencon_audiobook/cli.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import calendar
 import logging
+import os
 import re
 import shutil
 import sys
 import time
 from pathlib import Path
+from typing import cast
 
 import click
 from rich.logging import RichHandler
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from . import __version__
 from .audio import AudioError, BuildStats, build_m4b
@@ -22,6 +24,7 @@ from .downloader import (
     DownloadError,
     DownloadResult,
     _probe_audio_info,
+    conference_downloads_complete,
     download_conference,
 )
 from .epub_builder import EpubError, build_epub
@@ -43,6 +46,33 @@ console = shared_console
 
 _CONF_BASE = "https://www.churchofjesuschrist.org/study/general-conference"
 _CONFERENCE_RE = re.compile(r"^(\d{4})-(0[1-9]|1[0-2])$")
+
+
+class _OutputPathType(click.Path):
+    """Click path type that catches another option being used as --output's value."""
+
+    def convert(
+        self,
+        value: str | os.PathLike[str],
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> str:
+        if isinstance(value, str) and value.startswith("-"):
+            self.fail("requires a value and cannot use another option as its value", param, ctx)
+        return cast(str, super().convert(value, param, ctx))
+
+
+class _CliCommand(click.Command):
+    """Command subclass for clearer parse errors before Click consumes flags as values."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        if "--output" in args:
+            index = args.index("--output")
+            if index == len(args) - 1 or args[index + 1].startswith("-"):
+                raise click.UsageError(
+                    "Option '--output' requires a value and cannot use another option as its value."
+                )
+        return super().parse_args(ctx, args)
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +196,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 
     # No filter — fetch listing, default to most recent.
     try:
-        with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console) as sp:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            console=console,
+        ) as sp:
             sp.add_task("Fetching available conferences...")
             refs = fetch_available_conferences()
     except ScraperError as exc:
@@ -190,11 +225,12 @@ def _select_conference(conference_filter: str | None) -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 
 
-@click.command()
+@click.command(cls=_CliCommand)
 @click.option(
     "--output",
     default="~/gencon-audiobook",
     show_default=True,
+    type=_OutputPathType(path_type=str),
     help="Directory to save output files.",
 )
 @click.option(
@@ -272,6 +308,13 @@ def main(
     """Download General Conference talks as a chaptered m4b audiobook and epub companion."""
     _check_python_version()
     _setup_logging(verbose)
+    if audiobook_only and epub_only:
+        click.echo(
+            "Error: --audiobook-only and --epub-only are mutually exclusive. "
+            "Choose one output type or omit both to build both.",
+            err=True,
+        )
+        sys.exit(1)
 
     try:
         _run(
@@ -354,8 +397,13 @@ def _print_completion_report(
         size_mb = epub_path.stat().st_size / 1_048_576
         console.print(f"  EPUB:          {epub_path.name} ({size_mb:.1f} MB)")
 
-    if phase_times:
-        parts = ", ".join(f"{label} {elapsed:.0f}s" for label, elapsed in phase_times.items())
+    visible_phase_times = {
+        label: elapsed for label, elapsed in phase_times.items() if elapsed > 0.5
+    }
+    if visible_phase_times:
+        parts = ", ".join(
+            f"{label} {elapsed:.0f}s" for label, elapsed in visible_phase_times.items()
+        )
         console.print(f"  Timing:        {parts}")
 
     if len(failed_talks) > 0:
@@ -424,6 +472,7 @@ def _confirm_audio_choice(
     mp3_probe: AudioProbe,
     video_probe: AudioProbe,
     prefer_video_audio: bool,
+    skip_confirmation: bool = False,
 ) -> bool:
     """Return True when download_conference should extract video audio."""
     mp3_bitrate = mp3_probe.audio_bitrate_bps
@@ -434,8 +483,8 @@ def _confirm_audio_choice(
     if video_bitrate <= mp3_bitrate:
         if prefer_video_audio:
             console.print(
-                "\n--prefer-video-audio was requested, but the MP3 source is already "
-                "equal or better for this conference."
+                "\n[yellow]--prefer-video-audio was requested, but the MP3 source is already "
+                "equal or better for this conference.[/yellow]"
             )
             console.print(f"\n  Source MP3:  {_kbps(mp3_bitrate)} kbps")
             console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
@@ -444,7 +493,7 @@ def _confirm_audio_choice(
         return False
 
     if not prefer_video_audio:
-        console.print("\nHigher quality audio is available for this conference.\n")
+        console.print("\n[yellow]Higher quality audio is available for this conference.[/yellow]\n")
         console.print(f"  Source MP3:  {_kbps(mp3_bitrate)} kbps")
         console.print(f"  Video audio: {_kbps(video_bitrate)} kbps AAC")
         console.print(
@@ -456,10 +505,14 @@ def _confirm_audio_choice(
             sys.exit(0)
         return False
 
+    console.print("\n[cyan]--prefer-video-audio is active.[/cyan]\n")
+    if skip_confirmation:
+        console.print("All downloads and the audiobook already exist; skipping download confirmation.")
+        return True
+
     download_size, audio_cache_size, mp3_size, video_count, fallback_count = _video_estimates(
         conf_obj, mp3_probe, video_probe
     )
-    console.print("\n--prefer-video-audio is active.\n")
     console.print(
         f"  Talks to process:      {len(conf_obj.talks)}  "
         f"({video_count} via video, {fallback_count} fallback to MP3)"
@@ -493,6 +546,8 @@ def _run(
     # Resolve the output directory early — conf_title matches conf_obj.title, so we
     # can check the cache before scraping rather than after.
     conf_output_dir = output_dir / conf_title
+    m4b_path = conf_output_dir / f"{conf_title}.m4b"
+    epub_path = conf_output_dir / f"{conf_title}.epub"
 
     # Load from cache if available and --force-scrape not set.
     conf_obj = None
@@ -511,6 +566,14 @@ def _run(
         try:
             conf_obj = scrape_conference(conf_url)
         except ScraperError as exc:
+            if conference and "not found" in str(exc).lower():
+                click.echo(
+                    f"Error: Conference {conference} was not found at churchofjesuschrist.org.\n"
+                    "Check the conference code or run without --conference to choose from "
+                    "available conferences.",
+                    err=True,
+                )
+                sys.exit(1)
             click.echo(f"Error: {exc}", err=True)
             sys.exit(1)
         phase_times["scrape"] = time.monotonic() - t0
@@ -542,8 +605,24 @@ def _run(
         quality = _probe_conference_quality(conf_obj, ffprobe)
         if quality is not None:
             mp3_probe, video_probe = quality
+            skip_video_confirmation = (
+                prefer_video_audio
+                and audiobook_only
+                and not overwrite
+                and m4b_path.exists()
+                and conference_downloads_complete(
+                    conf_obj,
+                    conf_output_dir,
+                    skip_audio=False,
+                    prefer_video_audio=True,
+                )
+            )
             use_video_audio = _confirm_audio_choice(
-                conf_obj, mp3_probe, video_probe, prefer_video_audio
+                conf_obj,
+                mp3_probe,
+                video_probe,
+                prefer_video_audio,
+                skip_confirmation=skip_video_confirmation,
             )
 
     # Warn if disk space is low before starting downloads.
@@ -564,8 +643,10 @@ def _run(
     except DownloadError as exc:
         click.echo(f"Error: Download failed: {exc}", err=True)
         sys.exit(1)
-    phase_times["download"] = time.monotonic() - t0
-    failed_talks = dl_result.failed_talks
+    downloaded_count = dl_result.downloaded if isinstance(dl_result.downloaded, int) else 0
+    failed_talks = dl_result.failed_talks if isinstance(dl_result.failed_talks, list) else []
+    if downloaded_count > 0 or failed_talks:
+        phase_times["download"] = time.monotonic() - t0
 
     m4b_path = conf_output_dir / f"{conf_obj.title}.m4b"
     epub_path = conf_output_dir / f"{conf_obj.title}.epub"
@@ -573,6 +654,15 @@ def _run(
 
     # Build m4b audiobook
     if not epub_only:
+        if failed_talks and len(failed_talks) == len(conf_obj.talks):
+            click.echo(
+                "Error: No talk audio files were downloaded, so the audiobook cannot be built.\n"
+                f"All {len(failed_talks)} talk(s) failed. Check the log for details:\n"
+                f"{conf_output_dir / _LOG_FILENAME}\n"
+                "Run again to retry; already-downloaded files will be reused.",
+                err=True,
+            )
+            sys.exit(1)
         console.print("Building audiobook...")
         assert ffmpeg is not None
         assert ffprobe is not None
@@ -614,6 +704,7 @@ def _run(
                 with Progress(
                     SpinnerColumn(),
                     TextColumn("[progress.description]{task.description}"),
+                    TimeElapsedColumn(),
                     console=console,
                 ) as sp:
                     sp.add_task(f"Building EPUB: {conf_obj.title}")

--- a/src/gencon_audiobook/downloader.py
+++ b/src/gencon_audiobook/downloader.py
@@ -48,6 +48,19 @@ class DownloadResult:
 
 
 @dataclass(frozen=True)
+class _DownloadItem:
+    """One queued download or extraction operation."""
+
+    url: str
+    dest: Path
+    label: str
+    is_image: bool
+    talk: Talk | None = None
+    fallback_url: str | None = None
+    fallback_dest: Path | None = None
+
+
+@dataclass(frozen=True)
 class AudioProbe:
     """Remote media probe details needed for quality comparison and estimates."""
 
@@ -338,6 +351,7 @@ def _extract_video_audio(video_url: str, dest: Path, ffmpeg_path: Path) -> bool:
         "-i", video_url,
         "-vn",
         "-acodec", "copy",
+        "-f", "ipod",
         "-y",
         str(tmp),
     ]
@@ -379,6 +393,36 @@ def _inline_image_path(output_dir: Path, talk: Talk, asset_id: str) -> Path:
     return output_dir / "inline" / f"{talk.talk_index:03d}-{safe_id}.jpg"
 
 
+def conference_downloads_complete(
+    conference: Conference,
+    output_dir: Path,
+    skip_audio: bool = False,
+    prefer_video_audio: bool = False,
+) -> bool:
+    """Return True when every file download_conference would queue already exists."""
+    expected: list[Path] = []
+
+    if not skip_audio:
+        for talk in conference.talks:
+            if prefer_video_audio and talk.video_url:
+                expected.append(_video_audio_path(output_dir, talk))
+            elif talk.mp3_url:
+                expected.append(_audio_path(output_dir, talk))
+
+    if conference.cover_image_url:
+        expected.append(output_dir / "cover.jpg")
+
+    for talk in conference.talks:
+        if talk.speaker_image_url:
+            expected.append(_speaker_path(output_dir, talk))
+        expected.extend(
+            _inline_image_path(output_dir, talk, img.asset_id)
+            for img in talk.inline_images
+        )
+
+    return bool(expected) and all(path.exists() for path in expected)
+
+
 def download_conference(
     conference: Conference,
     output_dir: Path,
@@ -413,34 +457,47 @@ def download_conference(
     session = _make_session()
     talks = conference.talks
 
-    # Build download queue: (url, dest, label, is_image, talk_or_none)
-    # talk_or_none is set for audio items so failed talks can be returned to the caller.
-    queue: list[tuple[str, Path, str, bool, Talk | None]] = []
+    # talk is set for audio items so failed talks can be returned to the caller.
+    queue: list[_DownloadItem] = []
 
     if not skip_audio:
         for talk in talks:
             if prefer_video_audio and talk.video_url:
                 dest = _video_audio_path(output_dir, talk)
-                queue.append((talk.video_url, dest, f"[video audio] {talk.title[:50]}", False, talk))
+                queue.append(_DownloadItem(
+                    url=talk.video_url,
+                    dest=dest,
+                    label=f"[video audio] {talk.title[:50]}",
+                    is_image=False,
+                    talk=talk,
+                    fallback_url=talk.mp3_url,
+                    fallback_dest=_audio_path(output_dir, talk) if talk.mp3_url else None,
+                ))
             elif talk.mp3_url:
                 dest = _audio_path(output_dir, talk)
-                queue.append((talk.mp3_url, dest, f"[audio] {talk.title[:50]}", False, talk))
+                queue.append(_DownloadItem(
+                    url=talk.mp3_url,
+                    dest=dest,
+                    label=f"[audio] {talk.title[:50]}",
+                    is_image=False,
+                    talk=talk,
+                ))
             else:
                 logger.warning("Talk %r has no mp3_url — skipping audio download", talk.title)
 
     if conference.cover_image_url:
         cover_dest = output_dir / "cover.jpg"
-        queue.append((conference.cover_image_url, cover_dest, "[cover] cover.jpg", True, None))
+        queue.append(_DownloadItem(conference.cover_image_url, cover_dest, "[cover] cover.jpg", True))
 
     for talk in talks:
         if talk.speaker_image_url:
             dest = _speaker_path(output_dir, talk)
-            queue.append((talk.speaker_image_url, dest, f"[photo] {talk.speaker[:40]}", True, None))
+            queue.append(_DownloadItem(talk.speaker_image_url, dest, f"[photo] {talk.speaker[:40]}", True))
 
     for talk in talks:
         for img in talk.inline_images:
             dest = _inline_image_path(output_dir, talk, img.asset_id)
-            queue.append((img.url, dest, f"[image] {img.asset_id[:40]}", True, None))
+            queue.append(_DownloadItem(img.url, dest, f"[image] {img.asset_id[:40]}", True))
 
     if not queue:
         logger.info("Nothing to download.")
@@ -449,23 +506,25 @@ def download_conference(
     # Pre-scan: count locally present files without making HEAD requests.
     # This is an approximation — audio files are further verified by Content-Length
     # inside download_file, but the pre-scan is cheap and accurate enough for UX.
-    pre_exists = sum(1 for _, dest, _, _, _ in queue if dest.exists())
+    pre_exists = sum(1 for item in queue if item.dest.exists())
     needs_download = len(queue) - pre_exists
 
     if needs_download == 0:
         logger.debug("All %d files already present — skipping download phase.", len(queue))
         return DownloadResult(skipped=len(queue))
 
+    image_queue = [item for item in queue if item.is_image]
+    audio_queue = [item for item in queue if not item.is_image]
+    needed_audio = sum(1 for item in audio_queue if not item.dest.exists())
+    needed_images = sum(1 for item in image_queue if not item.dest.exists())
+    breakdown = f"{needed_audio} audio, {needed_images} image(s)"
     if pre_exists > 0:
         _console.print(
             f"Downloading {needs_download} of {len(queue)} files "
-            f"({pre_exists} already present)..."
+            f"({breakdown}; {pre_exists} already present)..."
         )
     else:
-        _console.print(f"Downloading {len(queue)} files...")
-
-    image_queue = [(url, dest, label) for url, dest, label, is_image, _ in queue if is_image]
-    audio_queue = [(url, dest, label, talk) for url, dest, label, is_image, talk in queue if not is_image]
+        _console.print(f"Downloading {len(queue)} files ({breakdown})...")
 
     logger.debug(
         "Download queue: %d audio, %d image(s)",
@@ -488,15 +547,16 @@ def download_conference(
         # requests.Session is not thread-safe.
         if image_queue:
 
-            def _download_one_image(args: tuple[str, Path, str]) -> tuple[bool, str | None]:
+            def _download_one_image(item: _DownloadItem) -> tuple[bool, str | None]:
                 """Worker: download one image. Returns (was_downloaded, label_on_failure)."""
-                url, dest, label = args
                 try:
-                    was_downloaded = _download_image(url, dest, _get_thread_session(), retries=3)
+                    was_downloaded = _download_image(
+                        item.url, item.dest, _get_thread_session(), retries=3
+                    )
                     return was_downloaded, None
                 except (DownloadError, ValueError) as exc:
-                    logger.error("Failed to download %s: %s", label, exc)
-                    return False, label
+                    logger.error("Failed to download %s: %s", item.label, exc)
+                    return False, item.label
                 finally:
                     overall_progress.advance(overall_task)
 
@@ -516,24 +576,36 @@ def download_conference(
         # MP3s are large; parallel streaming of many large files simultaneously
         # would be impolite to the server and offers little wall-clock benefit
         # since the bottleneck is bandwidth, not latency.
-        for url, dest, label, queue_talk in audio_queue:
-            overall_progress.update(overall_task, description=label)
+        for item in audio_queue:
+            overall_progress.update(overall_task, description=item.label)
             try:
-                if dest.suffix == ".m4a":
+                if item.dest.suffix == ".m4a":
                     assert ffmpeg_path is not None
-                    was_downloaded = _extract_video_audio(url, dest, ffmpeg_path)
+                    try:
+                        was_downloaded = _extract_video_audio(item.url, item.dest, ffmpeg_path)
+                    except (DownloadError, ValueError) as exc:
+                        if item.fallback_url is None or item.fallback_dest is None:
+                            raise
+                        logger.warning(
+                            "Video audio extraction failed for %r; falling back to MP3: %s",
+                            item.talk.title if item.talk else item.label,
+                            exc,
+                        )
+                        was_downloaded = download_file(
+                            item.fallback_url, item.fallback_dest, session, retries=3
+                        )
                 else:
-                    was_downloaded = download_file(url, dest, session, retries=3)
+                    was_downloaded = download_file(item.url, item.dest, session, retries=3)
                 if was_downloaded:
                     downloaded += 1
                     time.sleep(delay)
                 else:
                     skipped += 1
             except (DownloadError, ValueError) as exc:
-                logger.error("Failed to download %s: %s", label, exc)
-                failed.append(label)
-                if queue_talk is not None:
-                    failed_talks.append(queue_talk)
+                logger.error("Failed to download %s: %s", item.label, exc)
+                failed.append(item.label)
+                if item.talk is not None:
+                    failed_talks.append(item.talk)
             finally:
                 overall_progress.advance(overall_task)
 

--- a/src/gencon_audiobook/progress.py
+++ b/src/gencon_audiobook/progress.py
@@ -11,6 +11,7 @@ from rich.progress import (
     Task,
     TaskProgressColumn,
     TextColumn,
+    TimeElapsedColumn,
     TimeRemainingColumn,
 )
 from rich.text import Text
@@ -53,13 +54,14 @@ def standard_progress() -> Progress:
     All full-width progress bars (scrape, download, convert) use this factory
     so their columns are identical and visually aligned.
 
-    Column order: spinner | N/M count | bar | percent | time remaining | description
+    Column order: spinner | N/M count | bar | percent | elapsed | remaining | description
     """
     return Progress(
         SpinnerColumn(),
         ConditionalMofNColumn(),
         BarColumn(),
         TaskProgressColumn(),
+        TimeElapsedColumn(),
         TimeRemainingWithLabel(compact=True),
         TextColumn("[progress.description]{task.description}"),
         console=shared_console,

--- a/src/gencon_audiobook/scraper.py
+++ b/src/gencon_audiobook/scraper.py
@@ -264,6 +264,11 @@ def _fetch(http: requests.Session, url: str, delay: float = _REQUEST_DELAY) -> s
                     "github.com/XeroIP/gencon-audiobook"
                 )
 
+            if response.status_code == 404:
+                # 404 is deterministic for conference/talk pages — retrying only
+                # hides the real problem behind a misleading connectivity error.
+                raise ScraperError(f"Page not found: {url}")
+
             if response.status_code == 429:
                 # 429 is a transient rate-limit signal — respect Retry-After if present,
                 # otherwise fall through to raise_for_status() which triggers the retry loop.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,16 @@ def test_help_exits_zero() -> None:
     assert "--conference" in result.output
 
 
+def test_output_missing_value_reports_output_error() -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["--output", "--conference", "2024-04", "--audiobook-only"])
+
+    assert result.exit_code != 0
+    assert "--output" in result.output
+    assert "requires a value" in result.output
+    assert "unexpected extra argument" not in result.output.lower()
+
+
 def test_version_flag() -> None:
     from gencon_audiobook import __version__
     runner = CliRunner()
@@ -116,6 +126,17 @@ def test_audiobook_only_skips_epub(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     mock_m4b.assert_called_once()
     mock_epub.assert_not_called()
+
+
+def test_audiobook_only_and_epub_only_are_mutually_exclusive(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["--output", str(tmp_path), "--audiobook-only", "--epub-only"],
+    )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
 
 
 def test_default_builds_both(tmp_path: Path) -> None:
@@ -287,6 +308,22 @@ def test_scrape_conference_error_exits_nonzero(tmp_path: Path) -> None:
         result = runner.invoke(main, ["--output", str(tmp_path)])
 
     assert result.exit_code != 0
+
+
+def test_direct_conference_404_gets_conference_not_found_message(tmp_path: Path) -> None:
+    with patch(
+        "gencon_audiobook.cli.scrape_conference",
+        side_effect=ScraperError("Page not found: https://example.test/2099/04"),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["--output", str(tmp_path), "--conference", "2099-04", "--epub-only"],
+        )
+
+    assert result.exit_code != 0
+    assert "Conference 2099-04 was not found" in result.output
+    assert "internet connection" not in result.output
 
 
 def test_audio_error_exits_nonzero(tmp_path: Path) -> None:
@@ -468,6 +505,30 @@ def test_download_error_exits_nonzero(tmp_path: Path) -> None:
     assert result.exit_code != 0
     assert "Download error" in result.output or "timed out" in result.output, \
         f"Expected download error message in output, got: {result.output!r}"
+
+
+def test_all_talk_download_failures_exit_before_audiobook_build(tmp_path: Path) -> None:
+    refs = [_make_ref()]
+    conference = _make_conference()
+
+    with (
+        patch("gencon_audiobook.cli.fetch_available_conferences", return_value=refs),
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch(
+            "gencon_audiobook.cli.download_conference",
+            return_value=DownloadResult(failed_talks=conference.talks),
+        ),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli.build_m4b") as mock_build,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(main, ["--output", str(tmp_path), "--audiobook-only"])
+
+    assert result.exit_code != 0
+    assert "No talk audio files were downloaded" in result.output
+    assert "All 1 talk(s) failed" in result.output
+    mock_build.assert_not_called()
 
 
 def test_overwrite_skips_epub_when_epub_exists(tmp_path: Path) -> None:
@@ -665,6 +726,46 @@ def test_prefer_video_audio_prompts_with_estimates_and_enables_extraction(tmp_pa
     assert "--prefer-video-audio is active" in result.output
     assert "Estimated download" in result.output
     assert mock_download.call_args.kwargs["prefer_video_audio"] is True
+
+
+def test_prefer_video_audio_cached_noop_skips_heavy_confirmation(tmp_path: Path) -> None:
+    conference = _make_conference(
+        video_url="https://assets.churchofjesuschrist.org/video-360p-en.mp4"
+    )
+    output_dir = tmp_path / "April 2024 General Conference"
+    output_dir.mkdir()
+    (output_dir / "April 2024 General Conference.m4b").write_bytes(b"m4b")
+    (output_dir / "audio").mkdir()
+    (output_dir / "audio" / "001-Opening-Remarks.m4a").write_bytes(b"aac")
+
+    with (
+        patch("gencon_audiobook.cli.scrape_conference", return_value=conference),
+        patch("gencon_audiobook.cli.ensure_ffmpeg", return_value=Path("/usr/bin/ffmpeg")),
+        patch("gencon_audiobook.cli.ensure_ffprobe", return_value=Path("/usr/bin/ffprobe")),
+        patch("gencon_audiobook.cli._probe_audio_info", side_effect=[
+            AudioProbe(audio_bitrate_bps=32_000, duration_seconds=600.0, total_bitrate_bps=32_000),
+            AudioProbe(audio_bitrate_bps=96_000, duration_seconds=600.0, total_bitrate_bps=600_000),
+        ]),
+        patch("gencon_audiobook.cli.download_conference", return_value=DownloadResult()) as mock_download,
+        patch("gencon_audiobook.cli.click.confirm") as mock_confirm,
+        patch("gencon_audiobook.cli.build_m4b") as mock_build,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--output", str(tmp_path),
+                "--audiobook-only",
+                "--conference", "2024-04",
+                "--prefer-video-audio",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "skipping download confirmation" in result.output
+    mock_confirm.assert_not_called()
+    assert mock_download.call_args.kwargs["prefer_video_audio"] is True
+    mock_build.assert_not_called()
 
 
 def test_prefer_video_audio_does_not_downgrade_better_mp3(tmp_path: Path) -> None:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -15,9 +15,11 @@ from gencon_audiobook.downloader import (
     DownloadError,
     DownloadResult,
     _audio_path,
+    _extract_video_audio,
     _probe_audio_info,
     _speaker_path,
     _video_audio_path,
+    conference_downloads_complete,
     cleanup_tmp_files,
     download_conference,
     download_file,
@@ -283,6 +285,29 @@ def test_video_audio_path_format(tmp_path: Path) -> None:
     assert path.parent == tmp_path / "audio"
 
 
+def test_conference_downloads_complete_checks_preferred_video_audio_cache(tmp_path: Path) -> None:
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    assert not conference_downloads_complete(
+        conference,
+        tmp_path,
+        prefer_video_audio=True,
+    )
+
+    (tmp_path / "audio").mkdir()
+    (tmp_path / "audio" / "001-Test-Talk.m4a").write_bytes(b"aac")
+    (tmp_path / "cover.jpg").write_bytes(_jpeg_bytes())
+    (tmp_path / "speakers").mkdir()
+    (tmp_path / "speakers" / "001-Test-Speaker.jpg").write_bytes(_jpeg_bytes())
+
+    assert conference_downloads_complete(
+        conference,
+        tmp_path,
+        prefer_video_audio=True,
+    )
+
+
 def test_probe_audio_info_parses_ffprobe_json() -> None:
     result = MagicMock()
     result.stdout = """
@@ -298,6 +323,29 @@ def test_probe_audio_info_parses_ffprobe_json() -> None:
     assert probe.audio_bitrate_bps == 96_000
     assert probe.duration_seconds == 600.0
     assert probe.total_bitrate_bps == 600_000
+
+
+def test_extract_video_audio_specifies_muxer_for_tmp_output(tmp_path: Path) -> None:
+    result = MagicMock()
+    result.returncode = 0
+    result.stderr = ""
+    dest = tmp_path / "audio" / "001-Test-Talk.m4a"
+
+    def _write_tmp(cmd: list[str], **_: object) -> MagicMock:
+        tmp = Path(cmd[-1])
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        tmp.write_bytes(b"aac")
+        return result
+
+    with patch("gencon_audiobook.downloader.subprocess.run", side_effect=_write_tmp) as mock_run:
+        was_downloaded = _extract_video_audio(_ALLOWED_VIDEO, dest, Path("ffmpeg"))
+
+    assert was_downloaded is True
+    cmd = mock_run.call_args.args[0]
+    assert "-f" in cmd, f"ffmpeg command must specify output muxer for .m4a.tmp: {cmd}"
+    assert cmd[cmd.index("-f") + 1] == "ipod"
+    assert cmd[-1].endswith(".m4a.tmp")
+    assert dest.read_bytes() == b"aac"
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +394,52 @@ def test_download_conference_extracts_video_audio_when_preferred(tmp_path: Path)
     expected_dest = tmp_path / "audio" / "001-Test-Talk.m4a"
     mock_extract.assert_called_once_with(_ALLOWED_VIDEO, expected_dest, Path("ffmpeg"))
     assert result.downloaded == 1
+
+
+@rsps_lib.activate
+def test_download_conference_falls_back_to_mp3_when_video_extract_fails(tmp_path: Path) -> None:
+    rsps_lib.add(rsps_lib.GET, _MP3_URL, body=_small_mp3(), status=200)
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    with patch(
+        "gencon_audiobook.downloader._extract_video_audio",
+        side_effect=DownloadError("ffmpeg failed"),
+    ):
+        result = download_conference(
+            conference,
+            tmp_path,
+            delay=0,
+            prefer_video_audio=True,
+            ffmpeg_path=Path("ffmpeg"),
+        )
+
+    assert (tmp_path / "audio" / "001-Test-Talk.mp3").exists()
+    assert not (tmp_path / "audio" / "001-Test-Talk.m4a").exists()
+    assert result.downloaded == 1
+    assert result.failed_talks == []
+
+
+@rsps_lib.activate
+def test_download_conference_marks_talk_failed_when_video_and_mp3_fallback_fail(tmp_path: Path) -> None:
+    for _ in range(4):
+        rsps_lib.add(rsps_lib.GET, _MP3_URL, status=500)
+    conference = _make_single_talk_conference()
+    conference.talks[0].video_url = _ALLOWED_VIDEO
+
+    with patch(
+        "gencon_audiobook.downloader._extract_video_audio",
+        side_effect=DownloadError("ffmpeg failed"),
+    ):
+        result = download_conference(
+            conference,
+            tmp_path,
+            delay=0,
+            prefer_video_audio=True,
+            ffmpeg_path=Path("ffmpeg"),
+        )
+
+    assert result.failed_talks == [conference.talks[0]]
 
 
 @rsps_lib.activate


### PR DESCRIPTION
## Summary

Fixes the v0.2.0rc1 UAT findings and release-blocking video-audio extraction failure.

## Changes

- Fix ffmpeg video-audio extraction by specifying an explicit M4A-compatible muxer for `.m4a.tmp` outputs
- Fall back to MP3 per talk when preferred video-audio extraction fails
- Improve CLI error clarity for mutually-exclusive output flags, missing `--output` values, invalid direct conference URLs, and all-talk-audio-failed runs
- Add elapsed-time display to progress bars and spinner phases
- Make download status messages show audio/image counts
- Avoid misleading no-op download timing on cached/resume runs
- Style video-audio decision banners and skip the heavy confirmation on fully cached no-op `--prefer-video-audio` reruns
- Update changelog and add regression tests for the UAT findings

## Validation

- `python -m pytest tests/ -v --ignore=tests/test_scraper_live.py --ignore=tests/test_integration.py` passed: 276 tests
- `python -m ruff check src` passed
- `python -m mypy src\gencon_audiobook` passed
- `python -m build` passed
- Manual UAT passed for full April 2024 `--prefer-video-audio`, cached video rerun, CLI error checks, and video-audio prompt polish

Closes #170
Closes #171
Closes #172
Closes #173
Closes #174
Closes #175
Closes #176
